### PR TITLE
Make PscParticipant#scheduled_activities use Psc::ScheduledActivity

### DIFF
--- a/app/models/psc/scheduled_activity.rb
+++ b/app/models/psc/scheduled_activity.rb
@@ -195,7 +195,9 @@ module Psc
     ##
     # @private
     def label_with(prefix)
-      @processed_labels.detect { |l| l.start_with?(prefix) }
+      label = @processed_labels.detect { |l| l.start_with?(prefix) }
+
+      label.match(/^[^:]+:(.+)$/)[1] if label
     end
   end
 end

--- a/app/models/psc/scheduled_activity.rb
+++ b/app/models/psc/scheduled_activity.rb
@@ -110,6 +110,9 @@ module Psc
   #
   # TODO
   class ScheduledActivity < Struct.new(*SCHEDULED_ACTIVITY_ATTRS)
+    alias_method :name, :activity_name
+    alias_method :id, :activity_id
+
     ##
     # Constructs an instance of this class from a scheduled activity report row.
     def self.from_report(row)

--- a/app/models/psc/scheduled_activity.rb
+++ b/app/models/psc/scheduled_activity.rb
@@ -156,16 +156,17 @@ module Psc
     def initialize(*args)
       super
 
-      @processed_labels ||= []
+      @label_list ||= []
     end
 
     def labels=(v)
       super
 
-      @processed_labels = case v
-                          when String then v.split(' ')
-                          else v
-                          end
+      @label_list = case v
+                    when String then v.split(' ')
+                    when NilClass then []
+                    else v
+                    end
     end
 
     ##
@@ -195,7 +196,7 @@ module Psc
     ##
     # @private
     def label_with(prefix)
-      label = @processed_labels.detect { |l| l.start_with?(prefix) }
+      label = @label_list.detect { |l| l.start_with?(prefix) }
 
       label.match(/^[^:]+:(.+)$/)[1] if label
     end

--- a/app/models/psc/scheduled_activity_report.rb
+++ b/app/models/psc/scheduled_activity_report.rb
@@ -231,9 +231,7 @@ module Psc
     class Survey < Struct.new(:instrument_label)
       attr_accessor :model
 
-      def access_code
-        instrument_label.match(/^[^:]+:(.+)$/i)[1]
-      end
+      alias_method :access_code, :instrument_label
     end
   end
 end

--- a/app/models/psc/scheduled_activity_report/entity_resolution.rb
+++ b/app/models/psc/scheduled_activity_report/entity_resolution.rb
@@ -105,13 +105,13 @@ class Psc::ScheduledActivityReport
         next if !participant
 
         possible = participant.events
-        expected = OpenStruct.new(:labels => event.label, :ideal_date => event.ideal_date)
+        expected = OpenStruct.new(:labels => "event:#{event.label}", :ideal_date => event.ideal_date)
         accepted = possible.detect { |e| e.matches_activity(expected) }
 
         if accepted
           event.model = accepted
         else
-          logger.error %Q{Cannot map {label = #{event.label}, ideal date = #{event.ideal_date}, participant = #{participant.p_id}} to an event}
+          logger.error %Q{Cannot map {event label = #{event.label}, ideal date = #{event.ideal_date}, participant = #{participant.p_id}} to an event}
         end
       end
     end

--- a/lib/psc_participant.rb
+++ b/lib/psc_participant.rb
@@ -166,14 +166,17 @@ class PscParticipant
   # Transforms PSC's date-oriented schedule representation into an
   # hash of scheduled activities indexed by ID.
   #
+  # @return [Hash<String, Psc::ScheduledActivity>]
   # @return [Hash<String, Hash<String, Object>]
   def scheduled_activities(validity=:sa_content)
     # TODO: how to memoize with proper cache invalidation?
     days = schedule(validity)['days']
     return {} unless days
     days.inject({}) do |index, (day, day_value)|
-      day_value['activities'].each do |sa|
-        index[sa['id']] = sa
+      day_value['activities'].each do |row|
+        sa = Psc::ScheduledActivity.from_schedule(row)
+
+        index[sa.id] = sa
       end
       index
     end
@@ -200,7 +203,7 @@ class PscParticipant
       next index unless event
       key = [event, sa['ideal_date']]
 
-      (index[key] ||= []) << sa['id']
+      (index[key] ||= []) << sa.id
       index
     end
 

--- a/lib/psc_participant.rb
+++ b/lib/psc_participant.rb
@@ -198,8 +198,7 @@ class PscParticipant
     # build a map with key [event_type_label, ideal_date] and value
     # (array of SA IDs)
     event_date_index = scheduled_activities(:sa_list).inject({}) do |index, (sa_id, sa)|
-      next index unless sa['labels']
-      event = sa['labels'].scan(/\bevent:(\S+)\b/).first.first
+      event = sa.event_label
       next index unless event
       key = [event, sa['ideal_date']]
 

--- a/spec/lib/psc_participant_spec.rb
+++ b/spec/lib/psc_participant_spec.rb
@@ -374,7 +374,7 @@ describe PscParticipant do
     end
 
     it 'can retrieve an arbitrary activity' do
-      subject.scheduled_activities['352']['activity']['name'].should == 'Bar'
+      subject.scheduled_activities['352'].name.should == 'Bar'
     end
 
     it 'is empty if the schedule is empty' do

--- a/spec/models/psc/report_with_child_instruments.rb
+++ b/spec/models/psc/report_with_child_instruments.rb
@@ -47,11 +47,11 @@ shared_context 'report with child instruments' do
   end
 
   let(:activity_name) { 'Birth Interview' }
-  let(:event_birth) { 'event:birth' }
+  let(:event_birth) { 'birth' }
   let(:event_labels) { [event_birth] }
   let(:ideal_date) { '2012-07-06' }
-  let(:instrument_baby_name) { 'instrument:ins_que_birth_int_ehpbhi_p2_v2.0_baby_name' }
-  let(:instrument_birth) { 'references:ins_que_birth_int_ehpbhi_p2_v2.0' }
+  let(:instrument_baby_name) { 'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name' }
+  let(:instrument_birth) { 'ins_que_birth_int_ehpbhi_p2_v2.0' }
   let(:person_id) { '2f85c94e-edbb-4cbe-b9ab-5f12c033323f' }
   let(:scheduled_date) { '2012-07-10' }
   let(:survey_labels) { [instrument_birth, instrument_baby_name] }

--- a/spec/models/psc/report_without_child_instruments.rb
+++ b/spec/models/psc/report_without_child_instruments.rb
@@ -44,10 +44,10 @@ shared_context 'report without child instruments' do
   end
 
   let(:activity_name) { 'Low-Intensity Interview' }
-  let(:event_data_collection) { 'event:low_intensity_data_collection' }
+  let(:event_data_collection) { 'low_intensity_data_collection' }
   let(:event_labels) { [event_data_collection] }
   let(:ideal_date) { '2012-07-06' }
-  let(:instrument_pregnotpreg) { 'instrument:ins_que_lipregnotpreg_int_li_p2_v2.0' }
+  let(:instrument_pregnotpreg) { 'ins_que_lipregnotpreg_int_li_p2_v2.0' }
   let(:person_id) { '2f85c94e-edbb-4cbe-b9ab-5f12c033323f' }
   let(:scheduled_date) { '2012-07-10' }
   let(:survey_labels) { [instrument_pregnotpreg] }

--- a/spec/models/psc/scheduled_activity_report/entity_resolution_spec.rb
+++ b/spec/models/psc/scheduled_activity_report/entity_resolution_spec.rb
@@ -90,8 +90,8 @@ class Psc::ScheduledActivityReport
         it 'logs an error if an event cannot be found' do
           report.process
 
-          log.should =~ /cannot map \{label = event:low_intensity_data_collection, ideal date = #{ideal_date}, participant = #{pa.p_id}\} to an event/i
-          log.should =~ /cannot map \{label = event:informed_consent, ideal date = #{ideal_date}, participant = #{pa.p_id}\} to an event/i
+          log.should =~ /cannot map \{event label = low_intensity_data_collection, ideal date = #{ideal_date}, participant = #{pa.p_id}\} to an event/i
+          log.should =~ /cannot map \{event label = informed_consent, ideal date = #{ideal_date}, participant = #{pa.p_id}\} to an event/i
         end
       end
 

--- a/spec/models/psc/scheduled_activity_spec.rb
+++ b/spec/models/psc/scheduled_activity_spec.rb
@@ -119,5 +119,23 @@ module Psc
       it_should_behave_like 'a label reader'
       it_should_behave_like 'an activity state reader'
     end
+
+    let(:sa) { ScheduledActivity.new }
+
+    describe '#name' do
+      it 'returns #activity_name' do
+        sa.activity_name = 'foo'
+
+        sa.name.should == 'foo'
+      end
+    end
+
+    describe '#id' do
+      it 'returns #activity_id' do
+        sa.activity_id = 'foo'
+
+        sa.id.should == 'foo'
+      end
+    end
   end
 end

--- a/spec/models/psc/scheduled_activity_spec.rb
+++ b/spec/models/psc/scheduled_activity_spec.rb
@@ -68,12 +68,12 @@ module Psc
         end
       end
 
-      it_reads_label 'collection',        'collection:biological'
-      it_reads_label 'event',             'event:birth'
-      it_reads_label 'instrument',        'instrument:ins_que_birth_int_ehpbhi_p2_v2.0_baby_name'
-      it_reads_label 'order',             'order:01_02'
-      it_reads_label 'participant_type',  'participant_type:child'
-      it_reads_label 'references',        'references:ins_que_birth_int_ehpbhi_p2_v2.0'
+      it_reads_label 'collection',        'biological'
+      it_reads_label 'event',             'birth'
+      it_reads_label 'instrument',        'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name'
+      it_reads_label 'order',             '01_02'
+      it_reads_label 'participant_type',  'child'
+      it_reads_label 'references',        'ins_que_birth_int_ehpbhi_p2_v2.0'
     end
 
     shared_examples_for 'an activity state reader' do


### PR DESCRIPTION
I'd like to be able to use a simpler interface for getting activity data via PscParticipant.  In particular, I'd like to write code like this as part of #2302:

``` ruby
sas = activities_from_psc_schedule_via_psc_participant

sas.each do |sa|
  if sa.instrument_label == the_label_i_want
   # do something
  end
end
```
