### PR TITLE
A scope to eager-load NCS-coded attributes.

### DIFF
--- a/vendor/plugins/mdes_record/lib/mdes_record/acts_as_mdes_record.rb
+++ b/vendor/plugins/mdes_record/lib/mdes_record/acts_as_mdes_record.rb
@@ -42,6 +42,11 @@ module MdesRecord
       @mdes_time_pattern ||= /^(9\d:\d\d)|(([01]\d|2[0-3]):[0-5]\d)$/
     end
 
+    def with_codes(*attrs)
+      as = attrs.blank? ? ncs_coded_attributes.keys : attrs
+
+      includes(as)
+    end
   end
 
   class NcsCodedAttribute

--- a/vendor/plugins/mdes_record/test/acts_as_mdes_record_test.rb
+++ b/vendor/plugins/mdes_record/test/acts_as_mdes_record_test.rb
@@ -82,6 +82,22 @@ class ActsAsMdesRecordTest < Test::Unit::TestCase
     Foo.ncs_coded_attributes[:psu].list_name == 'PSU_CL1'
   end
 
+  def test_model_responds_to_with_codes
+    assert Foo.respond_to?(:with_codes)
+  end
+
+  def test_with_codes_eager_loads_codes
+    Foo.create
+
+    assert Foo.with_codes.first.association(:event_type).loaded?
+  end
+
+  def test_with_codes_supports_selective_loading
+    Foo.create
+
+    assert !Foo.with_codes(:psu).first.association(:event_type).loaded?
+  end
+
   def test_psu_code_is_set_upon_create
     foo = Foo.create
     assert_equal(NcsNavigatorCore.psu.to_i, foo.psu_code)
@@ -101,6 +117,7 @@ class Foo < ActiveRecord::Base
   acts_as_mdes_record
 
   ncs_coded_attribute :psu, 'PSU_CL1'
+  ncs_coded_attribute :event_type, 'EVENT_TYPE_CL1'
 end
 
 class Bar < ActiveRecord::Base

--- a/vendor/plugins/mdes_record/test/schema.rb
+++ b/vendor/plugins/mdes_record/test/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table :foos, :force => true do |t|
     t.string :name
     t.string :uuid
+    t.integer :event_type_code
     t.integer :psu_code
   end
 


### PR DESCRIPTION
This scope makes it easier to cut back on database latency caused by many `NcsCode`-related queries.  Example usage:

``` ruby
Instrument.with_codes.where(criterion)
```
