### PR TITLE
InstrumentPlan ought to be able to operate on any scheduled activities.

### DIFF
--- a/app/models/instrument_plan.rb
+++ b/app/models/instrument_plan.rb
@@ -2,11 +2,19 @@ class InstrumentPlan
 
   attr_accessor :scheduled_activities
 
+  def self.from_schedule(schedule = nil)
+    raise "No parameter supplied to build plan" if schedule.blank?
+
+    new.tap { |p| p.populate_from_schedule(schedule) }
+  end
+
   ##
   # Creates a new instance of the InstrumentPlan
-  def initialize(schedule)
-    raise "No parameter supplied to build plan" if schedule.blank?
-    @scheduled_activities = []
+  def initialize(activities = [])
+    @scheduled_activities = activities
+  end
+
+  def populate_from_schedule(schedule)
     parse_schedule(schedule)
     associate_scheduled_activity_with_participant
   end

--- a/lib/patient_study_calendar.rb
+++ b/lib/patient_study_calendar.rb
@@ -266,7 +266,7 @@ class PatientStudyCalendar
   # @param [Participant]
   # @return [InstrumentPlan]
   def build_activity_plan(participant)
-    InstrumentPlan.new(schedules(participant))
+    InstrumentPlan.from_schedule(schedules(participant))
   end
 
 

--- a/spec/models/instrument_plan_spec.rb
+++ b/spec/models/instrument_plan_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe InstrumentPlan do
 
-  describe ".new" do
+  describe ".from_schedule" do
 
     it "raises an exception if no parameter is sent to constructor" do
-      lambda { InstrumentPlan.new }.should raise_error
+      lambda { InstrumentPlan.from_schedule }.should raise_error
     end
 
     it "accepts a hash as a parameter" do
-      InstrumentPlan.new(participant_plan).should_not be_nil
+      InstrumentPlan.from_schedule(participant_plan).should_not be_nil
     end
 
     describe "building the plan" do
 
       describe ".events" do
         it "orders the events" do
-          plan = InstrumentPlan.new(participant_plan)
+          plan = InstrumentPlan.from_schedule(participant_plan)
           plan.events.size.should  == 3
           plan.events.first.should == 'birth'
           plan.events.last.should  == '6m'
@@ -25,7 +25,7 @@ describe InstrumentPlan do
 
       describe ".instruments" do
 
-        let(:plan) { InstrumentPlan.new(participant_plan) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "knows all of the instruments for the participant" do
           plan.instruments.size.should == 5
@@ -51,7 +51,7 @@ describe InstrumentPlan do
 
       describe ".scheduled_activities_for_survey" do
 
-        let(:plan) { InstrumentPlan.new(participant_plan) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "returns all scheduled_activity parts for a given survey" do
 
@@ -67,7 +67,7 @@ describe InstrumentPlan do
 
   context "for a Participant" do
 
-    describe ".new" do
+    describe ".from_schedule" do
 
       describe "for a mother with one child" do
 
@@ -84,7 +84,7 @@ describe InstrumentPlan do
           Factory(:participant_person_link, :participant => mother, :person => cp, :relationship_code => 8)
         end
 
-        let(:plan) { InstrumentPlan.new(participant_plan) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('6m').size.should == 2
@@ -194,7 +194,7 @@ describe InstrumentPlan do
           Factory(:participant_person_link, :participant => mother, :person => cp2, :relationship_code => 8)
         end
 
-        let(:plan) { InstrumentPlan.new(participant_plan) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('6m').size.should == 3
@@ -324,7 +324,7 @@ describe InstrumentPlan do
 
   context "moving through the plan" do
 
-    let(:plan) { InstrumentPlan.new(participant_plan) }
+    let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
     describe ".current_survey_title" do
       it "returns the first instrument if no response_set given" do
@@ -369,7 +369,7 @@ describe InstrumentPlan do
           Factory(:participant_person_link, :participant => mother, :person => cp, :relationship_code => 8)
         end
 
-        let(:plan) { InstrumentPlan.new(participant_plan_xp2) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan_xp2) }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('birth').size.should == 3
@@ -420,7 +420,7 @@ describe InstrumentPlan do
           Factory(:participant_person_link, :participant => mother, :person => cp2, :relationship_code => 8)
         end
 
-        let(:plan) { InstrumentPlan.new(participant_plan_xp2) }
+        let(:plan) { InstrumentPlan.from_schedule(participant_plan_xp2) }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('birth').size.should == 5


### PR DESCRIPTION
The process that generates work items for Field needs to be able to generate a sequence of surveys for a given instrument type.  `InstrumentPlan` does this (and more), so might as well just reuse it.  (Also, @rsutphin has mentioned to me that he's working on a subsystem that could benefit from a more source-neutral InstrumentPlan.)

This pull request contains a change that permits InstrumentPlan to accept _any_ set of scheduled activities, not just those derived from a single participant's schedule.  I'm not sure what assumptions this violates (if any), but the specs do pass.

Future pull requests (or maybe just commits in this one) will adjust InstrumentPlan to use `Psc::ScheduledActivity` objects and objects like it by moving InstrumentPlan-specific methods out of `ScheduledActivity` and to other places.
