### PR TITLE
Derive instrument version from survey title

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -61,7 +61,7 @@ class Instrument < ActiveRecord::Base
   validates_presence_of :instrument_version
   validates_presence_of :instrument_repeat_key
 
-  before_create :set_default_codes
+  before_create :set_default_codes, :set_instrument_version
 
   INSTRUMENT_LABEL_MARKER = "instrument:"
   COLLECTION_LABEL_MARKER = "collection:"
@@ -340,6 +340,10 @@ class Instrument < ActiveRecord::Base
     QUERY
   end
 
+  def determine_instrument_version_from_survey_title
+    survey.title ? survey.title[/V(\d+(\.\d)?)$/,1] : nil
+  end
+
   private
 
     ##
@@ -354,5 +358,12 @@ class Instrument < ActiveRecord::Base
           self.send("#{asso}=", val) if val
         end
       end
+    end
+
+    ##
+    # This will set the instrument version based on the survey title if one doesn't
+    # already exist.
+    def set_instrument_version
+      self.instrument_version = self.instrument_version || self.determine_instrument_version_from_survey_title
     end
 end

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -761,4 +761,24 @@ describe Instrument do
       instrument.sa_state_change_reason.should == 'Synchronized from Cases'
     end
   end
+
+  describe '#instrument_version' do
+    let(:survey) {Survey.new}
+    let(:instrument) {Instrument.new(:survey => survey)}
+
+    it 'has instrument_version' do
+      survey.title = "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.2"
+      instrument.determine_instrument_version_from_survey_title.should == "1.2"
+    end
+
+    it 'has instrument_version when whole number' do
+      survey.title = "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1"
+      instrument.determine_instrument_version_from_survey_title.should == "1"
+    end
+
+    it 'has no instrument_version' do
+      survey.title = "V's Bad Title"
+      instrument.determine_instrument_version_from_survey_title.should be_nil
+    end
+  end
 end


### PR DESCRIPTION
Instead of having Field and users set the instrument version we could derive it from survey title.
