### PR TITLE
Set default for event disposition category

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -57,7 +57,7 @@ class Event < ActiveRecord::Base
   validates_format_of :event_end_time,   :with => mdes_time_pattern, :allow_blank => true
 
   before_validation :strip_time_whitespace
-  before_create :set_start_time
+  before_create :set_start_time, :set_event_disposition_category_code
 
   POSTNATAL_EVENTS = [
     18, # Birth
@@ -218,6 +218,11 @@ class Event < ActiveRecord::Base
     end
   end
   private :set_start_time
+
+  def set_event_disposition_category_code
+    self.event_disposition_category_code = self.event_disposition_category_code || -4
+  end
+  private :set_event_disposition_category_code
 
   def event_start_time=(t)
     self['event_start_time'] = format_event_time(t)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -114,6 +114,13 @@ describe Event do
 
   end
 
+  describe "#event_disposition_category_code" do
+    it "is set on create if nil" do
+      e = Factory(:event, :event_disposition_category_code => nil)
+      e.event_disposition_category_code.should_not be_nil
+    end
+  end
+
   describe ".import_sort_date" do
 
     it "returns the event start date if the event end date is null" do


### PR DESCRIPTION
Set a default event disposition category code when a new event is created if one doesn't exist.
