### PR TITLE
Change 2709

### DIFF
--- a/app/assets/stylesheets/partials/_links.scss
+++ b/app/assets/stylesheets/partials/_links.scss
@@ -147,6 +147,11 @@ a.sort_link:hover, a.icon_link:hover {
   padding-right: 10px;
 }
 
+.conditional_link, .conditional_link:hover {
+  background: url(../../assets/help.png) 0 2px no-repeat !important;
+  padding-right: 10px;
+}
+
 .version_link, .version_link:hover,
 .reschedule_link, .reschedule_link:hover {
   background: url(../../assets/clock_red.png) 0 2px no-repeat !important;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,6 +50,7 @@ class EventsController < ApplicationController
     respond_to do |format|
       if @event.update_attributes(params[:event])
         mark_activity_occurred
+        @event.update_associated_informed_consent_event
 
         notice = 'Event was successfully updated.'
 

--- a/app/controllers/participant_consents_controller.rb
+++ b/app/controllers/participant_consents_controller.rb
@@ -54,6 +54,7 @@ class ParticipantConsentsController < ApplicationController
 
         mark_activity_occurred
         update_enrollment_status
+        create_informed_consent_event(@participant, @contact_link)
 
         format.html { redirect_to decision_page_contact_link_path(@contact_link), :notice => 'Participant consent was successfully created.' }
         format.json { render :json => @participant_consent, :status => :created, :location => @participant_consent }
@@ -162,6 +163,44 @@ class ParticipantConsentsController < ApplicationController
         participant.unenroll!(psc, "Consent withdrawn") unless participant.unenrolled?
       end
     end
+
+    ##
+    # Creates an Informed Consent Event for the given participant and contact_link
+    # @param[Participant]
+    # @param[ContactLink]
+    def create_informed_consent_event(participant, contact_link)
+      contact = contact_link.contact
+      if should_create_informed_consent_record?(participant, contact)
+        comment = "Informed Consent Event record created from ParticipantConsent record"
+        event = Event.create(:participant => participant,
+                             :event_type_code => Event.informed_consent_code,
+                             :event_breakoff_code => NcsCode::NO,
+                             :event_comment => comment,
+                             :event_repeat_key => 0)
+        ContactLink.create(:event => event, :contact => contact,
+                           :person => contact_link.person, :staff_id => contact_link.staff_id)
+      end
+    end
+
+    ##
+    # Return true if there are no Informed Consent Events associated with
+    # the given Participant.
+    #
+    # If there are Informed Consent Events associated with the participant
+    # return true if none are associated with the given Contact.
+    #
+    # Create one Informed Consent for the Participant per Contact
+    #
+    # @param[Participant]
+    # @param[Contact]
+    # @return[Boolean]
+    def should_create_informed_consent_record?(participant, contact)
+      events = Event.where(:participant_id => participant.id,
+                           :event_type_code => Event.informed_consent_code).all
+      return true if events.empty?
+      events.collect(&:contacts).flatten.include?(contact) ? false : true
+    end
+    private :should_create_informed_consent_record?
 
     def redirect_action
       if params[:contact_link_id]

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -18,6 +18,7 @@ class ParticipantsController < ApplicationController
 
     params[:q] ||= {}
     params[:q][:participant_person_links_relationship_code_eq] = 1
+    params[:q][:being_followed_true] = 1
 
     @q = Participant.search(params[:q])
     # @q.sorts = 'last_name asc' if @q.sorts.empty?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -332,20 +332,36 @@ class Event < ActiveRecord::Base
     PARTICIPANT_REPEATABLE_EVENTS
   end
 
+  def self.pregnancy_visit_1_code
+    13
+  end
+
+  def self.pregnancy_visit_2_code
+    15
+  end
+
+  def self.birth_code
+    18
+  end
+
+  def self.informed_consent_code
+    10
+  end
+
   def pregnancy_visit_1?
-    self.event_type_code == 13
+    self.event_type_code == self.pregnancy_visit_1_code
   end
   alias :pv1? :pregnancy_visit_1?
   alias :pregnancy_visit1? :pregnancy_visit_1?
 
   def pregnancy_visit_2?
-    self.event_type_code == 15
+    self.event_type_code == self.pregnancy_visit_2_code
   end
   alias :pv2? :pregnancy_visit_2?
   alias :pregnancy_visit2? :pregnancy_visit_2?
 
   def birth?
-    self.event_type_code == 18
+    self.event_type_code == self.birth_code
   end
 
   ##

--- a/app/models/instrument_plan.rb
+++ b/app/models/instrument_plan.rb
@@ -28,7 +28,7 @@ class InstrumentPlan
   def parse_schedule(schedule)
     activities(schedule).each do |activity|
       sa = ScheduledActivity.new(scheduled_activity_attrs_from_activity(activity))
-      @scheduled_activities << sa if sa.scheduled?
+      @scheduled_activities << sa if sa.scheduled? || sa.conditional?
       @occurred_activities << sa if sa.occurred?
     end
   end

--- a/app/models/ncs_code.rb
+++ b/app/models/ncs_code.rb
@@ -16,6 +16,9 @@ class NcsCode < ActiveRecord::Base
 
   validates_presence_of :list_name, :display_text, :local_code
 
+  YES = 1
+  NO  = 2
+
   ATTRIBUTE_MAPPING = {
 
     ### person

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -713,14 +713,14 @@ class Participant < ActiveRecord::Base
   # Returns true if participant enroll status is 'Yes' (i.e. local_code == 1)
   # @return [Boolean]
   def enrolled?
-    enroll_status.try(:local_code) == 1
+    enroll_status.try(:local_code) == NcsCode::YES
   end
 
   ##
   # Returns true if participant enroll status is 'No' (i.e. local_code == 2)
   # @return [Boolean]
   def unenrolled?
-    enroll_status.try(:local_code) == 2
+    enroll_status.try(:local_code) == NcsCode::NO
   end
 
   ##

--- a/app/models/scheduled_activity.rb
+++ b/app/models/scheduled_activity.rb
@@ -136,6 +136,12 @@ class ScheduledActivity
   end
 
   ##
+  # True if current_state == conditional
+  def conditional?
+    @current_state == Psc::ScheduledActivity::CONDITIONAL
+  end
+
+  ##
   # True if current_state == canceled
   def canceled?
     @current_state == Psc::ScheduledActivity::CANCELED

--- a/app/views/contact_links/_activity.html.haml
+++ b/app/views/contact_links/_activity.html.haml
@@ -1,0 +1,15 @@
+- if contact_link.contact.instrument_survey_titles.include?(survey.title)
+  %div{ :class => "known_instrument", :title => survey.title}
+    = activity.activity_name
+- elsif @current_activity == activity
+  %div{ :class => "instrument", :title => survey.title}
+    = link_to activity.activity_name,
+        start_instrument_person_path(person, :participant_id => activity.participant.id,
+                                             :references_survey_access_code => activity.references.to_s,
+                                             :survey_access_code => survey.access_code,
+                                             :contact_link_id => contact_link.id),
+        :class => "star_link icon_link"
+- else
+  %div{ :class => "instrument", :title => survey.title}
+    %a{ :href => "javascript:alert('Please choose instruments in order')", :class => "add_link icon_link"}
+      = activity.activity_name

--- a/app/views/contact_links/_consents.html.haml
+++ b/app/views/contact_links/_consents.html.haml
@@ -1,9 +1,9 @@
 
+- current_activity ||= false
 - if participant = @event.participant
-  - consent = participant.low_intensity? ? ParticipantConsent.low_intensity_consent_type_code : ParticipantConsent.general_consent_type_code
   .consent_link
-    = determine_participant_consent_path(consent.local_code, consent.to_s, participant, @contact_link)
-    - if participant.consented?(NcsCode.for_attribute_name_and_local_code(:consent_type_code, consent.local_code))
+    = determine_participant_consent_path(participant, @contact_link, current_activity)
+    - if participant.consented?(NcsCode.for_attribute_name_and_local_code(:consent_type_code, consent_type_for(participant).local_code))
       %span{ :class => "consented" }
         Participant has consented.
 

--- a/app/views/contact_links/_consents.html.haml
+++ b/app/views/contact_links/_consents.html.haml
@@ -1,3 +1,4 @@
+
 - if participant = @event.participant
   - consent = participant.low_intensity? ? ParticipantConsent.low_intensity_consent_type_code : ParticipantConsent.general_consent_type_code
   .consent_link

--- a/app/views/contact_links/_instrument_for_activity.html.haml
+++ b/app/views/contact_links/_instrument_for_activity.html.haml
@@ -1,23 +1,7 @@
 - if survey = Survey.most_recent_for_access_code(Survey.to_normalized_string(activity.instrument))
-  - if contact_link.contact.instrument_survey_titles.include?(survey.title)
-    %div{ :class => "known_instrument", :title => survey.title}
-      = activity.activity_name
-  - elsif @current_activity == activity
-    %div{ :class => "instrument", :title => survey.title}
-      = link_to activity.activity_name,
-          start_instrument_person_path(person, :participant_id => activity.participant.id,
-                                               :references_survey_access_code => activity.references.to_s,
-                                               :survey_access_code => survey.access_code,
-                                               :contact_link_id => contact_link.id),
-          :class => "star_link icon_link"
-  - else
-    %div{ :class => "instrument", :title => survey.title}
-      %a{ :href => "javascript:alert('Please choose instruments in order')", :class => "add_link icon_link"}
-        = activity.activity_name
-  = debug activity
+  = render "activity", :contact_link => contact_link, :survey => survey, :activity => activity, :person => person
 - elsif activity.consent_activity?
-  = render "consents"
-  = debug activity
+  = render "consents", :current_activity => (@current_activity == activity)
 - else
   .unknown_instrument
     = activity.activity_name

--- a/app/views/contact_links/_instrument_for_activity.html.haml
+++ b/app/views/contact_links/_instrument_for_activity.html.haml
@@ -14,8 +14,10 @@
     %div{ :class => "instrument", :title => survey.title}
       %a{ :href => "javascript:alert('Please choose instruments in order')", :class => "add_link icon_link"}
         = activity.activity_name
-- elsif activity.activity_name.include?("Consent")
+  = debug activity
+- elsif activity.consent_activity?
   = render "consents"
+  = debug activity
 - else
   .unknown_instrument
     = activity.activity_name

--- a/app/views/contact_links/_instruments_for_upcoming_events.html.haml
+++ b/app/views/contact_links/_instruments_for_upcoming_events.html.haml
@@ -19,13 +19,6 @@
   - if initial_instrument_for_contact
     .instructional_note
       Choose the Instrument from the list below to administer for this contact.
-      %br
-      (If there is a Consent link in the list, you should obtain consent before proceeding.)
-
-  - no_consent_event_exists = true
-
-  - if @event.to_s.include?("Consent")
-    - no_consent_event_exists = false
 
   - if @person.participant.blank?
     .person_not_participant
@@ -38,6 +31,3 @@
         = render "instrument_for_activity", :activity => sa, :person => @person, :contact_link => @contact_link
     - else
       = render "consent_or_empty", :contact_link => @contact_link
-
-  - if no_consent_event_exists
-    = render "unscheduled_consents", :person => @person, :contact_link => @contact_link

--- a/app/views/contact_links/_parental_permission_for_child_participation.html.haml
+++ b/app/views/contact_links/_parental_permission_for_child_participation.html.haml
@@ -1,7 +1,5 @@
 - participant = event.participant
 - if event.pv1? || event.pv2? || event.birth?
-  %h3
-    Parental Permission for Child Participation
   .child_participation
     = link_to "Create Child Participation Consent",
       new_child_participant_participant_consents_path(participant, {:contact_link_id => contact_link.id}),

--- a/app/views/contact_links/decision_page.html.haml
+++ b/app/views/contact_links/decision_page.html.haml
@@ -18,6 +18,8 @@
       - if instr = contact_link.instrument
         .edit_instrument
           = link_to "Edit #{instr}", edit_instrument_path(instr), :class => "edit_link icon_link"
+      - elsif contact_link.event.try(:informed_consent?)
+        = render "consents"
 
 .page_section
   %h3

--- a/doc/psc_labels.txt
+++ b/doc/psc_labels.txt
@@ -18,7 +18,7 @@ Lo Intensity Data Collection - 33
 ---------------------------------
 
 # Low Intensity Informed Consent
-event:informed_consent
+event:low_intensity_data_collection participant_type:mother
 
 event:low_intensity_data_collection instrument:2.0:ins_que_lipregnotpreg_int_li_p2_v2.0 order:01_01 participant_type:mother
 
@@ -41,7 +41,7 @@ collection:biological event:pre-pregnancy_visit instrument:2.0:ins_bio_adultbloo
 collection:biological event:pre-pregnancy_visit instrument:2.0:ins_bio_adulturine_dci_ehpbhi_p2_v1.0 order:11_01 participant_type:mother
 
 # Non-Pregnant Woman Informed Consent
-event:informed_consent
+event:pre-pregnancy_visit participant_type:mother
 
 # Pre-Pregnancy Visit Information Sheet
 event:pre-pregnancy_visit
@@ -60,7 +60,10 @@ collection:biological event:pregnancy_visit_1 instrument:2.0:ins_bio_adultblood_
 collection:biological event:pregnancy_visit_1 instrument:2.0:ins_bio_adulturine_dci_ehpbhi_p2_v1.0 order:11_01 participant_type:mother
 
 # Pregnant Woman Informed Consent
-event:informed_consent
+event:pregnancy_visit_1 order:00_99 participant_type:mother
+
+# Child Participation Informed Consent
+event:pregnancy_visit_1 order:90_99 participant_type:child
 
 collection:environmental event:pregnancy_visit_1 instrument:2.0:ins_env_tapwaterpesttechcollect_dci_ehpbhi_p2_v1.0 order:20_01 participant_type:mother
 
@@ -104,6 +107,9 @@ event:pregnancy_visit_2
 # Pregnancy Health Care Log
 event:pregnancy_visit_2
 
+# Child Participation Informed Consent
+event:pregnancy_visit_2 order:90_99 participant_type:child
+
 event:pregnancy_visit_2 instrument:3.0:ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one order:00_01 participant_type:mother
 
 event:pregnancy_visit_2 instrument:2.0:ins_que_pregvisit2_int_ehpbhi_p2_v2.0 instrument:3.0:ins_que_pregvisit2_int_ehpbhipbs_m3.0_v3.0 order:01_01 participant_type:mother
@@ -133,7 +139,7 @@ Father - 19
 -----------
 
 # Father Informed Consent
-event:informed_consent
+event:father event_type:informed_consent participant_type:father
 
 # Father Visit Information Sheet
 event:father
@@ -151,6 +157,9 @@ event:birth instrument:2.0:ins_que_birth_int_li_p2_v1.0_birth_visit_li_baby_name
 
 event:birth instrument:2.0:ins_que_birth_int_li_p2_v1.0_part_two mode:low_intensity_birth order:01_03 participant_type:mother references:2.0:ins_que_birth_int_li_p2_v1.0_part_one
 
+# Child Participation Informed Consent
+event:birth order:00_99 participant_type:child
+
 
 
 Birth - 18
@@ -163,6 +172,9 @@ event:birth
 
 # Infant Health Care Log
 event:birth
+
+# Child Participation Informed Consent
+event:birth order:00_00 participant_type:child
 
 event:birth instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_part_one instrument:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one order:01_01 participant_type:mother
 

--- a/spec/controllers/participant_consents_controller_spec.rb
+++ b/spec/controllers/participant_consents_controller_spec.rb
@@ -11,12 +11,8 @@ describe ParticipantConsentsController do
       :consent_type_code               => 1,
       :consent_form_type_code          => 1,
       :consent_given_code              => 1,
-      :consent_withdraw_code           => 2,
-      :consent_withdraw_type_code      => 1,
-      :consent_withdraw_reason_code    => 2,
       :consent_language_code           => 1,
       :who_consented_code              => 2,
-      :who_wthdrw_consent_code         => 2,
       :consent_translate_code          => 1,
       :reconsideration_script_use_code => 1,
       :consent_version                 => "1.2"
@@ -26,9 +22,12 @@ describe ParticipantConsentsController do
   context "with an authenticated user" do
 
     let(:mother_person) { Factory(:person) }
-    let(:mother) { Factory(:participant) }
+    let(:mother) { Factory(:participant, :enroll_status_code => nil) }
     let(:event) { Factory(:event, :participant => mother) }
-    let(:contact_link) { Factory(:contact_link, :event => event, :instrument => nil) }
+    let(:contact) { Factory(:contact) }
+    let(:contact_link) { Factory(:contact_link, :event => event,
+                                 :instrument => nil, :contact => contact,
+                                 :person => mother_person) }
 
     before(:each) do
       login(user_login)
@@ -57,7 +56,95 @@ describe ParticipantConsentsController do
         get :new, :contact_link_id => contact_link.id, :participant_id => mother.id
         assigns[:participant_consent].participant_consent_samples.size.should == 3
       end
+    end
 
+    describe "POST create" do
+      describe "with valid params" do
+        describe "with html request" do
+          it "creates a new ParticipantConsent" do
+            expect {
+              post :create, :contact_link_id => contact_link.id,
+                   :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+            }.to change(ParticipantConsent, :count).by(1)
+          end
+
+          it "assigns a newly created ParticipantConsent as @participant_consent" do
+            post :create, :contact_link_id => contact_link.id,
+                 :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+            assigns(:participant_consent).should be_a(ParticipantConsent)
+            assigns(:participant_consent).should be_persisted
+          end
+
+          it "redirects to the contact link decision page" do
+            post :create, :contact_link_id => contact_link.id,
+                 :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+            response.should redirect_to(decision_page_contact_link_path(contact_link))
+          end
+
+          it "updates the participant into a enrolled state" do
+            mother.should_not be_enrolled
+            post :create, :contact_link_id => contact_link.id,
+                 :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+            Participant.find(mother.id).should be_enrolled
+          end
+
+          describe "Informed Consent event" do
+            it "creates an Informed Consent Event record and associates it with the contact link" do
+              ic = Event.where(:participant_id => mother.id, :event_type_code => Event.informed_consent_code).first
+              ic.should be_nil
+
+              post :create, :contact_link_id => contact_link.id,
+                   :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+
+              ic = Event.where(:participant_id => mother.id, :event_type_code => Event.informed_consent_code).last
+              ic.should_not be_nil
+              ic_cl = ic.contact_links.first
+              ic_cl.contact.should  == contact_link.contact
+              ic_cl.staff_id.should == contact_link.staff_id
+              ic_cl.person.should   == contact_link.person
+            end
+
+            it "is created only once for the participant for any particular contact" do
+              ic = Event.where(:participant_id => mother.id, :event_type_code => Event.informed_consent_code).first
+              ic.should be_nil
+
+              3.times do
+                post :create, :contact_link_id => contact_link.id,
+                     :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+              end
+
+              Event.where(:participant_id => mother.id,
+                          :event_type_code => Event.informed_consent_code).count.should == 1
+            end
+
+            it "is created for the participant for each individual contact" do
+              ic = Event.where(:participant_id => mother.id, :event_type_code => Event.informed_consent_code).first
+              ic.should be_nil
+
+              3.times do
+                post :create, :contact_link_id => contact_link.id,
+                     :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+              end
+
+              Event.where(:participant_id => mother.id,
+                          :event_type_code => Event.informed_consent_code).count.should == 1
+
+              new_contact = Factory(:contact)
+              new_contact_link = Factory(:contact_link,
+                                         :event => event,
+                                         :contact => new_contact,
+                                         :person => mother_person)
+
+              post :create, :contact_link_id => new_contact_link.id,
+                   :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+
+              Event.where(:participant_id => mother.id,
+                          :event_type_code => Event.informed_consent_code).count.should == 2
+            end
+
+          end
+        end
+      end
     end
 
     describe "GET new_child" do
@@ -104,7 +191,7 @@ describe ParticipantConsentsController do
               :contact_link_id => contact_link.id, :participant_id => mother.id,
               :participant_consent => valid_attributes,
               :person => { :first_name => "fn", :last_name => "ln"}
-          }.to change(Person, :count).by(2) # the creation of the mother and the child
+          }.to change(Person, :count).by(1)
           child = Person.last
           child.first_name.should == "fn"
           child.last_name.should == "ln"


### PR DESCRIPTION
Remove Informed Consent from PSC Template

This commit creates an Informed Consent Event 'behind the scenes' and associates it with the contact for the "main event" (e.g. PV1).
