### PR TITLE
Task 2600

### DIFF
--- a/app/models/ncs_code.rb
+++ b/app/models/ncs_code.rb
@@ -18,6 +18,7 @@ class NcsCode < ActiveRecord::Base
 
   YES = 1
   NO  = 2
+  OTHER = -5
 
   ATTRIBUTE_MAPPING = {
 

--- a/app/models/operational_data_extractor/base.rb
+++ b/app/models/operational_data_extractor/base.rb
@@ -803,10 +803,11 @@ module OperationalDataExtractor
 
     def process_new_type_race(person_race, attribute, value)
       standard_and_new_type_intersection = [-5, -1, -2, 1, 2, 3, 4]
+      new_type_exclusive_values = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
 
-      if standard_and_new_type_intersection.include?(value) && value.class == Fixnum
+      if standard_and_new_type_intersection.include?(value)
         set_value(person_race, attribute, value)
-      elsif value.class == Fixnum
+      elsif new_type_exclusive_values.include?(value)
         person_race.race_code = -5
         person_race.race_other = NcsCode.where(:list_name => "RACE_CL6", :local_code => value.to_i).first.display_text
       else

--- a/app/models/operational_data_extractor/base.rb
+++ b/app/models/operational_data_extractor/base.rb
@@ -700,6 +700,9 @@ module OperationalDataExtractor
       institution
     end
 
+    def process_person_race
+    end
+
     def finalize_institution(institute)
       ActiveRecord::Base.transaction do
         unless institute.blank?

--- a/app/models/operational_data_extractor/birth.rb
+++ b/app/models/operational_data_extractor/birth.rb
@@ -141,25 +141,25 @@ module OperationalDataExtractor
       mail_address = nil
       work_address = nil
       institution  = nil
+      person_race = nil
 
       process_person(PERSON_MAP)
 
-      child = process_child(CHILD_PERSON_MAP)
-
+      child        = process_child(CHILD_PERSON_MAP)
       mail_address = process_address(person, MAIL_ADDRESS_MAP, Address.mailing_address_type)
       work_address = process_address(person, WORK_ADDRESS_MAP, Address.work_address_type)
-
       phone        = process_telephone(person, TELEPHONE_MAP)
       home_phone   = process_telephone(person, HOME_PHONE_MAP, Telephone.home_phone_type)
       cell_phone   = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)
-
       email        = process_email(EMAIL_MAP)
       institution  = process_institution(INSTITUTION_MAP, response_set)
+      person_race  = process_person_race(PERSON_RACE_MAP)
 
       finalize_email(email)
       finalize_addresses(mail_address, work_address)
       finalize_telephones(cell_phone, home_phone, phone)
       finalize_institution(institution)
+      finalize_person_race(person_race)
 
       update_instrument_mode
 

--- a/app/models/operational_data_extractor/birth.rb
+++ b/app/models/operational_data_extractor/birth.rb
@@ -133,16 +133,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-
-      email        = nil
-      home_phone   = nil
-      cell_phone   = nil
-      phone        = nil
-      mail_address = nil
-      work_address = nil
-      institution  = nil
-      person_race = nil
-
       process_person(PERSON_MAP)
 
       child        = process_child(CHILD_PERSON_MAP)

--- a/app/models/operational_data_extractor/birth.rb
+++ b/app/models/operational_data_extractor/birth.rb
@@ -9,6 +9,9 @@ module OperationalDataExtractor
     BIRTH_LI_PREFIX      = "BIRTH_VISIT_LI"
     BIRTH_VISIT_3_PREFIX = "BIRTH_VISIT_3"
 
+    BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX = "BIRTH_VISIT_BABY_RACE_NEW_3"
+    BIRTH_VISIT_BABY_RACE_1_3_PREFIX   = "BIRTH_VISIT_BABY_RACE_1_3"
+
     CHILD_PERSON_MAP = {
       "#{BABY_NAME_PREFIX}.BABY_FNAME"        => "first_name",
       "#{BABY_NAME_PREFIX}.BABY_MNAME"        => "middle_name",
@@ -101,6 +104,13 @@ module OperationalDataExtractor
       "prepopulated_mode_of_contact" => "prepopulated_mode_of_contact"
     }
 
+    PERSON_RACE_MAP = {
+      "#{BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW"     => "race_code",
+      "#{BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW_OTH" => "race_other",
+      "#{BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1"         => "race_code",
+      "#{BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH"     => "race_other"
+    }
+
     def initialize(response_set)
       super(response_set)
     end
@@ -117,7 +127,8 @@ module OperationalDataExtractor
         CELL_PHONE_MAP,
         EMAIL_MAP,
         INSTITUTION_MAP,
-        MODE_OF_CONTACT_MAP
+        MODE_OF_CONTACT_MAP,
+        PERSON_RACE_MAP
       ]
     end
 

--- a/app/models/operational_data_extractor/birth.rb
+++ b/app/models/operational_data_extractor/birth.rb
@@ -143,13 +143,12 @@ module OperationalDataExtractor
       cell_phone   = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)
       email        = process_email(EMAIL_MAP)
       institution  = process_institution(INSTITUTION_MAP, response_set)
-      person_race  = process_person_race(PERSON_RACE_MAP)
+      process_person_race(PERSON_RACE_MAP)
 
       finalize_email(email)
       finalize_addresses(mail_address, work_address)
       finalize_telephones(cell_phone, home_phone, phone)
       finalize_institution(institution)
-      finalize_person_race(person_race)
 
       update_instrument_mode
 

--- a/app/models/operational_data_extractor/low_intensity_pregnancy_visit.rb
+++ b/app/models/operational_data_extractor/low_intensity_pregnancy_visit.rb
@@ -52,8 +52,6 @@ module OperationalDataExtractor
     def extract_data
 
       ppg_status_history = nil
-      birth_address = nil
-      institution          = nil
 
       birth_address, institution = process_birth_institution_and_address(BIRTH_ADDRESS_MAP, INSTITUTION_MAP)
 

--- a/app/models/operational_data_extractor/participant_verification.rb
+++ b/app/models/operational_data_extractor/participant_verification.rb
@@ -89,11 +89,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-      child_phone    = nil
-      child_phone2   = nil
-      child_address  = nil
-      child_address2 = nil
-
       process_person(PERSON_MAP)
 
       if child

--- a/app/models/operational_data_extractor/pbs_eligibility_screener.rb
+++ b/app/models/operational_data_extractor/pbs_eligibility_screener.rb
@@ -101,7 +101,8 @@ module OperationalDataExtractor
         EMAIL_MAP,
         PPG_DETAILS_MAP,
         DUE_DATE_DETERMINER_MAP,
-        MODE_OF_CONTACT_MAP
+        MODE_OF_CONTACT_MAP,
+        PERSON_RACE_MAP
       ]
     end
 
@@ -116,6 +117,7 @@ module OperationalDataExtractor
       phone1       = nil
       phone2       = nil
       address      = nil
+      person_race  = nil
 
       process_person(PERSON_MAP)
       process_participant(PARTICIPANT_MAP)
@@ -137,6 +139,8 @@ module OperationalDataExtractor
       end
 
       address = process_address(person, ADDRESS_MAP, Address.home_address_type)
+
+      person_race = process_person_race(PERSON_RACE_MAP)
 
       phone1  = process_telephone(person, TELEPHONE_MAP1, nil, primary_rank)
       phone2  = process_telephone(person, TELEPHONE_MAP2, nil, secondary_rank)
@@ -168,6 +172,7 @@ module OperationalDataExtractor
 
       end
 
+      finalize_person_race(person_race)
       finalize_email(email)
       finalize_addresses(address)
       finalize_telephones(phone1, phone2)

--- a/app/models/operational_data_extractor/pbs_eligibility_screener.rb
+++ b/app/models/operational_data_extractor/pbs_eligibility_screener.rb
@@ -112,13 +112,6 @@ module OperationalDataExtractor
 
     def extract_data
 
-      ppg_detail   = nil
-      email        = nil
-      phone1       = nil
-      phone2       = nil
-      address      = nil
-      person_race  = nil
-
       process_person(PERSON_MAP)
       process_participant(PARTICIPANT_MAP)
 
@@ -185,7 +178,6 @@ module OperationalDataExtractor
 
     def calculated_due_date(response_set)
       # try due date first
-      ret = nil
       ret = due_date_response(response_set, "ORIG_DUE_DATE", INTERVIEW_PREFIX)
       ret = due_date_response(response_set, "DATE_PERIOD", INTERVIEW_PREFIX) unless ret
       ret

--- a/app/models/operational_data_extractor/pbs_eligibility_screener.rb
+++ b/app/models/operational_data_extractor/pbs_eligibility_screener.rb
@@ -8,6 +8,9 @@ module OperationalDataExtractor
 
     INTERVIEW_PREFIX = "PBS_ELIG_SCREENER"
 
+    PBS_ELIG_SCREENER_RACE_NEW_PREFIX = "PBS_ELIG_SCREENER_RACE_NEW"
+    PBS_ELIG_SCREENER_RACE_1_PREFIX = "PBS_ELIG_SCREENER_RACE_1"
+
     ENGLISH               = "#{INTERVIEW_PREFIX}.ENGLISH"
     CONTACT_LANG          = "#{INTERVIEW_PREFIX}.CONTACT_LANG_NEW"
     CONTACT_LANG_OTH      = "#{INTERVIEW_PREFIX}.CONTACT_LANG_NEW_OTH"
@@ -82,6 +85,14 @@ module OperationalDataExtractor
 
     MODE_OF_CONTACT_MAP = {
       "prepopulated_mode_of_contact" => "prepopulated_mode_of_contact"
+    }
+    PBS_ELIG_SCREENER_RACE_NEW_PREFIX = "PBS_ELIG_SCREENER_RACE_NEW"
+
+    PERSON_MAP = {
+      "#{PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW" => "race_code",
+      "#{PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW_OTH" => "race_other",
+      "#{PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1" => "race_code",
+      "#{PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1_OTH" => "race_other"
     }
 
     def maps

--- a/app/models/operational_data_extractor/pbs_eligibility_screener.rb
+++ b/app/models/operational_data_extractor/pbs_eligibility_screener.rb
@@ -133,7 +133,7 @@ module OperationalDataExtractor
 
       address = process_address(person, ADDRESS_MAP, Address.home_address_type)
 
-      person_race = process_person_race(PERSON_RACE_MAP)
+      process_person_race(PERSON_RACE_MAP)
 
       phone1  = process_telephone(person, TELEPHONE_MAP1, nil, primary_rank)
       phone2  = process_telephone(person, TELEPHONE_MAP2, nil, secondary_rank)
@@ -165,7 +165,6 @@ module OperationalDataExtractor
 
       end
 
-      finalize_person_race(person_race)
       finalize_email(email)
       finalize_addresses(address)
       finalize_telephones(phone1, phone2)

--- a/app/models/operational_data_extractor/pbs_eligibility_screener.rb
+++ b/app/models/operational_data_extractor/pbs_eligibility_screener.rb
@@ -32,11 +32,6 @@ module OperationalDataExtractor
       "#{INTERVIEW_PREFIX}.AGE_RANGE_PBS"   => "age_range_code",
     }
 
-    PERSON_RACE_MAP = {
-      "#{INTERVIEW_PREFIX}.RACE_NEW"         => "race_code",
-      "#{INTERVIEW_PREFIX}.RACE_NEW_OTH"     => "race_other",
-    }
-
     PARTICIPANT_MAP = {
       "#{INTERVIEW_PREFIX}.AGE_ELIG"        => "pid_age_eligibility_code"
     }
@@ -86,9 +81,8 @@ module OperationalDataExtractor
     MODE_OF_CONTACT_MAP = {
       "prepopulated_mode_of_contact" => "prepopulated_mode_of_contact"
     }
-    PBS_ELIG_SCREENER_RACE_NEW_PREFIX = "PBS_ELIG_SCREENER_RACE_NEW"
 
-    PERSON_MAP = {
+    PERSON_RACE_MAP = {
       "#{PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW" => "race_code",
       "#{PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW_OTH" => "race_other",
       "#{PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1" => "race_code",

--- a/app/models/operational_data_extractor/post_natal.rb
+++ b/app/models/operational_data_extractor/post_natal.rb
@@ -236,21 +236,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-      email = nil
-      cell_phone = nil
-
-      contact1 = nil
-      contact1phone = nil
-      contact1address = nil
-      contact1relationship = nil
-
-      contact2 = nil
-      contact2phone = nil
-      contact2address = nil
-      contact2relationship = nil
-
-      person_race = nil
-
       if child
         process_child(CHILD_PERSON_NAME_MAP)
         process_child_dob(CHILD_PERSON_DATE_OF_BIRTH_MAP)

--- a/app/models/operational_data_extractor/post_natal.rb
+++ b/app/models/operational_data_extractor/post_natal.rb
@@ -210,7 +210,7 @@ module OperationalDataExtractor
 
     PERSON_RACE_MAP = {
       "#{THREE_MONTH_MOTHER_RACE_PREFIX}.RACE"  => "race_code",
-      "#{THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH"  => "race_oth",
+      "#{THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH"  => "race_other",
     }
 
     def initialize(response_set)
@@ -249,6 +249,8 @@ module OperationalDataExtractor
       contact2address = nil
       contact2relationship = nil
 
+      person_race = nil
+
       if child
         process_child(CHILD_PERSON_NAME_MAP)
         process_child_dob(CHILD_PERSON_DATE_OF_BIRTH_MAP)
@@ -270,11 +272,14 @@ module OperationalDataExtractor
         contact2phone = process_telephone(contact2, CONTACT_2_PHONE_MAP)
       end
 
+      person_race = process_person_race(PERSON_RACE_MAP)
+
       finalize_contact(contact1, contact1relationship, contact1address, contact1phone)
       finalize_contact(contact2, contact2relationship, contact2address, contact2phone)
 
       finalize_email(email)
       finalize_telephones(cell_phone)
+      finalize_person_race(person_race)
 
       child.save! if child
       participant.save!

--- a/app/models/operational_data_extractor/post_natal.rb
+++ b/app/models/operational_data_extractor/post_natal.rb
@@ -257,14 +257,13 @@ module OperationalDataExtractor
         contact2phone = process_telephone(contact2, CONTACT_2_PHONE_MAP)
       end
 
-      person_race = process_person_race(PERSON_RACE_MAP)
+      process_person_race(PERSON_RACE_MAP)
 
       finalize_contact(contact1, contact1relationship, contact1address, contact1phone)
       finalize_contact(contact2, contact2relationship, contact2address, contact2phone)
 
       finalize_email(email)
       finalize_telephones(cell_phone)
-      finalize_person_race(person_race)
 
       child.save! if child
       participant.save!

--- a/app/models/operational_data_extractor/post_natal.rb
+++ b/app/models/operational_data_extractor/post_natal.rb
@@ -15,6 +15,8 @@ module OperationalDataExtractor
     EIGHTEEN_MONTH_MOTHER_SECTION_PREFIX = "EIGHTEEN_MTH_MOTHER"
     TWENTY_FOUR_MONTH_MOTHER_SECTION_PREFIX = "TWENTY_FOUR_MTH_MOTHER"
 
+    THREE_MONTH_MOTHER_RACE_PREFIX = "THREE_MTH_MOTHER_RACE"
+
     CHILD_PERSON_NAME_MAP = {
       "#{THREE_MONTH_CHILD_SECTION_PREFIX}.C_FNAME"       =>"first_name",
       "#{THREE_MONTH_CHILD_SECTION_PREFIX}.C_LNAME"       =>"last_name",
@@ -206,6 +208,11 @@ module OperationalDataExtractor
       "#{TWENTY_FOUR_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_PHONE_2"     => "phone_nbr",
     }
 
+    PERSON_RACE_MAP = {
+      "#{THREE_MONTH_MOTHER_RACE_PREFIX}.RACE"  => "race_code",
+      "#{THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH"  => "race_oth",
+    }
+
     def initialize(response_set)
       super(response_set)
     end
@@ -223,7 +230,8 @@ module OperationalDataExtractor
         CONTACT_2_PERSON_MAP,
         CONTACT_2_RELATIONSHIP_MAP,
         CONTACT_2_ADDRESS_MAP,
-        CONTACT_2_PHONE_MAP
+        CONTACT_2_PHONE_MAP,
+        PERSON_RACE_MAP
       ]
     end
 

--- a/app/models/operational_data_extractor/ppg_follow_up.rb
+++ b/app/models/operational_data_extractor/ppg_follow_up.rb
@@ -71,15 +71,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-
-      ppg_status_history = nil
-      home_phone         = nil
-      cell_phone         = nil
-      work_phone         = nil
-      other_phone        = nil
-      phone              = nil
-      email              = nil
-
       phone        = process_telephone(person, TELEPHONE_MAP)
       home_phone   = process_telephone(person, HOME_PHONE_MAP, Telephone.home_phone_type)
       cell_phone   = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)

--- a/app/models/operational_data_extractor/pre_pregnancy.rb
+++ b/app/models/operational_data_extractor/pre_pregnancy.rb
@@ -92,20 +92,6 @@ module OperationalDataExtractor
 
 
     def extract_data
-
-      cell_phone           = nil
-      email                = nil
-
-      contact1             = nil
-      contact1relationship = nil
-      contact1phone        = nil
-      contact1address      = nil
-
-      contact2             = nil
-      contact2relationship = nil
-      contact2phone        = nil
-      contact2address      = nil
-
       process_person(PERSON_MAP)
       cell_phone = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)
       email = process_email(EMAIL_MAP)

--- a/app/models/operational_data_extractor/pregnancy_screener.rb
+++ b/app/models/operational_data_extractor/pregnancy_screener.rb
@@ -8,6 +8,8 @@ module OperationalDataExtractor
 
     INTERVIEW_PREFIX = "PREG_SCREEN_HI_2"
 
+    PREG_SCREEN_HI_RACE_2 = "PREG_SCREEN_HI_RACE_2"
+
     ENGLISH               = "#{INTERVIEW_PREFIX}.ENGLISH"
     CONTACT_LANG          = "#{INTERVIEW_PREFIX}.CONTACT_LANG"
     CONTACT_LANG_OTH      = "#{INTERVIEW_PREFIX}.CONTACT_LANG_OTH"
@@ -90,6 +92,10 @@ module OperationalDataExtractor
       "#{INTERVIEW_PREFIX}.WEEKS_PREG"      => "WEEKS_PREG",
       "#{INTERVIEW_PREFIX}.DATE_PERIOD"     => "DATE_PERIOD",
       "#{INTERVIEW_PREFIX}.ORIG_DUE_DATE"   => "ORIG_DUE_DATE",
+    }
+    PERSON_RACE_MAP = {
+      "#{PREG_SCREEN_HI_RACE_2}.RACE"         => "race_code",
+      "#{PREG_SCREEN_HI_RACE_2}.RACE_OTH"     => "race_other"
     }
 
     def initialize(response_set)

--- a/app/models/operational_data_extractor/pregnancy_screener.rb
+++ b/app/models/operational_data_extractor/pregnancy_screener.rb
@@ -119,16 +119,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-
-      ppg_detail   = nil
-      email        = nil
-      home_phone   = nil
-      cell_phone   = nil
-      phone        = nil
-      mail_address = nil
-      address      = nil
-      person_race  = nil
-
       process_person(PERSON_MAP)
       process_participant(PARTICIPANT_MAP)
 

--- a/app/models/operational_data_extractor/pregnancy_screener.rb
+++ b/app/models/operational_data_extractor/pregnancy_screener.rb
@@ -128,7 +128,7 @@ module OperationalDataExtractor
       home_phone   = process_telephone(person, HOME_PHONE_MAP, Telephone.home_phone_type)
       cell_phone   = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)
       email        = process_email(EMAIL_MAP)
-      person_race  = process_person_race(PERSON_RACE_MAP)
+      process_person_race(PERSON_RACE_MAP)
 
       if participant
         ppg_detail = process_ppg_details(participant, PPG_DETAILS_MAP, INTERVIEW_PREFIX)
@@ -138,7 +138,6 @@ module OperationalDataExtractor
       finalize_email(email)
       finalize_addresses(mail_address, address)
       finalize_telephones(cell_phone, home_phone, phone)
-      finalize_person_race(person_race)
 
       participant.save!
       person.save!

--- a/app/models/operational_data_extractor/pregnancy_screener.rb
+++ b/app/models/operational_data_extractor/pregnancy_screener.rb
@@ -8,7 +8,7 @@ module OperationalDataExtractor
 
     INTERVIEW_PREFIX = "PREG_SCREEN_HI_2"
 
-    PREG_SCREEN_HI_RACE_2 = "PREG_SCREEN_HI_RACE_2"
+    PREG_SCREEN_HI_RACE_2_PREFIX = "PREG_SCREEN_HI_RACE_2"
 
     ENGLISH               = "#{INTERVIEW_PREFIX}.ENGLISH"
     CONTACT_LANG          = "#{INTERVIEW_PREFIX}.CONTACT_LANG"
@@ -94,8 +94,8 @@ module OperationalDataExtractor
       "#{INTERVIEW_PREFIX}.ORIG_DUE_DATE"   => "ORIG_DUE_DATE",
     }
     PERSON_RACE_MAP = {
-      "#{PREG_SCREEN_HI_RACE_2}.RACE"         => "race_code",
-      "#{PREG_SCREEN_HI_RACE_2}.RACE_OTH"     => "race_other"
+      "#{PREG_SCREEN_HI_RACE_2_PREFIX}.RACE"         => "race_code",
+      "#{PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH"     => "race_other"
     }
 
     def initialize(response_set)
@@ -113,7 +113,8 @@ module OperationalDataExtractor
         CELL_PHONE_MAP,
         EMAIL_MAP,
         PPG_DETAILS_MAP,
-        DUE_DATE_DETERMINER_MAP
+        DUE_DATE_DETERMINER_MAP,
+        PERSON_RACE_MAP
       ]
     end
 
@@ -126,6 +127,7 @@ module OperationalDataExtractor
       phone        = nil
       mail_address = nil
       address      = nil
+      person_race  = nil
 
       process_person(PERSON_MAP)
       process_participant(PARTICIPANT_MAP)
@@ -136,6 +138,7 @@ module OperationalDataExtractor
       home_phone   = process_telephone(person, HOME_PHONE_MAP, Telephone.home_phone_type)
       cell_phone   = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)
       email        = process_email(EMAIL_MAP)
+      person_race  = process_person_race(PERSON_RACE_MAP)
 
       if participant
         ppg_detail = process_ppg_details(participant, PPG_DETAILS_MAP, INTERVIEW_PREFIX)
@@ -145,6 +148,7 @@ module OperationalDataExtractor
       finalize_email(email)
       finalize_addresses(mail_address, address)
       finalize_telephones(cell_phone, home_phone, phone)
+      finalize_person_race(person_race)
 
       participant.save!
       person.save!

--- a/app/models/operational_data_extractor/pregnancy_visit.rb
+++ b/app/models/operational_data_extractor/pregnancy_visit.rb
@@ -344,27 +344,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-
-      cell_phone           = nil
-      email                = nil
-      birth_address        = nil
-      contact1             = nil
-      contact1relationship = nil
-      contact1phone        = nil
-      contact1address      = nil
-      contact2             = nil
-      contact2relationship = nil
-      contact2phone        = nil
-      contact2address      = nil
-      father               = nil
-      father_phone         = nil
-      father_address       = nil
-      father_relationship  = nil
-      work_address         = nil
-      confirm_work_address = nil
-      institution          = nil
-      person_race          = nil
-
       process_person(PERSON_MAP)
       process_ppg_status(PPG_STATUS_MAP)
       cell_phone = process_telephone(person, CELL_PHONE_MAP, Telephone.cell_phone_type)

--- a/app/models/operational_data_extractor/pregnancy_visit.rb
+++ b/app/models/operational_data_extractor/pregnancy_visit.rb
@@ -374,7 +374,7 @@ module OperationalDataExtractor
         father_phone = process_telephone(father, FATHER_PHONE_MAP)
       end
 
-      person_race = process_person_race(PERSON_RACE_MAP)
+      process_person_race(PERSON_RACE_MAP)
 
       set_due_date(DUE_DATE_DETERMINER_MAP)
 
@@ -388,8 +388,6 @@ module OperationalDataExtractor
       finalize_addresses(birth_address, work_address, confirm_work_address)
       finalize_telephones(cell_phone)
       finalize_institution_with_birth_address(birth_address, institution)
-
-      finalize_person_race(person_race)
 
       if due_date = calculated_due_date(response_set)
         participant.ppg_details.first.update_due_date(due_date)

--- a/app/models/operational_data_extractor/pregnancy_visit.rb
+++ b/app/models/operational_data_extractor/pregnancy_visit.rb
@@ -12,6 +12,8 @@ module OperationalDataExtractor
     PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX  = "PREG_VISIT_1_3"
     PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX  = "PREG_VISIT_2_3"
 
+    PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX = "PREG_VISIT_1_RACE_NEW_3"
+    PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX   = "PREG_VISIT_1_RACE_1_3"
 
     PERSON_MAP = {
       "#{PREGNANCY_VISIT_1_INTERVIEW_PREFIX}.R_FNAME"           => "first_name",
@@ -302,6 +304,13 @@ module OperationalDataExtractor
       "prepopulated_mode_of_contact" => "prepopulated_mode_of_contact"
     }
 
+    PERSON_RACE_MAP = {
+      "#{PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW"        => "race_code",
+      "#{PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW_OTH"    => "race_other",
+      "#{PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1"            => "race_code",
+      "#{PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH"        => "race_other"
+    }
+
     def initialize(response_set)
       super(response_set)
     end
@@ -329,7 +338,8 @@ module OperationalDataExtractor
         FATHER_PHONE_MAP,
         DUE_DATE_DETERMINER_MAP,
         INSTITUTION_MAP,
-        MODE_OF_CONTACT_MAP
+        MODE_OF_CONTACT_MAP,
+        PERSON_RACE_MAP
       ]
     end
 

--- a/app/models/operational_data_extractor/pregnancy_visit.rb
+++ b/app/models/operational_data_extractor/pregnancy_visit.rb
@@ -363,6 +363,7 @@ module OperationalDataExtractor
       work_address         = nil
       confirm_work_address = nil
       institution          = nil
+      person_race          = nil
 
       process_person(PERSON_MAP)
       process_ppg_status(PPG_STATUS_MAP)
@@ -394,6 +395,8 @@ module OperationalDataExtractor
         father_phone = process_telephone(father, FATHER_PHONE_MAP)
       end
 
+      person_race = process_person_race(PERSON_RACE_MAP)
+
       set_due_date(DUE_DATE_DETERMINER_MAP)
 
       finalize_father(father, father_relationship, father_address, father_phone)
@@ -406,6 +409,8 @@ module OperationalDataExtractor
       finalize_addresses(birth_address, work_address, confirm_work_address)
       finalize_telephones(cell_phone)
       finalize_institution_with_birth_address(birth_address, institution)
+
+      finalize_person_race(person_race)
 
       if due_date = calculated_due_date(response_set)
         participant.ppg_details.first.update_due_date(due_date)

--- a/app/models/operational_data_extractor/tracing_module.rb
+++ b/app/models/operational_data_extractor/tracing_module.rb
@@ -170,29 +170,6 @@ module OperationalDataExtractor
     end
 
     def extract_data
-
-      email        = nil
-      home_phone   = nil
-      cell_phone   = nil
-      new_address  = nil
-      address      = nil
-
-      contact1             = nil
-      contact1relationship = nil
-      contact1phone        = nil
-      contact1phone2       = nil
-      contact1address      = nil
-      contact2             = nil
-      contact2relationship = nil
-      contact2phone        = nil
-      contact2phone2       = nil
-      contact2address      = nil
-      contact3             = nil
-      contact3relationship = nil
-      contact3phone        = nil
-      contact3phone2       = nil
-      contact3address      = nil
-
       address = process_address(person, ADDRESS_MAP, Address.home_address_type)
       new_address = process_address(person, NEW_ADDRESS_MAP, Address.home_address_type)
 

--- a/spec/models/operational_data_extractor/base_spec.rb
+++ b/spec/models/operational_data_extractor/base_spec.rb
@@ -584,4 +584,61 @@ describe OperationalDataExtractor::Base do
     end
 
   end
+
+  context "Processing PersonRace records" do
+    let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
+    let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+
+    before do
+      @person_race_map   = OperationalDataExtractor::Birth::PERSON_RACE_MAP
+
+      person = Factory(:person)
+      participant = Factory(:participant)
+      Factory(:participant_person_link, :participant => participant, :person => person)
+      survey = create_birth_survey_with_person_race_operational_data
+      response_set, instrument = prepare_instrument(person, participant, survey)
+
+      take_survey(survey, response_set) do |a|
+        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW_OTH", "Chinese"
+        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
+        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Korean"
+      end
+
+      response_set.save!
+
+      @birth_extractor = OperationalDataExtractor::Birth.new(response_set)
+    end
+
+    describe "#process_person_race" do
+      it "generates a person_race record" do
+        pending
+      end
+    end
+
+    describe "#process_standard" do
+      it "populates a standard person_race record with responses" do
+        pending
+      end
+    end
+
+    describe "#process_new_type" do
+      it "populates a 'new' type person_race record with responses" do
+        pending
+      end
+    end
+
+    describe "#get_person_race" do
+      it "retrieves a person_race record if one exists" do
+        pending
+      end
+    end
+
+    describe "#finalize_person_race" do
+      it "saves the person_race record" do
+        pending
+      end
+    end
+  end
+
 end

--- a/spec/models/operational_data_extractor/pbs_eligibility_screener_spec.rb
+++ b/spec/models/operational_data_extractor/pbs_eligibility_screener_spec.rb
@@ -774,6 +774,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
     let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+    let(:other_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", -5) }
+    let(:vietnamese_race) { NcsCode.for_list_name_and_local_code("RACE_CL6", 9) }
 
     before do
       @person = Factory(:person)
@@ -787,16 +789,27 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", black_race
-          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1_OTH", "Korean"
+          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", other_race
+          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
       end
 
-      it "extracts standard racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 2
-        extracted_person.race_other.should == "Korean"
+      it "extracts two standard racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "creates at least one race record with a specific non-other code" do
+        @person.races.map(&:race_code).should include(black_race.local_code)
+      end
+
+      it "creates at least one race record with an other code" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "creates an other code with the text 'Aborigine'" do
+        @person.races.map(&:race_other).should include("Aborigine")
       end
     end
 
@@ -804,16 +817,27 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", white_race
-          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW_OTH", "Chinese"
+          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", vietnamese_race
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
       end
 
-      it "extracts new type racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 1
-        extracted_person.race_other.should == "Chinese"
+      it "extracts a two new type racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "the record with a choice that is on the standard race code list is represented as a simple code" do
+        @person.races.map(&:race_code).should include(white_race.local_code)
+      end
+
+      it "the record generated from a response that is NOT on the standard race code list is represented with a code for 'other' (-5)" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "the record generated from a response that is NOT on the standard race code list should have the text associated with the choice in the 'race_other' attribute" do
+        other_race_record = @person.races.detect { |race| race.race_code == other_race.local_code }
+        other_race_record.race_other.should == "Vietnamese"
       end
     end
   end

--- a/spec/models/operational_data_extractor/post_natal_spec.rb
+++ b/spec/models/operational_data_extractor/post_natal_spec.rb
@@ -156,4 +156,36 @@ describe OperationalDataExtractor::PostNatal do
 
   end
 
+  context "extracting race operational data" do
+
+    let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
+    let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+
+    before do
+      @person = Factory(:person)
+      participant = Factory(:participant)
+      Factory(:participant_person_link, :participant => participant, :person => @person)
+      @survey = create_three_month_mother_int_part_two_survey_with_person_race_operational_data
+      @response_set, instrument = prepare_instrument(@person, participant, @survey)
+    end
+
+    describe "processing racial data" do
+      before do
+        take_survey(@survey, @response_set) do |a|
+          a.choice "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", black_race
+          a.str "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH", "Korean"
+        end
+
+        OperationalDataExtractor::PostNatal.new(@response_set).extract_data
+      end
+
+      it "extracts racial data" do
+        extracted_person = Person.find(@person.id).races.first
+        extracted_person.race_code.should == 2
+        extracted_person.race_other.should == "Korean"
+      end
+    end
+
+  end
+
 end

--- a/spec/models/operational_data_extractor/post_natal_spec.rb
+++ b/spec/models/operational_data_extractor/post_natal_spec.rb
@@ -160,6 +160,8 @@ describe OperationalDataExtractor::PostNatal do
 
     let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
     let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+    let(:other_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", -5) }
+    let(:vietnamese_race) { NcsCode.for_list_name_and_local_code("RACE_CL6", 9) }
 
     before do
       @person = Factory(:person)
@@ -173,16 +175,27 @@ describe OperationalDataExtractor::PostNatal do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", black_race
-          a.str "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH", "Korean"
+          a.choice "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", other_race
+          a.str "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PostNatal.new(@response_set).extract_data
       end
 
-      it "extracts racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 2
-        extracted_person.race_other.should == "Korean"
+      it "extracts two standard racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "creates at least one race record with a specific non-other code" do
+        @person.races.map(&:race_code).should include(black_race.local_code)
+      end
+
+      it "creates at least one race record with an other code" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "creates an other code with the text 'Aborigine'" do
+        @person.races.map(&:race_other).should include("Aborigine")
       end
     end
 

--- a/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
@@ -712,7 +712,7 @@ describe OperationalDataExtractor::PregnancyScreener do
     describe "#known_keys" do
       it "collects all the keys for the ODE maps" do
         ode = OperationalDataExtractor::PregnancyScreener.new(@response_set)
-        ode.known_keys.size.should == 47
+        ode.known_keys.size.should == 49
       end
     end
 
@@ -758,6 +758,38 @@ describe OperationalDataExtractor::PregnancyScreener do
       participant = person.participant
       participant.due_date.should == ((Date.today + 280.days) - ((months_pregnant * 30) - 15)).to_date
 
+    end
+
+  end
+
+  context "extracting race operational data" do
+
+    let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
+    let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+
+    before do
+      @person = Factory(:person)
+      participant = Factory(:participant)
+      Factory(:participant_person_link, :participant => participant, :person => @person)
+      @survey = create_pregnancy_screener_survey_with_race_operational_data
+      @response_set, instrument = prepare_instrument(@person, participant, @survey)
+    end
+
+    describe "processing racial data" do
+      before do
+        take_survey(@survey, @response_set) do |a|
+          a.choice "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", black_race
+          a.str "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH", "Korean"
+        end
+
+        OperationalDataExtractor::PregnancyScreener.new(@response_set).extract_data
+      end
+
+      it "extracts racial data" do
+        extracted_person = Person.find(@person.id).races.first
+        extracted_person.race_code.should == 2
+        extracted_person.race_other.should == "Korean"
+      end
     end
 
   end

--- a/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
@@ -766,6 +766,7 @@ describe OperationalDataExtractor::PregnancyScreener do
 
     let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
     let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+    let(:other_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", -5) }
 
     before do
       @person = Factory(:person)
@@ -779,16 +780,27 @@ describe OperationalDataExtractor::PregnancyScreener do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", black_race
-          a.str "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH", "Korean"
+          a.choice "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", other_race
+          a.str "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PregnancyScreener.new(@response_set).extract_data
       end
 
-      it "extracts racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 2
-        extracted_person.race_other.should == "Korean"
+      it "extracts two standard racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "creates at least one race record with a specific non-other code" do
+        @person.races.map(&:race_code).should include(black_race.local_code)
+      end
+
+      it "creates at least one race record with an other code" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "creates an other code with the text 'Aborigine'" do
+        @person.races.map(&:race_other).should include("Aborigine")
       end
     end
 

--- a/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
@@ -666,4 +666,52 @@ describe OperationalDataExtractor::PregnancyVisit do
     end
 
   end
+
+  context "extracting race operational data" do
+
+    let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
+    let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+
+    before do
+      @person = Factory(:person)
+      participant = Factory(:participant)
+      Factory(:participant_person_link, :participant => participant, :person => @person)
+      @survey = create_pbs_pregnancy_visit_1_with_race_operational_data
+      @response_set, instrument = prepare_instrument(@person, participant, @survey)
+    end
+
+    describe "processing standard racial data" do
+      before do
+        take_survey(@survey, @response_set) do |a|
+          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", black_race
+          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH", "Korean"
+        end
+
+        OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
+      end
+
+      it "extracts standard racial data" do
+        extracted_person = Person.find(@person.id).races.first
+        extracted_person.race_code.should == 2
+        extracted_person.race_other.should == "Korean"
+      end
+    end
+
+    describe "processing new type racial data" do
+      before do
+        take_survey(@survey, @response_set) do |a|
+          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", white_race
+          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW_OTH", "Chinese"
+        end
+
+        OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
+      end
+
+      it "extracts new type racial data" do
+        extracted_person = Person.find(@person.id).races.first
+        extracted_person.race_code.should == 1
+        extracted_person.race_other.should == "Chinese"
+      end
+    end
+  end
 end

--- a/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
@@ -671,6 +671,8 @@ describe OperationalDataExtractor::PregnancyVisit do
 
     let(:white_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 1) }
     let(:black_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", 2) }
+    let(:other_race) { NcsCode.for_list_name_and_local_code("RACE_CL1", -5) }
+    let(:vietnamese_race) { NcsCode.for_list_name_and_local_code("RACE_CL6", 9) }
 
     before do
       @person = Factory(:person)
@@ -684,16 +686,27 @@ describe OperationalDataExtractor::PregnancyVisit do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", black_race
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH", "Korean"
+          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", other_race
+          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
       end
 
-      it "extracts standard racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 2
-        extracted_person.race_other.should == "Korean"
+      it "extracts two standard racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "creates at least one race record with a specific non-other code" do
+        @person.races.map(&:race_code).should include(black_race.local_code)
+      end
+
+      it "creates at least one race record with an other code" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "creates an other code with the text 'Aborigine'" do
+        @person.races.map(&:race_other).should include("Aborigine")
       end
     end
 
@@ -701,16 +714,27 @@ describe OperationalDataExtractor::PregnancyVisit do
       before do
         take_survey(@survey, @response_set) do |a|
           a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", white_race
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW_OTH", "Chinese"
+          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", vietnamese_race
         end
 
         OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
       end
 
-      it "extracts new type racial data" do
-        extracted_person = Person.find(@person.id).races.first
-        extracted_person.race_code.should == 1
-        extracted_person.race_other.should == "Chinese"
+      it "extracts a two new type racial data" do
+        @person.races.should have(2).races
+      end
+
+      it "the record with a choice that is on the standard race code list is represented as a simple code" do
+        @person.races.map(&:race_code).should include(white_race.local_code)
+      end
+
+      it "the record generated from a response that is NOT on the standard race code list is represented with a code for 'other' (-5)" do
+        @person.races.map(&:race_code).should include(other_race.local_code)
+      end
+
+      it "the record generated from a response that is NOT on the standard race code list should have the text associated with the choice in the 'race_other' attribute" do
+        other_race_record = @person.races.detect { |race| race.race_code == other_race.local_code }
+        other_race_record.race_other.should == "Vietnamese"
       end
     end
   end

--- a/spec/support/test_surveys/birth_visit.rb
+++ b/spec/support/test_surveys/birth_visit.rb
@@ -167,6 +167,9 @@ module BirthVisit
     # Race New
     q = Factory(:question, :reference_identifier => "BABY_RACE_NEW", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_NEW_3.BABY_RACE_NEW", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
+    a = Factory(:answer, :question_id => q.id, :text => "Vietnamese", :response_class => "answer", :reference_identifier => "9")
 
     # Race New Other
     q = Factory(:question, :reference_identifier => "BABY_RACE_NEW_OTH", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_NEW_3.BABY_RACE_NEW_OTH", :survey_section_id => survey_section.id)
@@ -175,10 +178,13 @@ module BirthVisit
     # Race One
     q = Factory(:question, :reference_identifier => "BABY_RACE_1", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_1_3.BABY_RACE_1", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Other", :response_class => "answer", :reference_identifier => "neg_5")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "BABY_RACE_1_OTH", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_1_3.BABY_RACE_1_OTH", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
 
     survey
   end

--- a/spec/support/test_surveys/birth_visit.rb
+++ b/spec/support/test_surveys/birth_visit.rb
@@ -160,6 +160,29 @@ module BirthVisit
     survey
   end
 
+  def create_birth_survey_with_person_race_operational_data
+    survey = Factory(:survey, :title => "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_BIRTH_VISIT_BABY_NAME_3", :access_code => "ins-que-birth-int-ehpbhipbs-m3-0-v3-0-birth-visit-baby-name-3")
+    survey_section = Factory(:survey_section, :survey_id => survey.id)
+
+    # Race New
+    q = Factory(:question, :reference_identifier => "BABY_RACE_NEW", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_NEW_3.BABY_RACE_NEW", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+
+    # Race New Other
+    q = Factory(:question, :reference_identifier => "BABY_RACE_NEW_OTH", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_NEW_3.BABY_RACE_NEW_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Chinese", :response_class => "string")
+
+    # Race One
+    q = Factory(:question, :reference_identifier => "BABY_RACE_1", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_1_3.BABY_RACE_1", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+
+    # Race One Other
+    q = Factory(:question, :reference_identifier => "BABY_RACE_1_OTH", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_1_3.BABY_RACE_1_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+
+    survey
+  end
+
   def create_birth_part_one_survey_with_prepopulated_fields_for_part_two
     survey = Factory(:survey, :title => "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_ONE", :access_code => "ins-que-birth-int-ehpbhipbs-m3-0-v3-0-part-one")
     survey_section = Factory(:survey_section, :survey_id => survey.id)

--- a/spec/support/test_surveys/pbs_eligibility_screener.rb
+++ b/spec/support/test_surveys/pbs_eligibility_screener.rb
@@ -64,6 +64,9 @@ module PbsEligibilityScreener
     # Race New
     q = Factory(:question, :reference_identifier => "RACE_NEW", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_NEW.RACE_NEW", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
+    a = Factory(:answer, :question_id => q.id, :text => "Vietnamese", :response_class => "answer", :reference_identifier => "9")
 
     # Race New Other
     q = Factory(:question, :reference_identifier => "RACE_NEW_OTH", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_NEW.RACE_NEW_OTH", :survey_section_id => survey_section.id)
@@ -72,10 +75,13 @@ module PbsEligibilityScreener
     # Race One
     q = Factory(:question, :reference_identifier => "RACE_1", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_1.RACE_1", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Other", :response_class => "answer", :reference_identifier => "neg_5")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_1.RACE_1_OTH", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
 
     survey
   end

--- a/spec/support/test_surveys/pbs_eligibility_screener.rb
+++ b/spec/support/test_surveys/pbs_eligibility_screener.rb
@@ -57,6 +57,29 @@ module PbsEligibilityScreener
     survey
   end
 
+  def create_pbs_eligibility_screener_survey_with_person_race_operational_data
+    survey = Factory(:survey, :title => "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.0", :access_code => "ins-que-pbsamplingscreen-int-pbs-m3-0-v1-0")
+    survey_section = Factory(:survey_section, :survey_id => survey.id)
+
+    # Race New
+    q = Factory(:question, :reference_identifier => "RACE_NEW", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_NEW.RACE_NEW", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+
+    # Race New Other
+    q = Factory(:question, :reference_identifier => "RACE_NEW_OTH", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_NEW.RACE_NEW_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Chinese", :response_class => "string")
+
+    # Race One
+    q = Factory(:question, :reference_identifier => "RACE_1", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_1.RACE_1", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+
+    # Race One Other
+    q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_1.RACE_1_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+
+    survey
+  end
+
   def create_pbs_eligibility_screener_survey_with_address_operational_data
     survey = Factory(:survey, :title => "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.0", :access_code => "ins-que-pbsamplingscreen-int-pbs-m3-0-v1-0")
     survey_section = Factory(:survey_section, :survey_id => survey.id)

--- a/spec/support/test_surveys/post_natal.rb
+++ b/spec/support/test_surveys/post_natal.rb
@@ -27,10 +27,13 @@ module PostNatal
     # Race One
     q = Factory(:question, :reference_identifier => "RACE", :data_export_identifier => "THREE_MTH_MOTHER_RACE.RACE", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Other", :response_class => "answer", :reference_identifier => "neg_5")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "THREE_MTH_MOTHER_RACE.RACE_OTH", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
 
     survey
   end

--- a/spec/support/test_surveys/post_natal.rb
+++ b/spec/support/test_surveys/post_natal.rb
@@ -20,6 +20,21 @@ module PostNatal
     survey
   end
 
+  def create_three_month_mother_int_part_two_survey_with_person_race_operational_data
+    survey = Factory(:survey, :title => "INS_QUE_3MMother_INT_EHPBHI_P2_V1.1_PART_TWO", :access_code => "ins-que-3mmother-int-ehpbhi-p2-v1-1-part_two")
+    survey_section = Factory(:survey_section, :survey_id => survey.id)
+
+    # Race One
+    q = Factory(:question, :reference_identifier => "RACE", :data_export_identifier => "THREE_MTH_MOTHER_RACE.RACE", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+
+    # Race One Other
+    q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "THREE_MTH_MOTHER_RACE.RACE_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+
+    survey
+  end
+
   def create_three_month_mother_int_child_detail_survey_with_date_of_birth_operational_data
     survey = Factory(:survey, :title => "INS_QUE_3MMother_INT_EHPBHI_P2_V1.1_CHILD_DETAIL", :access_code => "ins-que-3mmother-int-ehpbhi-p2-v1-1-child-detail")
     survey_section = Factory(:survey_section, :survey_id => survey.id)

--- a/spec/support/test_surveys/pregnancy_screener.rb
+++ b/spec/support/test_surveys/pregnancy_screener.rb
@@ -170,6 +170,21 @@ module PregnancyScreener
     survey
   end
 
+  def create_pregnancy_screener_survey_with_race_operational_data
+    survey = Factory(:survey, :title => "INS_QUE_PregScreen_INT_HILI_M2.1_V2.1", :access_code => "ins-que-pregscreen-int-hili-m2-1-v2-1")
+    survey_section = Factory(:survey_section, :survey_id => survey.id)
+
+    # Race One
+    q = Factory(:question, :reference_identifier => "RACE", :data_export_identifier => "PREG_SCREEN_HI_RACE_2.RACE", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+
+    # Race One Other
+    q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "PREG_SCREEN_HI_RACE_2.RACE_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+
+    survey
+  end
+
   def create_pregnancy_screener_survey_with_address_operational_data
     survey = Factory(:survey, :title => "INS_QUE_PregScreen_INT_HILI_P2_V2.0", :access_code => "ins-que-pregscreen-int-hili-p2-v2-0")
     survey_section = Factory(:survey_section, :survey_id => survey.id)

--- a/spec/support/test_surveys/pregnancy_screener.rb
+++ b/spec/support/test_surveys/pregnancy_screener.rb
@@ -177,10 +177,13 @@ module PregnancyScreener
     # Race One
     q = Factory(:question, :reference_identifier => "RACE", :data_export_identifier => "PREG_SCREEN_HI_RACE_2.RACE", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Other", :response_class => "answer", :reference_identifier => "neg_5")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "PREG_SCREEN_HI_RACE_2.RACE_OTH", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
 
     survey
   end

--- a/spec/support/test_surveys/pregnancy_visit_one.rb
+++ b/spec/support/test_surveys/pregnancy_visit_one.rb
@@ -231,7 +231,7 @@ module PregnancyVisitOne
   end
 
   def create_pbs_pregnancy_visit_1_with_birth_address_operational_data
-    survey = Factory(:survey, :title => "INS_QUE_PregVisit1_INT_EHPBHIPBS_M3.0_V3.0", :access_code => "ins-que-pregvisit1-int-ehpbhipbs-m3-0-v3-0_test")
+    survey = Factory(:survey, :title => "INS_QUE_PregVisit1_INT_EHPBHIPBS_M3.0_V3.0", :access_code => "ins-que-pregvisit1-int-ehpbhipbs-m3-0-v3-0")
     survey_section = Factory(:survey_section, :survey_id => survey.id)
 
     # Address One
@@ -250,6 +250,29 @@ module PregnancyVisitOne
     # Zip
     q = Factory(:question, :reference_identifier => "B_ZIPCODE", :data_export_identifier => "PREG_VISIT_1_3.B_ZIPCODE", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Zip", :response_class => "string")
+
+    survey
+  end
+
+  def create_pbs_pregnancy_visit_1_with_race_operational_data
+    survey = Factory(:survey, :title => "INS_QUE_PregVisit1_INT_EHPBHIPBS_M3.0_V3.0", :access_code => "ins-que-pregvisit1-int-ehpbhipbs-m3-0-v3-0")
+    survey_section = Factory(:survey_section, :survey_id => survey.id)
+
+    # Race New
+    q = Factory(:question, :reference_identifier => "RACE_NEW", :data_export_identifier => "PREG_VISIT_1_RACE_NEW_3.RACE_NEW", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+
+    # Race New Other
+    q = Factory(:question, :reference_identifier => "RACE_NEW_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_NEW_3.RACE_NEW_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Chinese", :response_class => "string")
+
+    # Race One
+    q = Factory(:question, :reference_identifier => "RACE_1", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+
+    # Race One Other
+    q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1_OTH", :survey_section_id => survey_section.id)
+    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
 
     survey
   end

--- a/spec/support/test_surveys/pregnancy_visit_one.rb
+++ b/spec/support/test_surveys/pregnancy_visit_one.rb
@@ -261,6 +261,9 @@ module PregnancyVisitOne
     # Race New
     q = Factory(:question, :reference_identifier => "RACE_NEW", :data_export_identifier => "PREG_VISIT_1_RACE_NEW_3.RACE_NEW", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "White", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
+    a = Factory(:answer, :question_id => q.id, :text => "Vietnamese", :response_class => "answer", :reference_identifier => "9")
 
     # Race New Other
     q = Factory(:question, :reference_identifier => "RACE_NEW_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_NEW_3.RACE_NEW_OTH", :survey_section_id => survey_section.id)
@@ -269,10 +272,13 @@ module PregnancyVisitOne
     # Race One
     q = Factory(:question, :reference_identifier => "RACE_1", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Black or African American", :response_class => "answer", :reference_identifier => "2")
+    a = Factory(:answer, :question_id => q.id, :text => "Other", :response_class => "answer", :reference_identifier => "neg_5")
+    a = Factory(:answer, :question_id => q.id, :text => "Asian", :response_class => "answer", :reference_identifier => "4")
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1_OTH", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
 
     survey
   end


### PR DESCRIPTION
Added capability of the Operation Data Extractors to extract racial operational data. 

One peculiar aspect of developing this capability is the mandatory use of RACE_CL1 when extracting the data into the model. 

The MDES specifies two types of RACE records: those with the term 'New' in their reference identifiers and those without. The ones **without** the 'New' term have response groups that map to RACE_CL1, but those **with** the 'New' term map to RACE_CL6. 

RACE_CL6 represents an expansion of racial response options, so there is some intersection with RACE_CL1. 

For a 'New' response that intersects with an option on RACE_CL1, this response is handled in the standard way we handle normal NcsCoded responses: the `local_code` value is placed in the coded attribute. 

If the response is _not_ a member of RACE_CL1, we then use the NcsCode for 'other' in the `race_code`, which is -5, and grab the `display_text` description of the race and apply it to the `race_other` attribute, a string attribute. Please see me for further explanation.
