### PR TITLE
Added uniqueness constraints for institute_person_links, closes #3213.

### DIFF
--- a/app/models/operational_data_extractor/base.rb
+++ b/app/models/operational_data_extractor/base.rb
@@ -701,14 +701,11 @@ module OperationalDataExtractor
     end
 
     def finalize_institution(institute)
-      ActiveRecord::Base.transaction do
-        unless institute.blank?
-          ipl = InstitutionPersonLink.new
-          ipl.person = participant.person
-          ipl.institution = institute
-          ipl.save!
-          institute.save!
-        end
+      begin
+        institute.save!
+        InstitutionPersonLink.find_or_create_by_institution_id_and_person_id(institute.id, person.id)
+      rescue ActiveRecord::RecordNotUnique
+        log.warn("IPL with person_id of #{person.id} and institution_id of #{institute.id} already exists, not creating")
       end
     end
 

--- a/db/migrate/20130201195609_add_unique_index_on_person_id_and_institution_id_in_institution_person_links.rb
+++ b/db/migrate/20130201195609_add_unique_index_on_person_id_and_institution_id_in_institution_person_links.rb
@@ -1,0 +1,13 @@
+class AddUniqueIndexOnPersonIdAndInstitutionIdInInstitutionPersonLinks < ActiveRecord::Migration
+  def up
+    execute "DELETE FROM institution_person_links USING institution_person_links ipl
+             WHERE institution_person_links.person_id = ipl.person_id
+             AND institution_person_links.institution_id = ipl.institution_id
+             AND institution_person_links.id > ipl.id;"
+    add_index :institution_person_links, [:institution_id, :person_id], :unique => true
+  end
+
+  def down
+    drop_table :institution_person_links
+  end
+end

--- a/spec/models/operational_data_extractor/base_spec.rb
+++ b/spec/models/operational_data_extractor/base_spec.rb
@@ -553,17 +553,26 @@ describe OperationalDataExtractor::Base do
     end
 
     describe "#finalize_institution" do
+      before do
+        @institution = @pregnancy_visit_extractor.process_institution(@institution_map, @response_set, @hospital)
+      end
+
       it "links the person to the institution" do
-        institution = @pregnancy_visit_extractor.process_institution(@institution_map, @response_set, @hospital)
-        @pregnancy_visit_extractor.finalize_institution(institution)
-        @participant.person.institutions.first.should eq(institution)
+        @pregnancy_visit_extractor.finalize_institution(@institution)
+        @participant.person.institutions.first.should eq(@institution)
       end
 
       it "saves the institution record" do
-        institution = @pregnancy_visit_extractor.process_institution(@institution_map, @response_set, @hospital)
-        @pregnancy_visit_extractor.finalize_institution(institution)
+        @pregnancy_visit_extractor.finalize_institution(@institution)
         Institution.count.should == 1
-        Institution.first.should eq(institution)
+        Institution.first.should eq(@institution)
+      end
+
+      it "does not create a duplicate institution-person link if one already exists" do
+        (2).times do
+          @pregnancy_visit_extractor.finalize_institution(@institution)
+        end
+        InstitutionPersonLink.where(:person_id => @person.id, :institution_id => @institution.id).size.should == 1
       end
 
     end


### PR DESCRIPTION
Added a migration with SQL to remove any existing duplicate records, and then build unique indices for `person_id` and `institution_id` to `InstitiutionPersonLinks`. Altered `#finalize_institution` to use `#find_or_create_by`. Added tests.
