### PR TITLE
Set participant.enroll_date #3288

### DIFF
--- a/app/controllers/participant_consents_controller.rb
+++ b/app/controllers/participant_consents_controller.rb
@@ -170,7 +170,7 @@ class ParticipantConsentsController < ApplicationController
     def update_enrollment_status
       participant = Participant.find(@participant_consent.participant_id)
       if @participant_consent.consented?
-        participant.enroll! unless participant.enrolled?
+        participant.enroll!(@participant_consent.consent_date) unless participant.enrolled?
       else
         participant.unenroll!(psc, "Consent withdrawn") unless participant.unenrolled?
       end

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -259,28 +259,6 @@ class ParticipantsController < ApplicationController
     redirect_to participant_path(@participant)
   end
 
-  ##
-  # @deprecated Action is not currently available to users in UI
-  def enroll
-    @participant.enroll!
-
-    url = participant_path(@participant)
-    url = params[:redirect_to] unless params[:redirect_to].blank?
-
-    redirect_to(url, :notice => "Participant was successfully enrolled into the study.")
-  end
-
-  ##
-  # @deprecated Action is not currently available to users in UI
-  def unenroll
-    @participant.unenroll!(psc, params[:enrollment_status_comment])
-
-    url = participant_path(@participant)
-    url = params[:redirect_to] unless params[:redirect_to].blank?
-
-    redirect_to(url, :notice => "Participant was successfully un-enrolled from the study.")
-  end
-
   def remove_from_active_followup
     @participant.unenroll!(psc, params[:enrollment_status_comment])
 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -259,6 +259,8 @@ class ParticipantsController < ApplicationController
     redirect_to participant_path(@participant)
   end
 
+  ##
+  # @deprecated Action is not currently available to users in UI
   def enroll
     @participant.enroll!
 
@@ -268,6 +270,8 @@ class ParticipantsController < ApplicationController
     redirect_to(url, :notice => "Participant was successfully enrolled into the study.")
   end
 
+  ##
+  # @deprecated Action is not currently available to users in UI
   def unenroll
     @participant.unenroll!(psc, params[:enrollment_status_comment])
 

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -760,14 +760,17 @@ class Participant < ActiveRecord::Base
   ##
   # Sets the enroll status to Yes (i.e. local_code = 1)
   # and the enroll_date to the given date
-  # @param enroll_date [Date] - defaults to today
-  def enroll(enroll_date = Date.today)
+  # @param enroll_date [Date]
+  def enroll(enroll_date)
     self.enroll_status = NcsCode.for_attribute_name_and_local_code(:enroll_status_code, NcsCode::YES)
     self.enroll_date = enroll_date
     self.being_followed = true
   end
 
-  def enroll!(enroll_date = Date.today)
+  ##
+  # Enroll and save!
+  # @param enroll_date [Date]
+  def enroll!(enroll_date)
     self.enroll(enroll_date)
     self.save!
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -744,7 +744,7 @@ class Participant < ActiveRecord::Base
   def unenroll(psc, reason = "Participant has been un-enrolled from the study.")
     self.enrollment_status_comment = reason
     self.participant_consents.each { |c| c.withdraw! if c.consented? }
-    self.enroll_status = NcsCode.for_attribute_name_and_local_code(:enroll_status_code, 2)
+    self.enroll_status = NcsCode.for_attribute_name_and_local_code(:enroll_status_code, NcsCode::NO)
     self.pending_events.each { |e| e.cancel_and_close_or_delete!(psc, reason) }
     self.being_followed = false
   end
@@ -759,13 +759,16 @@ class Participant < ActiveRecord::Base
 
   ##
   # Sets the enroll status to Yes (i.e. local_code = 1)
-  def enroll
-    self.enroll_status = NcsCode.for_attribute_name_and_local_code(:enroll_status_code, 1)
+  # and the enroll_date to the given date
+  # @param enroll_date [Date] - defaults to today
+  def enroll(enroll_date = Date.today)
+    self.enroll_status = NcsCode.for_attribute_name_and_local_code(:enroll_status_code, NcsCode::YES)
+    self.enroll_date = enroll_date
     self.being_followed = true
   end
 
-  def enroll!
-    self.enroll
+  def enroll!(enroll_date = Date.today)
+    self.enroll(enroll_date)
     self.save!
   end
 

--- a/app/views/participants/_enrollment.html.haml
+++ b/app/views/participants/_enrollment.html.haml
@@ -14,44 +14,45 @@
                 = f.submit switch_arm_message(@participant)
               - else
                 = f.submit switch_arm_message(@participant), :confirm => "Please confirm that participant is eligible for High Intensity - (i.e. in TSU)"
-    - if permit?(Role::SYSTEM_ADMINISTRATOR, Role::USER_ADMINISTRATOR, Role::STAFF_SUPERVISOR)
-      .enrollment
-        - if false
-          %b
-            Enrollment
-          %div
-            - if @participant.enrolled?
-              - path = unenroll_participant_path(@participant, :redirect_to => redirection)
-              - msg = "Un-enroll Participant from Study"
-              - show_enrollment_status_comment = true
-            - else
-              - path = enroll_participant_path(@participant, :redirect_to => redirection)
-              - msg = "Enroll Participant in Study"
-              - show_enrollment_status_comment = false
-            = form_for(@participant, :url => path) do |f|
-              - if show_enrollment_status_comment
-                %p
-                  = label_tag :enrollment_status_comment, "Reason for un-enrolling:"
-                  %br
-                  = text_area_tag :enrollment_status_comment
+- if permit?(Role::SYSTEM_ADMINISTRATOR, Role::USER_ADMINISTRATOR, Role::STAFF_SUPERVISOR)
+  .page_section
+    .enrollment
+      - if false
+        %b
+          Enrollment
+        %div
+          - if @participant.enrolled?
+            - path = unenroll_participant_path(@participant, :redirect_to => redirection)
+            - msg = "Un-enroll Participant from Study"
+            - show_enrollment_status_comment = true
+          - else
+            - path = enroll_participant_path(@participant, :redirect_to => redirection)
+            - msg = "Enroll Participant in Study"
+            - show_enrollment_status_comment = false
+          = form_for(@participant, :url => path) do |f|
+            - if show_enrollment_status_comment
               %p
-                = f.submit msg, :confirm => "Are you certain you would like to #{msg}?"
-        - if @participant.being_followed?
-          %b
-            Remove from active follow-up
-          %div
-            = form_for(@participant, :url => remove_from_active_followup_participant_path(@participant, :redirect_to => redirection)) do |f|
-              %p
-                = label_tag :enrollment_status_comment, "Reason for marking participant as not being actively followed:"
+                = label_tag :enrollment_status_comment, "Reason for un-enrolling:"
                 %br
                 = text_area_tag :enrollment_status_comment
-              %p
-                = f.submit "Mark Participant as not being actively followed", :confirm => "Are you certain?"
-
-      .psc
-        %b
-          Reconcile with PSC
-        %div
-          = form_for(@participant, :url => update_psc_participant_path(@participant)) do |f|
             %p
-              = f.submit "Reconcile with PSC", :confirm => "Are you certain?"
+              = f.submit msg, :confirm => "Are you certain you would like to #{msg}?"
+      - if @participant.being_followed?
+        %b
+          Remove from active follow-up
+        %div
+          = form_for(@participant, :url => remove_from_active_followup_participant_path(@participant, :redirect_to => redirection)) do |f|
+            %p
+              = label_tag :enrollment_status_comment, "Reason for marking Participant as not being actively followed:"
+              %br
+              = text_area_tag :enrollment_status_comment
+            %p
+              = f.submit "Mark Participant as not being actively followed", :confirm => "Are you certain?"
+  .page_section
+    .psc
+      %b
+        Reconcile Participant data with PSC
+      %div
+        = form_for(@participant, :url => update_psc_participant_path(@participant)) do |f|
+          %p
+            = f.submit "Reconcile Participant data with PSC", :confirm => "Are you certain?"

--- a/app/views/participants/_enrollment.html.haml
+++ b/app/views/participants/_enrollment.html.haml
@@ -17,26 +17,6 @@
 - if permit?(Role::SYSTEM_ADMINISTRATOR, Role::USER_ADMINISTRATOR, Role::STAFF_SUPERVISOR)
   .page_section
     .enrollment
-      - if false
-        %b
-          Enrollment
-        %div
-          - if @participant.enrolled?
-            - path = unenroll_participant_path(@participant, :redirect_to => redirection)
-            - msg = "Un-enroll Participant from Study"
-            - show_enrollment_status_comment = true
-          - else
-            - path = enroll_participant_path(@participant, :redirect_to => redirection)
-            - msg = "Enroll Participant in Study"
-            - show_enrollment_status_comment = false
-          = form_for(@participant, :url => path) do |f|
-            - if show_enrollment_status_comment
-              %p
-                = label_tag :enrollment_status_comment, "Reason for un-enrolling:"
-                %br
-                = text_area_tag :enrollment_status_comment
-            %p
-              = f.submit msg, :confirm => "Are you certain you would like to #{msg}?"
       - if @participant.being_followed?
         %b
           Remove from active follow-up

--- a/db/migrate/20130207172547_set_enroll_date_for_enrolled_participants.rb
+++ b/db/migrate/20130207172547_set_enroll_date_for_enrolled_participants.rb
@@ -1,0 +1,31 @@
+class SetEnrollDateForEnrolledParticipants < ActiveRecord::Migration
+  def change
+    sql = <<SQL
+select item_id, created_at from versions where object_changes like
+'%enroll_status_code:
+- -4
+- 1
+%'
+or object_changes like
+'%enroll_status_code:
+- 
+- 1
+%'
+or object_changes like
+'%enroll_status_code:
+- 2
+- 1
+%'
+SQL
+    rs = ActiveRecord::Base.connection.execute(sql)
+    Participant.transaction do
+      rs.each do |r|
+        if participant = Participant.find(r["item_id"])
+          dt = participant.participant_consents.where(:consent_given_code => 1).order(:created_at).first.try(:created_at)
+          dt = r["created_at"] if dt.blank?
+          participant.update_attribute(:enroll_date, dt.to_date)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130206202031) do
+ActiveRecord::Schema.define(:version => 20130207172547) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false

--- a/spec/controllers/participant_consents_controller_spec.rb
+++ b/spec/controllers/participant_consents_controller_spec.rb
@@ -11,6 +11,7 @@ describe ParticipantConsentsController do
       :consent_type_code               => 1,
       :consent_form_type_code          => 1,
       :consent_given_code              => 1,
+      :consent_date                    => Date.parse("2525-12-25"),
       :consent_language_code           => 1,
       :who_consented_code              => 2,
       :consent_translate_code          => 1,
@@ -22,7 +23,7 @@ describe ParticipantConsentsController do
   context "with an authenticated user" do
 
     let(:mother_person) { Factory(:person) }
-    let(:mother) { Factory(:participant, :enroll_status_code => nil) }
+    let(:mother) { Factory(:participant, :enroll_status_code => nil, :enroll_date => nil) }
     let(:event) { Factory(:event, :participant => mother) }
     let(:contact) { Factory(:contact) }
     let(:contact_link) { Factory(:contact_link, :event => event,
@@ -86,6 +87,13 @@ describe ParticipantConsentsController do
             post :create, :contact_link_id => contact_link.id,
                  :participant_consent => valid_attributes.merge({:participant_id => mother.id})
             Participant.find(mother.id).should be_enrolled
+          end
+
+          it "sets the enroll date on the participant to the consent date" do
+            mother.should_not be_enrolled
+            post :create, :contact_link_id => contact_link.id,
+                 :participant_consent => valid_attributes.merge({:participant_id => mother.id})
+            Participant.find(mother.id).enroll_date.should == valid_attributes[:consent_date]
           end
 
           describe "Informed Consent event" do


### PR DESCRIPTION
Cases was not setting the enroll date on Participant when
the Participant was being enrolled. This commit sets the enroll
date to the ParticipantConsent.consent_date (if available) or today.

We also include a migration to set the enroll date to the date that it
should have been set to - either the first consent where consent was
given or the date of the record where consent was determined.

Closes #3288
