### PR TITLE
Participant awareness of its provider type, Task #3308

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -67,6 +67,23 @@ class Participant < ActiveRecord::Base
   has_many :events
   has_many :response_sets, :inverse_of => :participant
 
+  has_many :providers, :through => :people
+  has_many :pbs_lists, :through => :providers
+
+  def self.has_self_link
+    where('participant_person_links.relationship_code' => 1)
+  end
+
+  def self.from_hospital_type_provider
+    hospitals = PbsList.is_hospital_type
+
+    has_self_link.joins(:pbs_lists).merge(PbsList.is_hospital_type)
+  end
+
+  def hospital?
+    self.class.from_hospital_type_provider.exists?(self)
+  end
+
   # validates_presence_of :person
 
   accepts_nested_attributes_for :ppg_details, :allow_destroy => true

--- a/app/models/pbs_list.rb
+++ b/app/models/pbs_list.rb
@@ -61,13 +61,10 @@ class PbsList < ActiveRecord::Base
   # -4 (Missing in Error)
 
   SEARCH_LOCATIONS = ["Original location", "Substitute location"]
+  HOSPITAL_VALUES = [4,5]
 
-  ##
-  # Returns true if the in_out_frame_code is one of the following:
-  # * 4 Hospital in final sampling frame; out of scope for screening
-  # * 5 Hospital not in final sampling frame; out of scope for screening
-  def hospital?
-    [4,5].include?(in_out_frame_code)
+  def self.is_hospital_type
+    where(:in_out_frame_code => HOSPITAL_VALUES)
   end
 
   def recruitment_started?
@@ -138,8 +135,8 @@ class PbsList < ActiveRecord::Base
   end
 
   ##
-  # Marks recruited if logistics are completed and 
-  # update the provider recruitment event 
+  # Marks recruited if logistics are completed and
+  # update the provider recruitment event
   # date with latest logistic completion date
   def update_recruitment_status!
     self.mark_in_progress! if provider.has_no_provider_recruited_contacts?
@@ -179,7 +176,7 @@ class PbsList < ActiveRecord::Base
   end
 
   ##
-  # Called at create/update/delete of contact 
+  # Called at create/update/delete of contact
   # or create/update/delete of logistics
   # updates the pbs_list dates appropriately
   # and opens recruitment on provider if necessary

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1799,4 +1799,68 @@ describe Participant do
       end
     end
   end
+
+  describe "determining if participants are from a hospital" do
+    before do
+
+    end
+
+    describe ".in_hospital" do
+      before do
+        @participant1 = Factory(:participant)
+        @participant2 = Factory(:participant)
+        @participant3 = Factory(:participant)
+        @person1      = Factory(:person)
+        @person2      = Factory(:person)
+        @person3      = Factory(:person)
+        Factory(:participant_person_link, :person => @person1, :participant => @participant1, :relationship_code => 1)
+        Factory(:participant_person_link, :person => @person2, :participant => @participant2, :relationship_code => 1)
+        Factory(:participant_person_link, :person => @person3, :participant => @participant3, :relationship_code => 1)
+        provider1    = Factory(:provider)
+        provider2    = Factory(:provider)
+        provider3    = Factory(:provider)
+        @person1.providers << provider1
+        @person2.providers << provider2
+        @person3.providers << provider3
+        pbs_list1   = Factory(:pbs_list, :in_out_frame_code => 4)
+        pbs_list2   = Factory(:pbs_list, :in_out_frame_code => 4)
+        pbs_list3   = Factory(:pbs_list, :in_out_frame_code => 1)
+        provider1.pbs_list = pbs_list1
+        provider2.pbs_list = pbs_list2
+        provider3.pbs_list = pbs_list3
+      end
+
+      it "returns set of participants that are from a hospital" do
+        Participant.from_hospital_type_provider.should == [@participant1, @participant2]
+
+      end
+
+      it "does not include in a returned set participants that are not from a hospital" do
+        Participant.from_hospital_type_provider.should_not include(@participant3)
+      end
+    end
+
+    describe "#hospital?" do
+      before do
+        @participant = Factory(:participant)
+        person      = Factory(:person)
+        Factory(:participant_person_link, :person => person, :participant => @participant, :relationship_code => 1)
+        @provider    = Factory(:provider)
+        person.providers << @provider
+      end
+
+      it "returns true for participants that are from a hospital" do
+        hospital_pbs_list       = Factory(:pbs_list, :in_out_frame_code => 4)
+        @provider.pbs_list = hospital_pbs_list
+        @participant.should be_hospital
+      end
+
+      it "returns false for participants that are not from a hospital" do
+        not_hospital_pbs_list   = Factory(:pbs_list, :in_out_frame_code => 1)
+        @provider.pbs_list = not_hospital_pbs_list
+        @participant.should_not be_hospital
+      end
+    end
+
+  end
 end

--- a/spec/models/pbs_list_spec.rb
+++ b/spec/models/pbs_list_spec.rb
@@ -157,7 +157,7 @@ describe PbsList do
     end
 
     it "returns last contact date from the provider recruitment contacts" do
-      Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person), 
+      Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person),
         :contact => Factory(:contact, :contact_date_date => Date.new(2012, 05, 11)), :provider => @provider)
       @pbs_list.earliest_provider_recruitment_contact_date.should == Date.new(2012, 05, 11)
     end
@@ -190,7 +190,7 @@ describe PbsList do
 
       it "lastest provider contact date" do
         @pbs_list.pr_recruitment_start_date.should be_nil
-        Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person), 
+        Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person),
                 :contact => Factory(:contact, :contact_date_date => Date.new(2012, 05, 11)), :provider => @provider)
         @pbs_list.update_recruitment_dates!
         @pbs_list.pr_recruitment_start_date.should == Date.new(2012, 05, 11)
@@ -206,7 +206,7 @@ describe PbsList do
 
       it "earliest successful provider recruitment contact date" do
         @pbs_list.pr_recruitment_start_date.should be_nil
-        Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person), 
+        Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person),
                 :contact => Factory(:contact, :contact_disposition => 70, :contact_date_date => Date.new(2012, 05, 12)), :provider => @provider)
         @pbs_list.update_recruitment_dates!
         @pbs_list.pr_cooperation_date.should == Date.new(2012, 05, 12)
@@ -254,11 +254,27 @@ describe PbsList do
     end
 
     it "updates the provider event end date to the latest provider logistic completion date if such event exist" do
-      Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person), 
+      Factory(:contact_link, :event => Factory(:event, :event_type_code => 22), :person => Factory(:person),
         :contact => Factory(:contact, :contact_disposition => 70, :contact_date_date => Date.new(2012, 05, 12)), :provider => @provider)
       Factory(:provider_logistic, :completion_date => Date.new(2012, 05, 17), :provider => @provider)
       @pbs_list.update_recruitment_status!
       @pbs_list.provider.provider_recruitment_event.event_end_date.should == Date.new(2012, 05, 17);
+    end
+  end
+
+  describe ".is_hospital_type" do
+    before do
+      @hospital_pbs_list1 = Factory(:pbs_list, :in_out_frame_code => 4)
+      @hospital_pbs_list2 = Factory(:pbs_list, :in_out_frame_code => 4)
+      @non_hospital_pbs_list = Factory(:pbs_list, :in_out_frame_code => 1)
+    end
+
+    it "returns pbs_lists that have hospital sources" do
+      PbsList.is_hospital_type.should == [@hospital_pbs_list1, @hospital_pbs_list2]
+    end
+
+    it "does not return pbs_lists that do not have hospital sources" do
+      PbsList.is_hospital_type.should_not include(@non_hospital_pbs_list1)
     end
   end
 


### PR DESCRIPTION
### Summary

Adding the capability for a participant to query whether its (any) associated provider is from a hospital source, as indicated on its associated `PBS list` `in_out_frame_code`, and a class method for `Participant` to get all hospital-sourced participants.
#### Background

This commit started with this [gist](https://gist.github.com/greenone1975/4757173) The extensive method chain spanning several models jumped out as a definite code smell, especially when I started writing tests in each model, with the set-up growing obscenely with each chain link. 

I sought ways to alleviate this situation, drawing inspiration from this [post](http://devblog.avdi.org/2011/07/05/demeter-its-not-just-a-good-idea-its-the-law/), which was ultimately unsatisfying - drawing on the suggestion to use delegation seemed to just cover-up the structural coupling.

I discussed this with David and the resulting commit is mostly his work, with my tests. I really like how he just acknowledged in `Participant` the associations that are already in existence, so we could just query the `PbsList` directly. 

Still not certain this solves the smell of reaching across models, but it's a way better solution than the couple I had implemented before. 
