### PR TITLE
Bugs 3319 and 3323

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,18 +52,18 @@ class ApplicationController < ActionController::Base
     ##
     # Disposition group based on specific events
     def set_disposition_group_for_event
-      case @event.event_type.to_s
-      when "Pregnancy Screener"
+      case @event.event_type_code
+      when Event.pregnancy_screener_code
         @disposition_group = DispositionMapper::PREGNANCY_SCREENER_EVENT
-      when "Informed Consent"
+      when Event.informed_consent_code
         @disposition_group = disposition_group_for_study_arm(@event)
-      when "Low Intensity Data Collection"
+      when Event.low_intensity_data_collection_code
         @disposition_group = disposition_group_for_study_arm(@event)
-      when "Low to High Conversion"
+      when Event.low_to_high_conversion_code
         @disposition_group = disposition_group_for_study_arm(@event)
-      when "Provider-Based Recruitment"
+      when Event.provider_recruitment_code
         @disposition_group = DispositionMapper::PROVIDER_RECRUITMENT_EVENT
-      when "PBS Participant Eligibility Screening"
+      when Event.pbs_eligibility_screener_code
         @disposition_group = DispositionMapper::PBS_ELIGIBILITY_EVENT
       else
         set_disposition_group_for_contact_link

--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -162,7 +162,7 @@ class ContactLinksController < ApplicationController
     event        = @contact_link.event
     if event && participant
       activity_plan        = psc.build_activity_plan(participant)
-      occurred_activities  = activity_plan.occurred_activities_for_event(event.to_s)
+      occurred_activities  = activity_plan.occurred_activities_for_event(event)
       saq_activity         = occurred_activities.find_all{|activity| activity.activity_name =~ /SAQ$/}.first
       if saq_activity
         survey = Survey.most_recent_for_access_code(Survey.to_normalized_string(saq_activity.instrument))

--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -86,9 +86,9 @@ class ContactLinksController < ApplicationController
     @event        = @contact_link.event
     if @participant && @event
       @activity_plan        = psc.build_activity_plan(@participant)
-      @activities_for_event = @activity_plan.activities_for_event(@event.to_s)
+      @activities_for_event = @activity_plan.activities_for_event(@event)
       @current_activity     = @activities_for_event.detect { |a| a.scheduled? }
-      @scheduled_activities = @activity_plan.scheduled_activities_for_event(@event.to_s)
+      @scheduled_activities = @activity_plan.scheduled_activities_for_event(@event)
       @saq_activities       = @activities_for_event.find_all { |activity| activity.activity_name =~ /SAQ$/ }
     end
   end
@@ -106,8 +106,8 @@ class ContactLinksController < ApplicationController
     @activity_plan = psc.build_activity_plan(@participant)
 
     if @participant && @event
-      @activities_for_event = @activity_plan.activities_for_event(@event.to_s)
-      @scheduled_activities = @activity_plan.scheduled_activities_for_event(@event.to_s)
+      @activities_for_event = @activity_plan.activities_for_event(@event)
+      @scheduled_activities = @activity_plan.scheduled_activities_for_event(@event)
     end
     @current_activity = @activity_plan.current_scheduled_activity(@event.to_s, @response_set)
   end

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -15,11 +15,10 @@ class SurveyorController < ApplicationController
 
     contact_link = @response_set.instrument.contact_link
     activity = @activity_plan.current_scheduled_activity(contact_link.event.to_s, @response_set)
-    event_type = @event.event_type.to_s
 
-    if @activity_plan.final_survey_part?(@response_set, event_type) || params[:breakoff] || activity.instruments.empty?
+    if @activity_plan.final_survey_part?(@response_set, @event) || params[:breakoff] || activity.instruments.empty?
       # mark all scheduled activities associated with survey as occurred
-      @activity_plan.scheduled_activities_for_survey(@response_set.survey.title, event_type).each do |a|
+      @activity_plan.scheduled_activities_for_survey(@response_set.survey.title, @event).each do |a|
         psc.update_activity_state(a.activity_id, @participant, Psc::ScheduledActivity::OCCURRED)
       end
 
@@ -61,7 +60,7 @@ class SurveyorController < ApplicationController
     @activities_for_event = []
     if @participant
       @activity_plan        = psc.build_activity_plan(@participant)
-      @activities_for_event = @activity_plan.scheduled_activities_for_event(@event.to_s)
+      @activities_for_event = @activity_plan.scheduled_activities_for_event(@event)
     end
   end
 

--- a/app/helpers/surveyor_helper.rb
+++ b/app/helpers/surveyor_helper.rb
@@ -20,7 +20,7 @@ module SurveyorHelper
     # use copy in memory instead of making extra db calls
     if @sections.last == @section
       txt = t('surveyor.next_section').html_safe
-      if @activity_plan.final_survey_part?(@response_set, @event.event_type.to_s)
+      if @activity_plan.final_survey_part?(@response_set, @event)
         txt = t('surveyor.click_here_to_finish').html_safe
       end
       submit_tag(txt, :name => "finish")

--- a/app/models/instrument_plan.rb
+++ b/app/models/instrument_plan.rb
@@ -119,24 +119,12 @@ class InstrumentPlan
   end
 
   ##
-  # Returns all the instruments from the
-  # @scheduled_activities attribute
-  #
-  # @param event [String] - the event name
-  # @return [Array<String>]
-  def instruments(event = nil)
-    scheduled_activities_for_event_name(event).sort_by do |a|
-      [a.ideal_date, a.order.to_s]
-    end.map(&:instrument).compact
-  end
-
-  ##
   # Returns all ScheduledActivities for the given event
   #
   # @param [Event] - the event
   # @return [Array<ScheduledActivity>]
-  def scheduled_activities_for_event(event = nil)
-    event.nil? ? @scheduled_activities : @scheduled_activities.select{ |sa| event.matches_activity(sa) }
+  def scheduled_activities_for_event(event)
+    @scheduled_activities.select{ |sa| event.matches_activity(sa) }
   end
 
   ##
@@ -145,9 +133,9 @@ class InstrumentPlan
   #
   # @param [String] - the event name
   # @return [Array<ScheduledActivity>]
-  def scheduled_activities_for_event_name(event = nil)
-    event = event.downcase.gsub(" ", "_") if event
-    event.nil? ? @scheduled_activities : @scheduled_activities.select{ |sa| sa.event == event }
+  def scheduled_activities_for_event_name(event)
+    event = event.to_s.downcase.gsub(" ", "_")
+    @scheduled_activities.select{ |sa| sa.event == event }
   end
 
   ##
@@ -155,7 +143,7 @@ class InstrumentPlan
   #
   # @param [Event] - the event
   # @return [Array<ScheduledActivity>]
-  def activities_for_event(event = nil)
+  def activities_for_event(event)
     event.nil? ? @all_activities : @all_activities.select{ |sa| event.matches_activity(sa) }
   end
 
@@ -164,19 +152,18 @@ class InstrumentPlan
   #
   # @param [String] - the event
   # @return [Array<ScheduledActivity>]
-  def activities_for_event_name(event = nil)
-    event = event.downcase.gsub(" ", "_") if event
-    event.nil? ? @all_activities : @all_activities.select{ |sa| sa.event == event }
+  def activities_for_event_name(event)
+    event = event.to_s.downcase.gsub(" ", "_")
+    @all_activities.select{ |sa| sa.event == event }
   end
 
   ##
   # Returns all OccurredActivities for the given event
   #
-  # @param [String] - the event
+  # @param [Event]
   # @return [Array<ScheduledActivity>]
-  def occurred_activities_for_event(event = nil)
-    event = event.downcase.gsub(" ", "_") if event
-    event.nil? ? @occurred_activities : @occurred_activities.select{ |oa| oa.event == event }
+  def occurred_activities_for_event(event)
+    @occurred_activities.select{ |oa| event.matches_activity(oa) }
   end
 
   ##
@@ -272,7 +259,7 @@ class InstrumentPlan
   # @param survey_title [String]
   # @param [Event] - the event, defaults to nil
   # @return [Array<ScheduledActivities>]
-  def scheduled_activities_for_survey(survey_title, event = nil)
+  def scheduled_activities_for_survey(survey_title, event)
     result = []
     if a = scheduled_activity_for_survey(survey_title, event)
       result = scheduled_activities_for_event(event).select do |sa|
@@ -289,7 +276,7 @@ class InstrumentPlan
   # @param survey_title [String]
   # @param [Event] - the event, defaults to nil
   # @return [ScheduledActivity]
-  def scheduled_activity_for_survey(survey_title, event = nil)
+  def scheduled_activity_for_survey(survey_title, event)
     survey_title = survey_title.to_s.downcase
     scheduled_activities_for_event(event).select { |sa| sa.instrument == survey_title }.first
   end

--- a/app/views/participants/_activities.html.haml
+++ b/app/views/participants/_activities.html.haml
@@ -8,7 +8,7 @@
   - else
     - pending_event = @participant.pending_events.first
     - activities_for_event = []
-    - activities_for_event = @participant_activity_plan.scheduled_activities_for_event(pending_event.event_type.to_s) if pending_event
+    - activities_for_event = @participant_activity_plan.scheduled_activities_for_event(pending_event) if pending_event
     = render "/people/schedule_or_perform_event", :participant => @participant, :person => @person, :pending_event => pending_event, :activities_for_event => activities_for_event
     .schedule
       - if @participant_activity_plan && pending_event

--- a/spec/controllers/contact_links_controller_spec.rb
+++ b/spec/controllers/contact_links_controller_spec.rb
@@ -9,7 +9,7 @@ describe ContactLinksController do
       @participant = Factory(:participant)
       @person = Factory(:person)
       @person_participant_link = Factory(:participant_person_link, :person => @person, :participant => @participant)
-      @event = Factory(:event, :participant => @participant,
+      @event = Factory(:event, :participant => @participant, :event_start_date => Date.parse('2010-12-01'),
                        :event_end_date => nil, :event_end_time => nil,
                        :event_type => NcsCode.find_event_by_lbl("pregnancy_visit_1"))
       @contact_link = Factory(:contact_link, :person => @person, :event => @event)

--- a/spec/controllers/surveyor_controller_spec.rb
+++ b/spec/controllers/surveyor_controller_spec.rb
@@ -13,7 +13,7 @@ describe SurveyorController do
   describe "GET show" do
 
     before(:each) do
-      @instrument  = Factory(:instrument, :event => Factory(:event))
+      @instrument  = Factory(:instrument, :event => Factory(:event, :event_start_date => Date.parse('2011-01-01')))
       @survey = Factory(:survey,
         :title => "xyz", :access_code => "xyz", :sections => [Factory(:survey_section)])
       @response_set = Factory(:response_set, :access_code => "pdq",
@@ -66,7 +66,7 @@ describe SurveyorController do
       person_participant_link_for_mother = Factory(:participant_person_link, :participant => mother_participant, :person => mother_person)
       child_participant = Factory(:participant, :p_type_code => 6)
       person_participant_link_for_child = Factory(:participant_person_link, :participant => child_participant, :person => mother_person, :relationship_code => 2)
-      
+
       @response_set.participant = child_participant
       @response_set.save!
 

--- a/spec/models/instrument_plan_spec.rb
+++ b/spec/models/instrument_plan_spec.rb
@@ -29,49 +29,19 @@ describe InstrumentPlan do
       end
 
       describe ".occurred_activities_for_event" do
+        let(:event) { Factory(:event, :event_type_code => Event.pregnancy_visit_1_code, :event_start_date => Date.parse('2010-12-01'))}
         it "returns all the occurred_activities for the particular event if event is specified" do
-          occurred_activities = InstrumentPlan.from_schedule(participant_plan).occurred_activities_for_event("pregnancy_visit_1")
+          occurred_activities = InstrumentPlan.from_schedule(participant_plan).occurred_activities_for_event(event)
           occurred_activities.size.should  == 2
         end
-
-        it "returns all the occurred_activities for the participant schedule if event is not specified" do
-          occurred_activities = InstrumentPlan.from_schedule(participant_plan).occurred_activities_for_event()
-          occurred_activities.size.should  == 3
-        end
-      end
-
-      describe ".instruments" do
-
-        let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
-
-        it "knows all of the instruments for the participant" do
-          plan.instruments.size.should == 5
-        end
-
-        it "orders the instruments by event and order label" do
-          [
-            'ins_que_birth_int_ehpbhi_p2_v2.0',
-            'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name',
-            'ins_que_3mmother_int_ehpbhi_p2_v1.1',
-            'ins_que_6mmother_int_ehpbhi_p2_v1.1'
-          ].each_with_index do |instrument, index|
-            plan.instruments[index].should == instrument
-          end
-        end
-
-        it "takes a String representing event as an optional parameter" do
-          plan.instruments('birth').size.should == 2
-          plan.instruments('3m').size.should == 1
-        end
-
       end
 
       describe ".scheduled_activities_for_survey" do
-
+        let(:event) { Factory(:event, :event_type_code => Event.birth_code, :event_start_date => Date.parse('2011-01-01'))}
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "returns all scheduled_activity parts for a given survey" do
-          parts = plan.scheduled_activities_for_survey('ins_que_birth_int_ehpbhi_p2_v2.0_baby_name')
+          parts = plan.scheduled_activities_for_survey('ins_que_birth_int_ehpbhi_p2_v2.0_baby_name', event)
           parts.size.should == 2
           parts.first.instrument.should == 'ins_que_birth_int_ehpbhi_p2_v2.0'
           parts.last.instrument.should == 'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name'
@@ -102,10 +72,6 @@ describe InstrumentPlan do
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
         let(:birth_event_start_date) { Date.parse('2011-01-01') }
-
-        it "knows all the instruments for the mother and child" do
-          plan.instruments('6m').size.should == 2
-        end
 
         it "knows all the scheduled activities for the mother and child" do
           plan.activities_for_event_name('6m').size.should == 2
@@ -213,10 +179,6 @@ describe InstrumentPlan do
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
         let(:birth_event_start_date) { Date.parse('2011-01-01') }
-
-        it "knows all the instruments for the mother and child" do
-          plan.instruments('6m').size.should == 3
-        end
 
         it "knows all the scheduled activities for the mother and child" do
           plan.scheduled_activities_for_event_name('6m').size.should == 3
@@ -389,10 +351,6 @@ describe InstrumentPlan do
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan_xp2) }
 
-        it "knows all the instruments for the mother and child" do
-          plan.instruments('birth').size.should == 3
-        end
-
         it "knows all the scheduled activities for the mother and child" do
           plan.scheduled_activities_for_event_name('birth').size.should == 4
         end
@@ -439,10 +397,6 @@ describe InstrumentPlan do
         end
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan_xp2) }
-
-        it "knows all the instruments for the mother and child" do
-          plan.instruments('birth').size.should == 5
-        end
 
         it "knows all the scheduled activities for the mother and child" do
           plan.activities_for_event_name('birth').size.should == 6
@@ -499,27 +453,33 @@ describe InstrumentPlan do
     end
 
     describe "#scheduled_activity_for_survey" do
-
-      it "returns first scheduled activity matching title if called without a scoping parameter" do
-        activity = plan.scheduled_activity_for_survey(@survey_title)
-        activity.event.should == "informed_consent"
+      describe "for the informed consent event" do
+        it "returns first scheduled activity matching title" do
+          activity = plan.scheduled_activity_for_survey(@survey_title, informed_consent_event)
+          activity.event.should == "informed_consent"
+        end
       end
 
-      it "returns first scheduled activity associated with a particular event if called with a scoping parameter" do
-        activity = plan.scheduled_activity_for_survey(@survey_title, birth_event)
-        activity.event.should == "birth"
+      describe "for the birth event" do
+        it "returns first scheduled activity matching title" do
+          activity = plan.scheduled_activity_for_survey(@survey_title, birth_event)
+          activity.event.should == "birth"
+        end
       end
     end
 
     describe "#scheduled_activities_for_survey" do
 
-      it "returns all scheduled_activities without event scoping parameter" do
-        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one').count.should == 4
+      describe "for the informed consent event" do
+        it "returns all scheduled_activities for the given survey title and event" do
+          plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', informed_consent_event).count.should == 2
+        end
       end
 
-      it "returns only those activites associated with their respective events if a scoping parameter is given" do
-        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', informed_consent_event).count.should == 2
-        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', birth_event).count.should == 2
+      describe "for the birth event" do
+        it "returns all scheduled_activities for the given survey title and event" do
+          plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', birth_event).count.should == 2
+        end
       end
     end
 

--- a/spec/models/instrument_plan_spec.rb
+++ b/spec/models/instrument_plan_spec.rb
@@ -71,7 +71,6 @@ describe InstrumentPlan do
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
 
         it "returns all scheduled_activity parts for a given survey" do
-
           parts = plan.scheduled_activities_for_survey('ins_que_birth_int_ehpbhi_p2_v2.0_baby_name')
           parts.size.should == 2
           parts.first.instrument.should == 'ins_que_birth_int_ehpbhi_p2_v2.0'
@@ -102,17 +101,18 @@ describe InstrumentPlan do
         end
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
+        let(:birth_event_start_date) { Date.parse('2011-01-01') }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('6m').size.should == 2
         end
 
         it "knows all the scheduled activities for the mother and child" do
-          plan.activities_for_event('6m').size.should == 2
+          plan.activities_for_event_name('6m').size.should == 2
         end
 
         it "knows the participant associated with the appropriate instrument" do
-          activities = plan.activities_for_event('6m')
+          activities = plan.activities_for_event_name('6m')
           mother_activity = activities.first
           mother_activity.instrument.should == 'ins_que_6mmother_int_ehpbhi_p2_v1.1'
           mother_activity.participant.should == mother
@@ -125,7 +125,7 @@ describe InstrumentPlan do
         describe ".final_survey_part?" do
 
           let(:birth_event) { NcsCode.find_event_by_lbl('birth') }
-          let(:event) { Factory(:event, :event_type => birth_event) }
+          let(:event) { Factory(:event, :event_type => birth_event, :event_start_date => birth_event_start_date) }
           let(:instrument) { Factory(:instrument, :event => event) }
           let(:survey1) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0') }
           let!(:response_set1) { Factory(:response_set, :survey => survey1, :instrument => instrument,
@@ -133,7 +133,7 @@ describe InstrumentPlan do
           let(:survey2) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name') }
 
           it "returns false if there is a next instrument" do
-            plan.final_survey_part?(response_set1, 'birth').should be_false
+            plan.final_survey_part?(response_set1, event).should be_false
           end
 
           it "returns true if there is no next instrument and
@@ -142,7 +142,7 @@ describe InstrumentPlan do
             rs2 = Factory(:response_set, :survey => survey2, :instrument => instrument,
                                          :person => mp, :participant => child)
             instrument.response_sets.reload
-            plan.final_survey_part?(rs2, 'birth').should be_true
+            plan.final_survey_part?(rs2, event).should be_true
           end
 
         end
@@ -150,7 +150,7 @@ describe InstrumentPlan do
         describe ".current_scheduled_activity" do
 
           let(:birth_event) { NcsCode.find_event_by_lbl('birth') }
-          let(:event) { Factory(:event, :event_type => birth_event) }
+          let(:event) { Factory(:event, :event_type => birth_event, :event_start_date => birth_event_start_date) }
           let(:instrument) { Factory(:instrument, :event => event) }
           let(:survey1) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0') }
           let(:survey2) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name') }
@@ -212,17 +212,18 @@ describe InstrumentPlan do
         end
 
         let(:plan) { InstrumentPlan.from_schedule(participant_plan) }
+        let(:birth_event_start_date) { Date.parse('2011-01-01') }
 
         it "knows all the instruments for the mother and child" do
           plan.instruments('6m').size.should == 3
         end
 
         it "knows all the scheduled activities for the mother and child" do
-          plan.scheduled_activities_for_event('6m').size.should == 3
+          plan.scheduled_activities_for_event_name('6m').size.should == 3
         end
 
         it "knows the participant associated with the appropriate instrument" do
-          activities = plan.scheduled_activities_for_event('6m')
+          activities = plan.scheduled_activities_for_event_name('6m')
           mother_activity = activities[0]
           mother_activity.instrument.should == 'ins_que_6mmother_int_ehpbhi_p2_v1.1'
           mother_activity.participant.should == mother
@@ -240,7 +241,7 @@ describe InstrumentPlan do
         describe ".final_survey_part?" do
 
           let(:birth_event) { NcsCode.find_event_by_lbl('birth') }
-          let(:event) { Factory(:event, :event_type => birth_event) }
+          let(:event) { Factory(:event, :event_type => birth_event, :event_start_date => birth_event_start_date) }
           let(:instrument) { Factory(:instrument, :event => event) }
           let(:survey1) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0') }
           let!(:response_set1) { Factory(:response_set, :survey => survey1, :instrument => instrument,
@@ -250,13 +251,13 @@ describe InstrumentPlan do
                                                         :person => mp, :participant => child1) }
 
           it "returns false if there is a next instrument" do
-            plan.final_survey_part?(response_set1, 'birth').should be_false
+            plan.final_survey_part?(response_set1, event).should be_false
           end
 
           it "returns false if there is no next instrument and
               there are NOT as many response_sets as there are scheduled_activities
               for the survey" do
-            plan.final_survey_part?(response_set2, 'birth').should be_false
+            plan.final_survey_part?(response_set2, event).should be_false
           end
 
           it "returns true if there is no next instrument and
@@ -265,7 +266,7 @@ describe InstrumentPlan do
             rs = Factory(:response_set, :survey => survey2, :instrument => instrument,
                                         :person => mp, :participant => child2)
             instrument.response_sets.reload
-            plan.final_survey_part?(rs, 'birth').should be_true
+            plan.final_survey_part?(rs, event).should be_true
           end
 
         end
@@ -273,7 +274,7 @@ describe InstrumentPlan do
         describe ".current_scheduled_activity" do
 
           let(:birth_event) { NcsCode.find_event_by_lbl('birth') }
-          let(:event) { Factory(:event, :event_type => birth_event) }
+          let(:event) { Factory(:event, :event_type => birth_event, :event_start_date => birth_event_start_date) }
           let(:instrument) { Factory(:instrument, :event => event) }
           let(:survey1) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0') }
           let(:survey2) { Factory(:survey, :title => 'ins_que_birth_int_ehpbhi_p2_v2.0_baby_name') }
@@ -286,7 +287,7 @@ describe InstrumentPlan do
           it "returns the first scheduled_activity that does not have a
               response_set associated with an instrument in the instrument_plan" do
 
-            plan.scheduled_activities_for_event('birth').size.should == 4
+            plan.scheduled_activities_for_event(event).size.should == 4
 
             csa = plan.current_scheduled_activity('birth')
             csa.survey_title.should == 'ins_que_birth_int_ehpbhi_p2_v2.0'
@@ -393,11 +394,11 @@ describe InstrumentPlan do
         end
 
         it "knows all the scheduled activities for the mother and child" do
-          plan.scheduled_activities_for_event('birth').size.should == 4
+          plan.scheduled_activities_for_event_name('birth').size.should == 4
         end
 
         it "knows the participant associated with the appropriate instrument" do
-          activities = plan.scheduled_activities_for_event('birth')
+          activities = plan.scheduled_activities_for_event_name('birth')
 
           mother_activity = activities[0]
           mother_activity.instrument.should == 'ins_que_birth_int_ehpbhi_p2_v2.0'
@@ -444,11 +445,11 @@ describe InstrumentPlan do
         end
 
         it "knows all the scheduled activities for the mother and child" do
-          plan.activities_for_event('birth').size.should == 6
+          plan.activities_for_event_name('birth').size.should == 6
         end
 
         it "knows the participant associated with the appropriate instrument" do
-          activities = plan.activities_for_event('birth')
+          activities = plan.activities_for_event_name('birth')
 
           mother_activity = activities[0]
           mother_activity.instrument.should == 'ins_que_birth_int_ehpbhi_p2_v2.0'
@@ -484,6 +485,12 @@ describe InstrumentPlan do
   context "finding scheduled activities" do
 
     let(:plan) { InstrumentPlan.from_schedule(find_scheduled_activity_plan) }
+    let(:birth_event_start_date) { Date.parse('2011-07-01') }
+    let(:ic_event_start_date) { Date.parse('2010-12-01') }
+    let(:informed_consent_event_type) { NcsCode.find_event_by_lbl('informed_consent') }
+    let(:birth_event_type)            { NcsCode.find_event_by_lbl('birth') }
+    let(:birth_event)                 { Factory(:event, :event_type => birth_event_type, :event_start_date => birth_event_start_date) }
+    let(:informed_consent_event)      { Factory(:event, :event_type => informed_consent_event_type, :event_start_date => ic_event_start_date) }
 
     before do
       NcsNavigatorCore.mdes.stub!(:version).and_return("3.0")
@@ -499,7 +506,7 @@ describe InstrumentPlan do
       end
 
       it "returns first scheduled activity associated with a particular event if called with a scoping parameter" do
-        activity = plan.scheduled_activity_for_survey(@survey_title, @event)
+        activity = plan.scheduled_activity_for_survey(@survey_title, birth_event)
         activity.event.should == "birth"
       end
     end
@@ -511,16 +518,12 @@ describe InstrumentPlan do
       end
 
       it "returns only those activites associated with their respective events if a scoping parameter is given" do
-        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', 'informed consent').count.should == 2
-        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', 'birth').count.should == 2
+        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', informed_consent_event).count.should == 2
+        plan.scheduled_activities_for_survey('ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one', birth_event).count.should == 2
       end
     end
 
     describe "#final_survey_part?" do
-      let(:informed_consent_event_type) { NcsCode.find_event_by_lbl('informed_consent') }
-      let(:birth_event_type)            { NcsCode.find_event_by_lbl('birth') }
-      let(:birth_event)                 { Factory(:event, :event_type => birth_event_type) }
-      let(:informed_consent_event)      { Factory(:event, :event_type => informed_consent_event_type) }
       let(:birth_instrument)            { Factory(:instrument, :event => birth_event) }
       let(:informed_consent_instrument) { Factory(:instrument, :event => informed_consent_event) }
       let(:part_verif_part_1_in_birth_event_survey)             { Factory(:survey, :title => 'ins_que_participantverif_dci_ehpbhilipbs_m3.0_v1.0_part_one') }
@@ -531,12 +534,12 @@ describe InstrumentPlan do
       let!(:informed_consent_response_set1) { Factory(:response_set, :survey => part_verif_part_1_in_informed_consent_event_survey, :instrument => informed_consent_instrument) }
 
       it "returns false if, with a scoping event parameter, there a more scheduled activities for that event than there are response sets" do
-        plan.final_survey_part?(birth_response_set1, 'birth').should be_false
+        plan.final_survey_part?(birth_response_set1, birth_event).should be_false
       end
 
       it "returns true if, with an appropriate scoping event parameter, there are equal or greater response sets present than there are scheduled activities for a given event" do
         birth_response_set2 = Factory(:response_set, :survey => part_verif_part_2_in_birth_event_survey, :instrument => birth_instrument)
-        plan.final_survey_part?(birth_response_set2, 'birth').should be_true
+        plan.final_survey_part?(birth_response_set2, birth_event).should be_true
       end
 
     end


### PR DESCRIPTION
This pull request addresses two bugs that are hindering current users from entering data.

The first commit for bug 3319 scopes scheduled activities for the participant to the event so that if the participant is scheduled for more than one event of the same type only the current event (matching event type and start date) will have activities.

The second commit replaces a case statement based on NcsCode display type with the local code.
