### PR TITLE
Validate event disposition #3290

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -836,15 +836,12 @@ class Event < ActiveRecord::Base
   private :associated_informed_consent_event
 
   ##
-  # Validates that the event_disposition value exists in the
-  # event_disposition_category_code.
+  # If the event_disposition and event_disposition_category_code attributes
+  # are set we validate that event_disposition value exists for that category
+  # using the disposition_code composition.
   def disposition_code_is_in_disposition_category
-    if self.event_disposition && self.event_disposition_category_code
-      category = DispositionMapper.for_event_disposition_category_code(self.event_disposition_category_code)
-      code = NcsNavigatorCore.mdes.disposition_codes.detect { |code| code.event == category && code.interim_code.to_i == self.event_disposition }
-      if code.nil?
-        errors.add(:event_disposition, "does not exist in the #{category} Disposition Category.")
-      end
+    if self.event_disposition && self.event_disposition_category_code && !self.disposition_code
+      errors.add(:event_disposition, "does not exist in the disposition category.")
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1019,7 +1019,7 @@ describe Event do
       expect do
         invalid.save!
       end.to raise_error(ActiveRecord::RecordInvalid,
-        "Validation failed: Event disposition does not exist in the General Study Visit Event Disposition Category.")
+        "Validation failed: Event disposition does not exist in the disposition category.")
     end
 
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1001,4 +1001,26 @@ describe Event do
       updated_ic_event.event_end_time.should == midnight
     end
   end
+
+  describe "#disposition_code_is_in_disposition_category" do
+
+    let(:valid)   { Factory.build(:event, :event_disposition_category_code => 3, :event_disposition => 60) }
+    let(:invalid) { Factory.build(:event, :event_disposition_category_code => 3, :event_disposition => 65) }
+
+    it "determines if a record is invalid" do
+      valid.should be_valid
+    end
+
+    it "determines if a record is valid" do
+      invalid.should_not be_valid
+    end
+
+    it "creates a descriptive error" do
+      expect do
+        invalid.save!
+      end.to raise_error(ActiveRecord::RecordInvalid,
+        "Validation failed: Event disposition does not exist in the General Study Visit Event Disposition Category.")
+    end
+
+  end
 end


### PR DESCRIPTION
This commit validates that the event disposition value on the event
is a valid value within the chosen event disposition category.

This does not mean that there is any sort of semantic check of the
value if the disposition category changes or anything of the sort, this
is just a check that the value exists within the disposition category.

Closes #3290
