### PR TITLE
Persist instrument contexts

### DIFF
--- a/app/contexts/create_instrument_context.rb
+++ b/app/contexts/create_instrument_context.rb
@@ -1,0 +1,56 @@
+class CreateInstrumentContext
+  attr_reader :person
+  attr_reader :response_set
+  attr_reader :user
+
+  def initialize(response_set, user)
+    @response_set = response_set
+    @user = user
+  end
+
+  def self.run(response_set)
+    new(response_set).create
+  end
+
+  def create
+    return if response_set.instrument_context
+
+    load_data
+
+    InstrumentContext.transaction do
+      ctx = response_set.create_instrument_context
+      populate(ctx)
+      ctx.save
+    end
+  end
+
+  def load_data
+    if response_set.user_id
+      @person = Person.with_contact_data.find(response_set.user_id)
+    end
+  end
+
+  def populate(ctx)
+    ctx.set 'interviewer_name', interviewer_name
+    ctx.set 'p_full_name', p_full_name
+    ctx.set 'p_dob', p_dob
+  end
+
+  def interviewer_name
+    user.full_name || '[INTERVIEWER NAME]'
+  end
+
+  def p_full_name
+    fn = person.try(:full_name)
+
+    if fn.blank?
+      '[UNKNOWN]'
+    else
+      fn
+    end
+  end
+
+  def p_dob
+    person.try(:person_dob) || '[UNKNOWN]'
+  end
+end

--- a/app/models/instrument_context.rb
+++ b/app/models/instrument_context.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+# Schema version: 20130212215454
+#
+# Table name: instrument_contexts
+#
+#  created_at      :datetime
+#  id              :integer          not null, primary key
+#  response_set_id :integer          not null
+#  updated_at      :datetime
+#
+
+class InstrumentContext < ActiveRecord::Base
+  belongs_to :response_set, :inverse_of => :instrument_context
+  has_many :elements, :class_name => 'InstrumentContextElement'
+
+  default_scope includes(:elements)
+
+  validates_presence_of :response_set_id
+end

--- a/app/models/instrument_context.rb
+++ b/app/models/instrument_context.rb
@@ -16,4 +16,18 @@ class InstrumentContext < ActiveRecord::Base
   default_scope includes(:elements)
 
   validates_presence_of :response_set_id
+
+  def set(key, value)
+    elements.build(:key => key, :value => value)
+  end
+
+  def to_mustache
+    FakeMustache.new(self)
+  end
+
+  class FakeMustache < ::Mustache
+    def initialize(ctx)
+      ctx.elements.each { |e| self[e.key] = e.value }
+    end
+  end
 end

--- a/app/models/instrument_context_element.rb
+++ b/app/models/instrument_context_element.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+# Schema version: 20130212215454
+#
+# Table name: instrument_context_elements
+#
+#  created_at            :datetime
+#  id                    :integer          not null, primary key
+#  instrument_context_id :integer          not null
+#  key                   :string(255)
+#  updated_at            :datetime
+#  value                 :text
+#
+
+class InstrumentContextElement < ActiveRecord::Base
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -123,6 +123,10 @@ class Person < ActiveRecord::Base
     self.age = self.computed_age if self.age.blank?
   end
 
+  def self.with_contact_data
+    includes(:addresses, :emails, :telephones)
+  end
+
   ##
   # How to format the date_move attribute
   # cf. MdesRecord

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -25,6 +25,8 @@ class ResponseSet < ActiveRecord::Base
   belongs_to :instrument, :inverse_of => :response_sets
   belongs_to :participant, :inverse_of => :response_sets
 
+  has_one :instrument_context, :inverse_of => :response_set
+
   after_save :extract_operational_data
 
   attr_accessible :participant_id

--- a/db/migrate/20130212184524_create_instrument_contexts.rb
+++ b/db/migrate/20130212184524_create_instrument_contexts.rb
@@ -1,0 +1,8 @@
+class CreateInstrumentContexts < ActiveRecord::Migration
+  def change
+    create_table :instrument_contexts do |t|
+      t.references :response_set, :null => false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20130212184932_create_instrument_context_elements.rb
+++ b/db/migrate/20130212184932_create_instrument_context_elements.rb
@@ -1,0 +1,10 @@
+class CreateInstrumentContextElements < ActiveRecord::Migration
+  def change
+    create_table :instrument_context_elements do |t|
+      t.references :instrument_context, :null => false
+      t.string :key
+      t.text :value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20130212215454_add_instrument_context_constraints.rb
+++ b/db/migrate/20130212215454_add_instrument_context_constraints.rb
@@ -1,0 +1,11 @@
+class AddInstrumentContextConstraints < ActiveRecord::Migration
+  def up
+    add_foreign_key 'instrument_context_elements', 'instrument_contexts'
+    add_foreign_key 'instrument_contexts', 'response_sets'
+  end
+
+  def down
+    remove_foreign_key 'instrument_context_elements', 'instrument_contexts'
+    remove_foreign_key 'instrument_contexts', 'response_sets'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130206202031) do
+ActiveRecord::Schema.define(:version => 20130212215454) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false
@@ -272,8 +272,6 @@ ActiveRecord::Schema.define(:version => 20130206202031) do
     t.integer  "lock_version",                                                                    :default => 0
   end
 
-  add_index "events", ["event_type_code"], :name => "e_event_type_code"
-
   create_table "fieldworks", :force => true do |t|
     t.string   "fieldwork_id",        :limit => 36
     t.datetime "created_at"
@@ -344,6 +342,8 @@ ActiveRecord::Schema.define(:version => 20130206202031) do
     t.datetime "updated_at"
   end
 
+  add_index "institution_person_links", ["institution_id", "person_id"], :name => "index_institution_person_links_on_institution_id_and_person_id", :unique => true
+
   create_table "institutions", :force => true do |t|
     t.string   "psu_code",                    :limit => 36, :null => false
     t.string   "institute_id",                              :null => false
@@ -366,6 +366,20 @@ ActiveRecord::Schema.define(:version => 20130206202031) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "response_set_id"
+  end
+
+  create_table "instrument_context_elements", :force => true do |t|
+    t.integer  "instrument_context_id", :null => false
+    t.string   "key"
+    t.text     "value"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "instrument_contexts", :force => true do |t|
+    t.integer  "response_set_id", :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "instruments", :force => true do |t|
@@ -1610,6 +1624,10 @@ ActiveRecord::Schema.define(:version => 20130206202031) do
 
   add_foreign_key "household_person_links", "household_units", :name => "household_person_links_household_units_fk"
   add_foreign_key "household_person_links", "people", :name => "household_person_links_people_fk"
+
+  add_foreign_key "instrument_context_elements", "instrument_contexts", :name => "instrument_context_elements_instrument_context_id_fk"
+
+  add_foreign_key "instrument_contexts", "response_sets", :name => "instrument_contexts_response_set_id_fk"
 
   add_foreign_key "instruments", "events", :name => "instruments_events_fk"
   add_foreign_key "instruments", "people", :name => "instruments_people_fk"

--- a/spec/contexts/create_instrument_context_spec.rb
+++ b/spec/contexts/create_instrument_context_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe CreateInstrumentContext do
+  let(:p) { Factory(:person) }
+  let(:s) { Factory(:survey) }
+  let(:rs) { Factory(:response_set, :person => p, :survey => s) }
+  let(:responsible_user) { double(:full_name => 'No Name') }
+
+  def run
+    CreateInstrumentContext.new(rs, responsible_user).create
+  end
+
+  def render(tpl)
+    run
+
+    m = rs.instrument_context.to_mustache.tap { |v| v.template = tpl }
+    m.render
+  end
+
+  describe '#interviewer_name' do
+    it "is the responsible user's full name" do
+      render('{{interviewer_name}}').should == 'No Name'
+    end
+
+    it "is [INTERVIEWER NAME] if the user has no full name" do
+      responsible_user.stub!(:full_name => nil)
+
+      render('{{interviewer_name}}').should == '[INTERVIEWER NAME]'
+    end
+  end
+
+  describe '#p_full_name' do
+    it 'is Person#full_name' do
+      render('{{p_full_name}}').should == p.full_name
+    end
+
+    it "is [UNKNOWN] if the person has no name" do
+      rs.person = Factory(:person, :first_name => nil, :last_name => nil)
+
+      render('{{p_full_name}}').should == '[UNKNOWN]'
+    end
+    
+    it "is [UNKNOWN] if the response set does not have a person" do
+      rs.update_attribute(:person, nil)
+
+      render('{{p_full_name}}').should == '[UNKNOWN]'
+    end
+  end
+
+  describe '#p_dob' do
+    it "is Person#person_dob" do
+      p.update_attribute(:person_dob, '2000-01-01')
+
+      render('{{p_dob}}').should == '2000-01-01'
+    end
+
+    it 'is [UNKNOWN] if the response set does not have a person' do
+      rs.update_attribute(:person, nil)
+
+      render('{{p_dob}}').should == '[UNKNOWN]'
+    end
+  end
+end

--- a/spec/models/instrument_context_element_spec.rb
+++ b/spec/models/instrument_context_element_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+# Schema version: 20130212215454
+#
+# Table name: instrument_context_elements
+#
+#  created_at            :datetime
+#  id                    :integer          not null, primary key
+#  instrument_context_id :integer          not null
+#  key                   :string(255)
+#  updated_at            :datetime
+#  value                 :text
+#
+
+require 'spec_helper'
+
+describe InstrumentContextElement do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/instrument_context_spec.rb
+++ b/spec/models/instrument_context_spec.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+# Schema version: 20130212215454
+#
+# Table name: instrument_contexts
+#
+#  created_at      :datetime
+#  id              :integer          not null, primary key
+#  response_set_id :integer          not null
+#  updated_at      :datetime
+#
+
+require 'spec_helper'
+
+describe InstrumentContext do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/instrument_context_spec.rb
+++ b/spec/models/instrument_context_spec.rb
@@ -12,5 +12,28 @@
 require 'spec_helper'
 
 describe InstrumentContext do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:ctx) { InstrumentContext.new }
+
+  def render(ctx, template)
+    v = ctx.to_mustache.tap { |v| v.template = template }
+    v.render
+  end
+
+  describe '#set' do
+    it 'sets a key to a value' do
+      ctx.set 'foo', 'bar'
+
+      render(ctx, '{{foo}}').should == 'bar'
+    end
+  end
+
+  describe '#save' do
+    it 'saves set context elements' do
+      ctx.set 'foo', 'bar'
+      ctx.response_set = Factory(:response_set)
+      ctx.save!
+
+      render(InstrumentContext.find(ctx.id), '{{foo}}').should == 'bar'
+    end
+  end
 end

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -26,6 +26,7 @@ describe ResponseSet do
   it { should belong_to(:person) }
   it { should belong_to(:instrument) }
   it { should belong_to(:participant) }
+  it { should have_one(:instrument_context) }
 
   it_should_behave_like 'a publicly identified record' do
     let(:o1) { Factory(:response_set) }


### PR DESCRIPTION
_This pull request should not be merged.  It's review-only._  (Github needs a way to notify people to look at stuff that isn't PRs.)

This PR contains code to generate instrument contexts, lock them to response sets, and generate Mustache rendering contexts from those ICs.

Currently, the goal is to replicate all functionality in the original `InstrumentContext` class.  This may be overkill: it seems to me that we should be able to generate just enough context for the response set.  However, to do that, we need to know what helpers are used in which surveys, and as far as I know that mapping doesn't exist.
