### PR TITLE
3411 event psc ideal date

### DIFF
--- a/app/assets/javascripts/event.js
+++ b/app/assets/javascripts/event.js
@@ -1,9 +1,25 @@
 $(document).ready(function() {
 
+  $("#enable_event_psc_ideal_date").click(function() {
+    msg = "Updating the ideal date should only be performed by System Administrators " +
+          "and under the rarest of circumstances.\nAltering the event ideal date might " +
+          "break the event association in PSC."
+    alert(msg);
+    $("#event_psc_ideal_date").removeAttr('disabled');
+    $('#disable_event_psc_ideal_date').show();
+    $('#enable_event_psc_ideal_date').hide();
+  });
+
+  $("#disable_event_psc_ideal_date").click(function() {
+    $("#event_psc_ideal_date").attr('disabled','disabled');
+    $('#enable_event_psc_ideal_date').show();
+    $('#disable_event_psc_ideal_date').hide();
+  });
+
   $("#enable_event_date_attributes").click(function() {
     $("#event_event_end_date").removeAttr('disabled');
     $("#event_event_end_time").removeAttr('disabled');
-    $('#disable_event_date_attributes').show();    
+    $('#disable_event_date_attributes').show();
     $('#enable_event_date_attributes').hide();
   });
 
@@ -11,33 +27,7 @@ $(document).ready(function() {
     $("#event_event_end_date").attr('disabled','disabled');
     $("#event_event_end_time").attr('disabled','disabled');
     $('#enable_event_date_attributes').show();
-    $('#disable_event_date_attributes').hide();    
-  });
-
-  $("#enable_event_type_code").click(function() {
-    alert("Altering the event type might break the event association in PSC.")
-    $("#event_event_type_code").removeAttr('disabled');
-    $('#disable_event_type_code').show();    
-    $('#enable_event_type_code').hide();
-  });
-
-  $("#disable_event_type_code").click(function() {
-    $("#event_event_type_code").attr('disabled','disabled');
-    $('#enable_event_type_code').show();
-    $('#disable_event_type_code').hide();    
-  });
-
-  $("#enable_event_start_date").click(function() {
-    alert("Altering the event start date might break the event association in PSC.")
-    $("#event_event_start_date").removeAttr('disabled');
-    $('#disable_event_start_date').show();
-    $('#enable_event_start_date').hide();    
-  });
-
-  $("#disable_event_start_date").click(function() {
-    $("#event_event_start_date").attr('disabled','disabled');
-    $('#enable_event_start_date').show();
-    $('#disable_event_start_date').hide();    
+    $('#disable_event_date_attributes').hide();
   });
 
 });

--- a/app/assets/javascripts/event.js
+++ b/app/assets/javascripts/event.js
@@ -1,21 +1,5 @@
 $(document).ready(function() {
 
-  $("#enable_event_psc_ideal_date").click(function() {
-    msg = "Updating the ideal date should only be performed by System Administrators " +
-          "and under the rarest of circumstances.\nAltering the event ideal date might " +
-          "break the event association in PSC."
-    alert(msg);
-    $("#event_psc_ideal_date").removeAttr('disabled');
-    $('#disable_event_psc_ideal_date').show();
-    $('#enable_event_psc_ideal_date').hide();
-  });
-
-  $("#disable_event_psc_ideal_date").click(function() {
-    $("#event_psc_ideal_date").attr('disabled','disabled');
-    $('#enable_event_psc_ideal_date').show();
-    $('#disable_event_psc_ideal_date').hide();
-  });
-
   $("#enable_event_date_attributes").click(function() {
     $("#event_event_end_date").removeAttr('disabled');
     $("#event_event_end_time").removeAttr('disabled');

--- a/app/models/field/adapters/event.rb
+++ b/app/models/field/adapters/event.rb
@@ -1,4 +1,5 @@
 # == Schema Information
+# Schema version: 20130226172617
 #
 # Table name: events
 #
@@ -21,6 +22,7 @@
 #  id                                 :integer          not null, primary key
 #  lock_version                       :integer          default(0)
 #  participant_id                     :integer
+#  psc_ideal_date                     :date
 #  psu_code                           :integer          not null
 #  scheduled_study_segment_identifier :string(255)
 #  transaction_type                   :string(255)

--- a/app/views/events/_form_fields.html.haml
+++ b/app/views/events/_form_fields.html.haml
@@ -4,17 +4,6 @@
 
   = render "shared/ncs_code_select", { :f => f, :code => :event_type_code, :label_text => "Event Type", :other => :event_type_other, :help_text => "events/event_event_type_tooltip", :html_attrs => { :disabled => 'disabled' } }
 
-  - if permit?(Role::SYSTEM_ADMINISTRATOR)
-    %p
-      %a{ :href => "javascript:void(0);", :class => "toggle_enable_link icon_link", :id => "enable_event_psc_ideal_date" }
-        Enable PSC Ideal Date
-      %a{ :href => "javascript:void(0);", :class => "toggle_disable_link icon_link", :id => "disable_event_psc_ideal_date" }
-        Disable PSC Ideal Date
-      %br
-      = f.label :psc_ideal_date, "PSC Ideal Date"
-      %br
-      = f.text_field :psc_ideal_date, :class => "datepicker", :disabled => 'disabled'
-
   = render "shared/ncs_code_select", { :f => f, :code => :event_disposition_category_code, :label_text => "Disposition Category" }
   = render "shared/disposition_code", { :f => f, :code => :event_disposition, :notify_marker => true }
 

--- a/app/views/events/_form_fields.html.haml
+++ b/app/views/events/_form_fields.html.haml
@@ -2,11 +2,18 @@
 
   = hidden_field_tag :contact_link_id, @contact_link.id if @contact_link
 
-  %a{ :href => "javascript:void(0);", :class => "toggle_enable_link icon_link", :id => "enable_event_type_code" }
-    Enable Event Type
-  %a{ :href => "javascript:void(0);", :class => "toggle_disable_link icon_link", :id => "disable_event_type_code" }
-    Disable Event Type
   = render "shared/ncs_code_select", { :f => f, :code => :event_type_code, :label_text => "Event Type", :other => :event_type_other, :help_text => "events/event_event_type_tooltip", :html_attrs => { :disabled => 'disabled' } }
+
+  - if permit?(Role::SYSTEM_ADMINISTRATOR)
+    %p
+      %a{ :href => "javascript:void(0);", :class => "toggle_enable_link icon_link", :id => "enable_event_psc_ideal_date" }
+        Enable PSC Ideal Date
+      %a{ :href => "javascript:void(0);", :class => "toggle_disable_link icon_link", :id => "disable_event_psc_ideal_date" }
+        Disable PSC Ideal Date
+      %br
+      = f.label :psc_ideal_date, "PSC Ideal Date"
+      %br
+      = f.text_field :psc_ideal_date, :class => "datepicker", :disabled => 'disabled'
 
   = render "shared/ncs_code_select", { :f => f, :code => :event_disposition_category_code, :label_text => "Disposition Category" }
   = render "shared/disposition_code", { :f => f, :code => :event_disposition, :notify_marker => true }
@@ -21,14 +28,9 @@
     = f.text_field :event_repeat_key
 
   %p
-    %a{ :href => "javascript:void(0);", :class => "toggle_enable_link icon_link", :id => "enable_event_start_date" }
-      Enable Event Start Date
-    %a{ :href => "javascript:void(0);", :class => "toggle_disable_link icon_link", :id => "disable_event_start_date" }
-      Disable Event Start Date
-    %br
     = f.label :event_start_date, "Event Start Date"
     %br
-    = f.text_field :event_start_date, :class => "datepicker", :disabled => 'disabled'
+    = f.text_field :event_start_date, :class => "datepicker"
 
   %p
     = f.label :event_start_time, "Event Start Time"

--- a/db/migrate/20130226164429_add_psc_ideal_date_to_events.rb
+++ b/db/migrate/20130226164429_add_psc_ideal_date_to_events.rb
@@ -1,0 +1,9 @@
+class AddPscIdealDateToEvents < ActiveRecord::Migration
+  def up
+    add_column :events, :psc_ideal_date, :date
+  end
+
+  def down
+    remove_column :events, :psc_ideal_date
+  end
+end

--- a/db/migrate/20130226172617_set_psc_ideal_date_on_events.rb
+++ b/db/migrate/20130226172617_set_psc_ideal_date_on_events.rb
@@ -1,8 +1,6 @@
 class SetPscIdealDateOnEvents < ActiveRecord::Migration
   def up
-    Event.all.each do |e|
-      e.update_attribute(:psc_ideal_date, e.event_start_date) if e.psc_ideal_date.blank?
-    end
+    execute("UPDATE events SET psc_ideal_date = event_start_date")
   end
 
   def down

--- a/db/migrate/20130226172617_set_psc_ideal_date_on_events.rb
+++ b/db/migrate/20130226172617_set_psc_ideal_date_on_events.rb
@@ -1,0 +1,11 @@
+class SetPscIdealDateOnEvents < ActiveRecord::Migration
+  def up
+    Event.all.each do |e|
+      e.update_attribute(:psc_ideal_date, e.event_start_date) if e.psc_ideal_date.blank?
+    end
+  end
+
+  def down
+    # NOOP - there should be no reason to delete the psc_ideal_date value
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130207172547) do
+ActiveRecord::Schema.define(:version => 20130226172617) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false
@@ -270,9 +270,8 @@ ActiveRecord::Schema.define(:version => 20130207172547) do
     t.datetime "updated_at"
     t.string   "scheduled_study_segment_identifier"
     t.integer  "lock_version",                                                                    :default => 0
+    t.date     "psc_ideal_date"
   end
-
-  add_index "events", ["event_type_code"], :name => "e_event_type_code"
 
   create_table "fieldworks", :force => true do |t|
     t.string   "fieldwork_id",        :limit => 36
@@ -343,6 +342,8 @@ ActiveRecord::Schema.define(:version => 20130207172547) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "institution_person_links", ["institution_id", "person_id"], :name => "index_institution_person_links_on_institution_id_and_person_id", :unique => true
 
   create_table "institutions", :force => true do |t|
     t.string   "psu_code",                    :limit => 36, :null => false

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -140,7 +140,8 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         :event_incentive_cash => :event_incent_cash,
         :event_incentive_noncash => :event_incent_noncash
       },
-      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier lock_version)
+      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
+        psc_ideal_date lock_version)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -174,7 +174,8 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         :event_incentive_cash => :event_incent_cash,
         :event_incentive_noncash => :event_incent_noncash
       },
-      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier lock_version)
+      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
+        psc_ideal_date lock_version)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -173,7 +173,8 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         :event_incentive_cash => :event_incent_cash,
         :event_incentive_noncash => :event_incent_noncash
       },
-      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier lock_version)
+      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
+        psc_ideal_date lock_version)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -174,7 +174,8 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         :event_incentive_cash => :event_incent_cash,
         :event_incentive_noncash => :event_incent_noncash
       },
-      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier lock_version)
+      :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
+        psc_ideal_date lock_version)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -126,6 +126,7 @@ Factory.define :event do |e|
   e.event_disposition_category_code  1
   e.event_breakoff_code              1
   e.event_incentive_type_code        1
+  e.psc_ideal_date                   nil
 end
 
 Factory.define :mdes_min_event, :class => Event do |e|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20120629204215
+# Schema version: 20130226172617
 #
 # Table name: events
 #
@@ -23,6 +23,7 @@
 #  id                                 :integer          not null, primary key
 #  lock_version                       :integer          default(0)
 #  participant_id                     :integer
+#  psc_ideal_date                     :date
 #  psu_code                           :integer          not null
 #  scheduled_study_segment_identifier :string(255)
 #  transaction_type                   :string(255)
@@ -59,6 +60,27 @@ describe Event do
       winner.event_type_other = 'winner'
       loser.event_type_other = 'loser'
     end
+  end
+
+  describe "#set_psc_ideal_date" do
+    let(:event) { Factory(:event, :event_start_date => start_date, :psc_ideal_date => ideal_date) }
+
+    describe "for an event without an ideal date" do
+      let(:start_date) { Date.parse('2525-12-25') }
+      let(:ideal_date) { nil }
+      it "sets the psc ideal date to the event start date before save" do
+        event.psc_ideal_date.should == start_date
+      end
+    end
+
+    describe "for an event without an ideal date" do
+      let(:start_date) { Date.parse('2525-12-25') }
+      let(:ideal_date) { Date.parse('2525-01-01') }
+      it "does not override the existing value" do
+        event.psc_ideal_date.should == ideal_date
+      end
+    end
+
   end
 
   describe 'to_s' do
@@ -799,7 +821,7 @@ describe Event do
     it 'returns activities whose label and ideal date match' do
       # Pregnancy Visit 1.
       event.event_type = NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13)
-      event.event_start_date = '2012-01-01'
+      event.psc_ideal_date = '2012-01-01'
       psc_participant.stub!(:scheduled_activities).and_return(schedule)
 
       event.scheduled_activities(psc_participant).should == [


### PR DESCRIPTION
This commit adds the psc_ideal_date attribute to Event and uses this attribute to match activities in PSC (replacing what event_start_date was doing previously).
