### PR TITLE
Time picker is misbehaving #3415

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -66,7 +66,7 @@ $(document).ready(function() {
 
   $("input[type='text'].datetime").datetimepicker({
     controlType: 'select',
-    timeFormat: 'hh:mm:ss',
+    timeFormat: 'HH:mm:ss',
     dateFormat: 'yy-mm-dd'
   });
   $("input[type='text'].date").datepicker({

--- a/vendor/assets/javascripts/surveyor/jquery.surveyor.js
+++ b/vendor/assets/javascripts/surveyor/jquery.surveyor.js
@@ -47,11 +47,7 @@ jQuery(document).ready(function(){
     }
   });
 
-  jQuery("form#survey_form input:not(.hasDatepicker, .datetime), form#survey_form select, form#survey_form textarea").change(surveyor_submit_response);
-
-  jQuery("form#survey_form input.hasDatepicker, form#survey_form input.datetime").blur(surveyor_submit_response);
-
-  function surveyor_submit_response() {
+  jQuery("form#survey_form input, form#survey_form select, form#survey_form textarea").change(function(){
     var elements = [$('[type="submit"]').parent(), $('[name="' + this.name +'"]').closest('li')];
 
     question_data = $(this).parents('fieldset[id^="q_"],tr[id^="q_"]').
@@ -66,7 +62,7 @@ jQuery(document).ready(function(){
         successfulSave(response);
       }
     });
-  }
+  });
 
   // http://www.filamentgroup.com/lab/update_jquery_ui_slider_from_a_select_element_now_with_aria_support/
   $('fieldset.q_slider select').each(function(i,e) {


### PR DESCRIPTION
#### Summary

_"It is not possible to enter a time after 11:59 AM. The dropdowns appear to support 
24-hour time entry, but they do not. If a time greater than 12 is entered, 12 hours are subtracted from the selection."_

The configuration for the `datetimepicker` was incorrect. Simple two-character change.

_"The time picker does not submit on change. It seems to be possible to enter a time that is not saved at all."_

Reverted a change that made the `datetimepicker` update `onblur`. Now the `datetimepicker` posts when a change is made via the dropdowns and when "done" is clicked.
