### PR TITLE
Reimplement Response#{value, value=} using response class

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -26,13 +26,8 @@
 
 class Response < ActiveRecord::Base
   include NcsNavigator::Core::Surveyor::HasPublicId
+  include NcsNavigator::Core::Surveyor::ResponseValue
   include Surveyor::Models::ResponseMethods
-
-  ##
-  # Used by {#value=} to recognize datetimes, dates, and times.
-  ISO8601_HHMM_FORMAT = /\A\s*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}([+-]\d{4}|Z)\s*\Z/
-  DATE_FORMAT = /\A\s*\d{4}-\d{2}-\d{2}\s*\Z/
-  TIME_FORMAT = /\A\s*\d{2}:\d{2}\s*\Z/
 
   def self.default_scope; end
 
@@ -79,36 +74,5 @@ class Response < ActiveRecord::Base
     else
       self.string_value
     end
-  end
-
-  def value=(val)
-    case val
-    when String
-      # This is pretty crazy.
-      #
-      # See
-      # https://github.com/NUBIC/surveyor/blob/0a4424ce6b732d111954354ec9c1c7e21d6ebc9b/lib/surveyor/models/response_methods.rb#L92-L103
-      # for Surveyor expectations on presenting dates, times, and datetimes as
-      # JSON.
-      if val =~ ISO8601_HHMM_FORMAT
-        self.datetime_value = Time.parse(val)
-      elsif val =~ DATE_FORMAT
-        self.date_value = val
-      elsif val =~ TIME_FORMAT
-        self.time_value = val
-      end
-
-      self.string_value = val
-    when Integer
-      self.integer_value = val
-    when Float
-      self.float_value = val
-    end
-  end
-
-  def value
-    a = answer
-
-    as(a.response_class.to_sym) unless a.response_class == 'answer'
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -29,7 +29,7 @@ class Response < ActiveRecord::Base
   include NcsNavigator::Core::Surveyor::ResponseValue
   include Surveyor::Models::ResponseMethods
 
-  def self.default_scope; end
+  default_scope reorder().includes(:answer, :question)
 
   def self.for_merge
     includes(:answer, :question, :response_set)

--- a/lib/ncs_navigator/core/surveyor.rb
+++ b/lib/ncs_navigator/core/surveyor.rb
@@ -1,3 +1,4 @@
 module NcsNavigator::Core::Surveyor
-  autoload :HasPublicId,  'ncs_navigator/core/surveyor/has_public_id'
+  autoload :HasPublicId,    'ncs_navigator/core/surveyor/has_public_id'
+  autoload :ResponseValue,  'ncs_navigator/core/surveyor/response_value'
 end

--- a/lib/ncs_navigator/core/surveyor/response_value.rb
+++ b/lib/ncs_navigator/core/surveyor/response_value.rb
@@ -1,0 +1,188 @@
+module NcsNavigator::Core::Surveyor
+  ##
+  # Wraps Surveyor's many value columns with a single accessor.
+  #
+  # This is useful for code that needs to work with response values but
+  # should not care about Surveyor internals.  (Merge and prepopulation, for
+  # example.)
+  #
+  # These accessors make great use of the answer association on Response,
+  # which means that you MAY want to eager-load answer as a default scope.
+  #
+  #
+  # Relationship to Response#reportable_value
+  # -----------------------------------------
+  #
+  # Response#reportable_value is intended for warehouse use.  It performs
+  # transformations that -- while appropriate for warehousing -- may not be
+  # appropriate for more general use.  For example, #reportable_value coerces
+  # all numbers to strings and returns reference identifiers of answers.  The
+  # accessor defined here attempts to keep transformations to a minimum.
+  module ResponseValue
+    ##
+    # Response columns altered by this method.
+    VALUE_FIELDS = ::Response.columns.map(&:name).select { |n| n.end_with?('_value') }
+
+    def self.included(model)
+      model.before_save :write_value_to_record
+      model.define_attribute_method :value
+    end
+
+    ##
+    # Sets a value.
+    #
+    # This method does not directly alter model state.  Instead, this merely
+    # writes to an instance variable.  That instance variable is then persisted
+    # to its corresponding column in a before-save hook.
+    #
+    # The rationale for this behavior:
+    #
+    # 1. A response value cannot be set without an answer.
+    # 2. The answer may not be present at the time #value= is called.
+    # 3. If #value= immediately attempts to coerce its input and an answer is
+    #    not present, there is no sensible behavior but to raise an exception.
+    # 4. Because of (3), we must now enforce prerequisites for usage of
+    #    #value=; namely, an answer must be set before using #value=.
+    # 5. However, no other model in Cases has accessors that intentionally
+    #    exhibit the peculiar behavior described in (4).
+    # 6. Additionally, the behavior described in (4) is really odd for
+    #    ActiveRecord models and Ruby objects in general.  You should be able
+    #    to set object attributes in _any_ order.
+    #
+    # When you set a value via #value=, you can read that value exactly as you
+    # set it by invoking #value.   Once the response is saved, #value will
+    # report the persisted value _after any necessary coercions have occurred_.
+    # This means that you could end up seeing this behavior:
+    #
+    #     r = Response.new(:answer => Answer.new(:response_class => 'integer'))
+    #     r.value = "42"
+    #     r.value         # => "42"
+    #     r.value.class   # => String
+    #     r.save          # => true
+    #     r.value         # => 42
+    #     r.value.class   # => Fixnum
+    #
+    #
+    # On values for non-value response classes
+    # ----------------------------------------
+    #
+    # Some response classes don't have values.  (Answer, for example.)
+    #
+    # In non-production environments, attempting to set a value for such a
+    # response will cause a ResponseValue::CannotSetValue exception to be
+    # raised.
+    #
+    # In production, however, no exception is raised and the attempted setting
+    # is logged at WARN level.  Rationale: it's possible that this may result
+    # from malicious intent, and the error is entirely recoverable (i.e. by not
+    # doing anything).
+    def value=(v)
+      value_will_change! unless @value == v
+
+      @value = v
+    end
+
+    ##
+    # Retrieves a value.
+    #
+    # Behavior:
+    #
+    # 1. If the response's value was made dirty via #value=, then this returns
+    #    the object passed to #value=.
+    # 2. If the response's value was made dirty via some other mechanism (say, by
+    #    directly setting the underlying value columns), then this returns the
+    #    dirty value of the response's corresponding value column.
+    # 3. If the response's value is not dirty, then this returns the persisted
+    #    value of the response's corresponding value column.
+    def value
+      if value_changed?
+        @value
+      else
+        value_from_response
+      end
+    end
+
+    private
+
+    def value_from_response
+      rc = answer.response_class
+
+      as(rc) if has_value?(rc)
+    end
+
+    def write_value_to_record
+      return unless value_changed?
+
+      # before_save callbacks run after before_validation callbacks, and
+      # Surveyor installs a presence check on answer_id, so we know that we
+      # have an answer if we get this far.
+      k = answer.response_class
+
+      field = value_field_for(k, value)
+
+      if field
+        reset_values
+        send("#{field}=", value)
+      else
+        msg = "A value was set for response #{id}, but the response has non-value response class #{k.inspect}.  The value will not be set."
+
+        if Rails.env.production?
+          Rails.logger.warn msg
+        else
+          raise CannotSetValue, msg
+        end
+      end
+    end
+
+    def reset_values
+      VALUE_FIELDS.each { |f| send("#{f}=", nil) }
+    end
+
+    module_function
+
+    def has_value?(rc)
+      # Yes, the value is used in some cases to determine an appropriate value
+      # field.  However, so long as you get *some* non-nil value out of
+      # value_field_for for (response class, nil), it doesn't matter what that
+      # value is.
+      value_field_for(rc, nil)
+    end
+
+    # Notes:
+    #
+    # Surveyor's Response#date_value= is defined as
+    #
+    #   def date_value=(val)
+    #     self.datetime_value = Time.zone.parse(val).to_datetime
+    #   end
+    #
+    # Now:
+    #
+    # 1. Time.zone.parse cannot accept Dates, so this will fail if we just
+    #    use #date_value=.
+    # 2. Surveyor::ActsAsResponse#as returns a Date for answers of response
+    #    class date.
+    # 3. Response#date_value doesn't actually return a Date; it gives you
+    #    back a String in YYYY-MM-DD form or nil.
+    #
+    # The existence of fact #3 means that I'm not really sure what to do
+    # when returning a date value, but as #as is used to implement #value,
+    # it seems like it's consistent (or at least intelligent) to also
+    # accept Dates here.  To do that, we need to use
+    # Response#datetime_value=.
+    def value_field_for(rc, v)
+      case rc
+      when 'datetime';  'datetime_value'
+      when 'date';       Date === v ? 'datetime_value' : 'date_value'
+      when 'time';      'time_value'
+      when 'float';     'float_value'
+      when 'integer';   'integer_value'
+      when 'string';    'string_value'
+      when 'text';      'text_value'
+      end
+    end
+
+    class CannotSetValue < StandardError
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/core/surveyor/response_value_spec.rb
+++ b/spec/lib/ncs_navigator/core/surveyor/response_value_spec.rb
@@ -1,0 +1,170 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Surveyor
+  describe ResponseValue do
+    describe '::VALUE_FIELDS' do
+      %w(
+        datetime_value
+        float_value
+        integer_value
+        string_value
+        text_value
+      ).each do |f|
+        it "includes #{f}" do
+          ResponseValue::VALUE_FIELDS.should include(f)
+        end
+      end
+    end
+  end
+
+  describe 'Response value accessor' do
+    let(:r) { Factory(:response, :answer => a, :question => q) }
+    let(:a) { Factory(:answer) }
+    let(:q) { Factory(:question) }
+
+    t_zulu = '2000-01-01T00:00:00Z'
+    t_utc_m6 = '2000-01-01T00:00:00-0600'
+    t_utc_p1 = '2000-01-01T00:00:00+0100'
+    dt_zulu = Time.parse(t_zulu)
+    dt_utc_m6 = Time.parse(t_utc_m6)
+    dt_utc_p1 = Time.parse(t_utc_p1)
+    d = Date.new(2000, 01, 01)
+    d_world = '2000-01-01'
+    d_us = '01/01/2000'
+    t_noon_str = '12:00'
+    t_noon = Time.parse(t_noon_str)
+
+    # rclass      column name         input           persisted   output
+    [
+     # String echo.
+     'string',    'string_value',     'foo',          'foo',      'foo',
+
+     # Integer -> string coercion.
+     'string',    'string_value',     42,             '42',       '42',
+
+     # Integer echo.
+     'integer',   'integer_value',    42,             42,         42,
+
+     # Float echo.
+     'float',     'float_value',      10.1,           10.1,       10.1,
+
+     # Text isn't the same as string.
+     'text',      'text_value',       'foo',          'foo',      'foo',
+
+     # Datetime echo.
+     'datetime',  'datetime_value',   dt_zulu,        dt_zulu,    dt_zulu,
+
+     # Date echo.
+     'date',      'datetime_value',   d,              d.to_time,  d,
+
+     # YYYY-MM-DD strings as dates.
+     # Surveyor uses a datetime field to store datetimes, dates, and times.
+     # This is why you see the #to_time conversions.  They're kind of gross,
+     # but we have to live with it.
+     'date',      'datetime_value',   d_world,        d.to_time,  d,
+
+     # MM/DD/YYYY strings as dates.
+     'date',      'datetime_value',   d_us,           d.to_time,  d,
+
+     # HH:MM times.
+     'time',      'datetime_value',   t_noon_str,     t_noon,     t_noon,
+
+     # ISO8601 times as strings.
+     'datetime',  'datetime_value',   t_zulu,         dt_zulu,    dt_zulu,
+     'datetime',  'datetime_value',   t_utc_m6,       dt_utc_m6,  dt_utc_m6,
+     'datetime',  'datetime_value',   t_utc_p1,       dt_utc_p1,  dt_utc_p1
+
+    ].each_slice(5) do |response_class, mapped_field, input, persisted, output|
+      describe "with response class #{response_class}" do
+        before do
+          a.update_attribute(:response_class, response_class)
+        end
+
+        it "returns #{input.inspect} when given #{input.inspect}" do
+          r.value = input
+
+          r.value.should == input
+        end
+
+        describe "after setting #{input.inspect} and saving" do
+          let(:sr) { Response.find(r.id) }
+
+          before do
+          end
+
+          it "sets #{mapped_field} to #{persisted.inspect}" do
+            r.value = input
+            r.save!
+
+            sr.send(mapped_field).should == persisted
+          end
+
+          it 'resets all other value fields' do
+            ResponseValue::VALUE_FIELDS.each do |f|
+              r.send("#{f}=", "100")
+            end
+
+            r.value = input
+            r.save!
+
+            vs = (ResponseValue::VALUE_FIELDS - [mapped_field]).map { |f| sr.send(f) }
+
+            vs.all?(&:nil?).should be_true
+          end
+
+          it "returns #{output.inspect}" do
+            r.value = input
+            r.save!
+
+            sr.value.should == output
+          end
+        end
+      end
+    end
+
+    describe '#value' do
+      it 'is read back from the database on reload' do
+        a.update_attribute(:response_class, 'integer')
+        r.value = 42
+        r.save!
+        r.value = '42'
+        r.reload
+
+        r.value.should == 42
+      end
+    end
+
+    describe 'with response class answer' do
+      before do
+        a.update_attribute(:response_class, 'answer')
+      end
+
+      describe '#value=' do
+        describe 'in production' do
+          before do
+            Rails.env.stub!(:production? => true)
+          end
+
+          it 'does not set anything when persisting' do
+            r.value = 'foo'
+            r.save!
+
+            r.reload.value.should be_nil
+          end
+        end
+
+        describe 'not in production' do
+          before do
+            Rails.env.stub!(:production? => false)
+          end
+
+          it 'raises CannotSetValue when persisting' do
+            r.value = 'foo'
+
+            expect { r.save }.to raise_error(ResponseValue::CannotSetValue)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -90,67 +90,6 @@ describe Response do
     end
   end
 
-  describe '#value=' do
-    describe 'given a String' do
-      let(:val) { 'foo' }
-
-      before do
-        subject.value = val
-      end
-
-      describe 'given an ISO8601 datetime' do
-        let(:val) { '2012-12-04T16:51-0600' }
-
-        it 'sets #datetime_value' do
-          subject.datetime_value.should == Time.parse('2012-12-04T16:51:00-0600')
-        end
-      end
-
-      describe 'given a date in the form YYYY-MM-DD' do
-        let(:val) { '2012-12-04' }
-
-        it 'roundtrips to JSON' do
-          subject.answer = Factory(:answer, :response_class => 'date')
-
-          subject.json_value.should == '2012-12-04'
-        end
-      end
-
-      describe 'given a time in the form HH:MM' do
-        let(:val) { '12:00' }
-
-        it 'roundtrips to JSON' do
-          subject.answer = Factory(:answer, :response_class => 'time')
-
-          subject.json_value.should == '12:00'
-        end
-      end
-
-      it 'sets #string_value' do
-        subject.string_value.should == val
-      end
-    end
-
-    describe 'given an Integer' do
-      let(:val) { 10 }
-
-      it 'sets #integer_value' do
-        subject.value = val
-
-        subject.integer_value.should == val
-      end
-    end
-
-    describe 'given a Float' do
-      let(:val) { 3.14 }
-
-      it 'sets #float_value' do
-        subject.value = val
-        subject.float_value.should == val
-      end
-    end
-  end
-
   describe '#reportable_value' do
     let(:questions_dsl) {
       <<-DSL


### PR DESCRIPTION
This reimplements `Response#value` and `Response#value=` using the response's answer's response class.  This was necessary to properly differentiate between e.g. strings that were meant for `string_value` or `text_value`, as it's not possible to figure that out on value type alone.

This PR also adds a default scope to Response that eager-loads the Question and Answer; see the commit messages for rationale.
