### PR TITLE
Use #advance for state transition, eliminate of #update_state_after_survey, #3453

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -58,8 +58,8 @@ class EventsController < ApplicationController
           # do not set participant
         else
           participant = @event.participant
-          if participant.pending_events.blank? && participant.eligible?
-            resp = Event.schedule_and_create_placeholder(psc, participant)
+          unless participant.ineligible?
+            resp = participant.advance(psc)
             notice += " Could not schedule next event [#{participant.next_study_segment}]" unless resp
           end
         end

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -22,8 +22,8 @@ class SurveyorController < ApplicationController
         psc.update_activity_state(a.activity_id, @participant, Psc::ScheduledActivity::OCCURRED)
       end
 
-      # go to contact_link.edit_instrument
-      update_participant_based_on_survey(@response_set)
+      # judge eligiblity then go to contact_link.edit_instrument
+      EligibilityAdjudicator.adjudicate_eligibility(@response_set)
       edit_instrument_contact_link_path(contact_link.id)
 
     else
@@ -84,14 +84,5 @@ class SurveyorController < ApplicationController
         raise e
       end
     end
-  end
-
-  private
-
-  # TODO: ensure that the state transitions are based on the responses in the response set
-  #       and that the disposition of the instrument was completed
-  def update_participant_based_on_survey(response_set)
-    EligibilityAdjudicator.adjudicate_eligibility(response_set)
-    response_set.participant.update_state_after_survey(response_set, psc) if response_set.participant
   end
 end

--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -22,7 +22,7 @@ class SurveyorController < ApplicationController
         psc.update_activity_state(a.activity_id, @participant, Psc::ScheduledActivity::OCCURRED)
       end
 
-      # judge eligiblity then go to contact_link.edit_instrument
+      # judge eligibility then go to contact_link.edit_instrument
       EligibilityAdjudicator.adjudicate_eligibility(@response_set)
       edit_instrument_contact_link_path(contact_link.id)
 

--- a/app/helpers/participants_helper.rb
+++ b/app/helpers/participants_helper.rb
@@ -43,7 +43,7 @@ module ParticipantsHelper
   end
 
   def should_show_informed_consent_scheduling_form?(participant)
-    participant.eligible? && !(participant.pending_events.first.try(:event_type_code) == Event.informed_consent_code)
+    !participant.ineligible? && !(participant.pending_events.first.try(:event_type_code) == Event.informed_consent_code)
   end
 
   def upcoming_events_for(person_or_participant)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -729,7 +729,6 @@ class Event < ActiveRecord::Base
   # @param[Date] (optional)
   # @return[Response]
   def self.schedule_and_create_placeholder(psc, participant, date = nil)
-    return nil unless participant.eligible?
     return nil unless participant.next_scheduled_event
 
     date ||= participant.next_scheduled_event.date.to_s

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1117,11 +1117,7 @@ class Participant < ActiveRecord::Base
     ( !pbs? && !has_eligible_ppg_status? )
   end
 
-  def pbs?
-    NcsNavigatorCore.recruitment_strategy.pbs?
-  end
-
-  def pbs_eligbility_prefix
+  def pbs_eligibility_prefix
     hospital? ? "#{OperationalDataExtractor::PbsEligibilityScreener::HOSPITAL_INTERVIEW_PREFIX}" : "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}"
   end
 
@@ -1149,7 +1145,7 @@ class Participant < ActiveRecord::Base
   # @param[String] data_export_identifier for question
   # @return[Boolean]
   def eligible_for?(person, reference_identifier)
-    data_export_identifier = pbs_eligbility_prefix + "." + reference_identifier
+    data_export_identifier = pbs_eligibility_prefix + "." + reference_identifier
     most_recent_response = person.responses_for(data_export_identifier).last
     most_recent_response.try(:answer).try(:reference_identifier) == "1"
   end
@@ -1166,6 +1162,10 @@ class Participant < ActiveRecord::Base
   end
 
   private
+
+    def pbs?
+      NcsNavigatorCore.recruitment_strategy.pbs?
+    end
 
     def relationships(code)
       participant_person_links.

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -570,21 +570,25 @@ class Participant < ActiveRecord::Base
   ##
   def update_state_to_next_event(event)
     case event.event_type.local_code
-    when 4, 5, 6, 9, 29, 34
-      # Pregnancy Screener Events or PBS Eligibility Screener
+    when 34
       if NcsNavigatorCore.recruitment_strategy.pbs?
-        completed_pbs_eligibility_screener!
-      elsif can_assign_to_pregnancy_probability_group?
+        if (eligible_for_pbs? || eligible_for_birth_cohort?) && hospital?
+          birth_cohort!
+        else
+          completed_pbs_eligibility_screener!
+        end
+      end
+    when 4, 5, 6, 9, 29
+      # Pregnancy Screener Events or PBS Eligibility Screener
+      if can_assign_to_pregnancy_probability_group?
         assign_to_pregnancy_probability_group!
       end
     when 10
       # Informed Consent
       low_intensity_consent! if can_low_intensity_consent?
-
     when 33
       # Lo I Quex
       follow_low_intensity! if can_follow_low_intensity?
-
     when 7,8
       # Pregnancy Probability
       follow! if can_follow? && high_intensity?

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -22,7 +22,7 @@
 
     %p
       = f.submit "Submit", :disable_with => 'Submitting...'
-      - if person && @contact_link && continuable?(@event) && participant.eligible?
+      - if person && @contact_link && continuable?(@event) && !participant.ineligible?
         %p
           = "- OR -"
         %p

--- a/app/views/participants/_activities.html.haml
+++ b/app/views/participants/_activities.html.haml
@@ -3,7 +3,7 @@
     %b
       Upcoming Activities
 
-  - if recruitment_strategy.pbs? && !@participant.eligible?
+  - if recruitment_strategy.pbs? && @participant.ineligible?
     CANDIDATE DETERMINED INELIGIBLE.
   - else
     - pending_event = @participant.pending_events.first

--- a/app/views/participants/_header_information.html.haml
+++ b/app/views/participants/_header_information.html.haml
@@ -7,6 +7,6 @@
     %b
       = "::"
   = participant.ppg_status
-  - if participant.ppg_status.blank? && participant.eligible?
+  - if participant.ppg_status.blank? && !participant.ineligible?
     %span.warning
       No PPG Assigned

--- a/spec/context/eligibility_adjudicator_spec.rb
+++ b/spec/context/eligibility_adjudicator_spec.rb
@@ -10,53 +10,55 @@ describe EligibilityAdjudicator do
       father =      Factory(:person)
       grandparent = Factory(:person)
       @participant = Factory(:participant)
-      person =      Factory(:person)
+      @person =      Factory(:person)
       provider = Factory(:provider)
-      Factory(:person_provider_link, :person => person, :provider => provider)
+      Factory(:person_provider_link, :person => @person, :provider => provider)
       Factory(:participant_person_link, :person => father, :participant=> @participant, :relationship_code => 4)
       Factory(:participant_person_link, :person => grandparent,:participant => @participant, :relationship_code => 10)
-      person.participant = @participant
-      person.save!
+      @person.participant = @participant
+      @person.save!
       screener_survey = Factory(:survey, :title => "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.0")
-      @response_set = Factory(:response_set, :survey => screener_survey, :person => person, :participant => @participant)
+      @response_set = Factory(:response_set, :survey => screener_survey, :person => @person, :participant => @participant)
+      @another_response_set = Factory(:response_set, :survey => screener_survey, :person => @person, :participant => @participant)
+      @and_another_response_set = Factory(:response_set, :survey => screener_survey, :person => @person, :participant => @participant)
       @event = Factory(:event, :participant => @response_set.participant)
     end
 
     context "when ineligible" do
 
       before do
-        @participant.stub!(:eligible? => false)
+        @participant.stub!(:ineligible? => true)
       end
 
       it "deletes all participant_person_links for a participant" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         ParticipantPersonLink.where(:participant_id => @response_set.participant).count.should == 0
       end
 
       it "sets the participant_id to nil for all events associated with the person" do
         participant_id = @response_set.participant.id
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         Event.where(:participant_id => participant_id).count.should be 0
       end
 
       it "does not delete the event records" do
-        participant_id = @response_set.participant.id
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         Event.exists?(@event.id).should be_true
       end
 
       it "sets the participant_id to nil for the response set" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
-        ResponseSet.find(@response_set.id).participant_id.should be_nil
+        participant_id = @response_set.participant.id
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
+        ResponseSet.where(:participant_id => participant_id).all? { |rs| rs.participant_id.nil? }.should be_true
       end
 
       it "creates a SamplePersonsIneligibility record" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         SampledPersonsIneligibility.count.should == 1
       end
 
       it "deletes participant record" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         Participant.count.should == 0
       end
     end
@@ -67,67 +69,31 @@ describe EligibilityAdjudicator do
       end
 
       it "does not delete participant_person_links for a participant" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         ParticipantPersonLink.where(:participant_id => @response_set.participant.id).count.should == 3
       end
 
       it "does not disturb the participant association with events associated with the person" do
         participant_id = @response_set.participant.id
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         Event.where(:participant_id => participant_id).count.should be 1
       end
 
       it "does not set the participant_id to nil for the response set" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         ResponseSet.find(@response_set.id).participant_id.should_not be_nil
       end
 
       it "does not create a SamplePersonsIneligibility record" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         SampledPersonsIneligibility.count.should == 0
       end
 
       it "does not deletes participant record" do
-        EligibilityAdjudicator.adjudicate_eligibility(@response_set)
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
         Participant.count.should be 1
       end
     end
 
-  end
-
-  describe "#person_taking_screener_ineligible?" do
-
-    before do
-      screener_survey     = Factory(:survey, :title => "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.0")
-      non_screener_survey = Factory(:survey, :title => "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_TWO")
-      ineligible_participant = Factory(:participant)
-      eligible_participant   = Factory(:participant)
-      ineligible_participant.stub!(:eligible? => false)
-      eligible_participant.stub!(:eligible? => true)
-      @screener_and_ineligible_person_response_set     = Factory(:response_set, :survey_id => screener_survey.id,     :participant => ineligible_participant)
-      @non_screener_and_ineligible_person_response_set = Factory(:response_set, :survey_id => non_screener_survey.id, :participant => ineligible_participant)
-      @screener_and_eligible_person_response_set       = Factory(:response_set, :survey_id => screener_survey.id,     :participant => eligible_participant)
-      @non_screener_and_eligible_person_response_set   = Factory(:response_set, :survey_id => non_screener_survey.id, :participant => eligible_participant)
-    end
-
-    context "survey is screener" do
-      it "returns false when person is eligible" do
-        EligibilityAdjudicator.new(@screener_and_eligible_person_response_set).person_taking_screener_ineligible?.should be_false
-      end
-
-      it "returns true when person is not eligible" do
-        EligibilityAdjudicator.new(@screener_and_ineligible_person_response_set).person_taking_screener_ineligible?.should be_true
-      end
-    end
-
-    context "survey is not screener" do
-      it "returns false when person is eligible" do
-        EligibilityAdjudicator.new(@non_screener_and_eligible_person_response_set).person_taking_screener_ineligible?.should be_false
-      end
-
-      it "returns false when person is not eligible" do
-        EligibilityAdjudicator.new(@non_screener_and_ineligible_person_response_set).person_taking_screener_ineligible?.should be_false
-      end
-    end
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1546,7 +1546,7 @@ describe Participant do
           end
 
           it "returns the screener prefix taken by the participant" do
-            @part.pbs_eligbility_prefix.should == OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX
+            @part.pbs_eligibility_prefix.should == OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX
           end
         end
       end
@@ -1620,59 +1620,45 @@ describe Participant do
 
     context "different eligibility scenarios" do
       let(:participant) { Factory(:participant) }
-      let(:birth_cohort) { participant.stub!(:birth_cohort? => true)}
-      let(:pbs) { participant.stub!(:pbs? => true)}
-      let(:non_pbs) { participant.stub!(:pbs? => false)}
-      let(:eligible_for_pbs) { participant.stub!(:eligible_for_pbs? => true)}
-      let(:ineligible_for_pbs) { participant.stub!(:eligible_for_pbs? => false)}
-      let(:eligible_for_birth_cohort) { participant.stub!(:eligible_for_birth_cohort? => true) }
-      let(:ineligible_for_birth_cohort) { participant.stub!(:eligible_for_birth_cohort? => false) }
-      let(:has_eligible_ppg_status) { participant.stub!(:has_eligible_ppg_status? => true) }
-      let(:does_not_have_eligible_ppg_status) { participant.stub!(:has_eligible_ppg_status? => false) }
 
       it "a birth cohort participant whose ineligible for birth cohort is ineligible" do
-        birth_cohort
-        ineligible_for_birth_cohort
-        participant.ineligible?.should be_true
+        participant.stub!(:birth_cohort? => true, :eligible_for_birth_cohort? => false)
+        participant.should be_ineligible
       end
 
-      it "a birth cohort participant whose eligible for birth cohort is not ineligible" do
-        birth_cohort
-        eligible_for_birth_cohort
-        participant.ineligible?.should be_false
+      it "a birth cohort participant whose eligible for birth cohort is eligible" do
+        participant.stub!(:birth_cohort? => true, :eligible_for_birth_cohort? => true)
+        participant.should_not be_ineligible
       end
 
       it "a pbs participant whose ineligible for pbs, yet eligible for birth cohort, is ineligible" do
-        pbs
-        ineligible_for_pbs
-        eligible_for_birth_cohort
-        participant.ineligible?.should be_true
+        participant.stub!(:pbs? => true, :eligible_for_pbs? => false, :eligible_for_birth_cohort? => true)
+        participant.should be_ineligible
       end
 
-      it "a pbs participant whose eligible for pbs is not ineligible" do
-        pbs
-        eligible_for_pbs
-        participant.ineligible?.should be_false
+      it "a pbs participant whose ineligible for pbs, yet has an eligible ppg status, is ineligible" do
+        participant.stub!(:pbs? => true, :eligible_for_pbs? => false, :has_eligible_ppg_status? => true)
+        participant.should be_ineligible
+      end
+
+      it "a pbs participant whose eligible for pbs is eligible" do
+        participant.stub!(:pbs? => true, :eligible_for_pbs? => true)
+        participant.should_not be_ineligible
       end
 
       it "a non_pbs participant whose eligible for birth cohort, yet does not have an eligible ppg_status, is ineligible" do
-        non_pbs
-        eligible_for_birth_cohort
-        does_not_have_eligible_ppg_status
-        participant.ineligible?.should be_true
+        participant.stub!(:pbs? => false, :eligible_for_birth_cohort? => true, :has_eligible_ppg_status? => false)
+        participant.should be_ineligible
       end
 
       it "a non_pbs participant whose eligible for pbs, yet does not have an eligible ppg_status, is ineligible" do
-        non_pbs
-        eligible_for_pbs
-        does_not_have_eligible_ppg_status
-        participant.ineligible?.should be_true
+        participant.stub!(:pbs? => false, :eligible_for_pbs? => true, :has_eligible_ppg_status? => false)
+        participant.should be_ineligible
       end
 
       it "a non_pbs participant who has an eligible ppg_status, is eligible" do
-        non_pbs
-        has_eligible_ppg_status
-        participant.ineligible?.should be_false
+        participant.stub!(:pbs? => false, :has_eligible_ppg_status? => true)
+        participant.should_not be_ineligible
       end
     end
   end
@@ -1731,7 +1717,7 @@ describe Participant do
 
       context "A person is ineligible when they have" do
         it "no responses for eligiblity questions (except provider frame questions)" do
-          @ineligible_participant.ineligible?.should be_true
+          @ineligible_participant.should be_ineligible
         end
 
         it "all ineligible responses" do
@@ -1741,7 +1727,7 @@ describe Participant do
           @negative_psu_county_eligible_response.update_attribute(:response_set, all_ineligible_response_set)
           @negative_provider_in_frame_response.update_attribute(:response_set, all_ineligible_response_set)
 
-          @ineligible_participant.ineligible?.should be_true
+          @ineligible_participant.should be_ineligible
         end
 
         it "multiple ineligible responses" do
@@ -1751,7 +1737,7 @@ describe Participant do
           @negative_psu_county_eligible_response.update_attribute(:response_set, multiple_ineligible_response_set)
           @negative_provider_in_frame_response.update_attribute(:response_set, multiple_ineligible_response_set)
 
-          @ineligible_participant.ineligible?.should be_true
+          @ineligible_participant.should be_ineligible
         end
 
         it "even one ineligible response" do
@@ -1761,20 +1747,20 @@ describe Participant do
           @positive_psu_county_eligible_response.update_attribute(:response_set, one_ineligible_response_set)
           @negative_provider_in_frame_response.update_attribute(:response_set, one_ineligible_response_set)
 
-          @ineligible_participant.ineligible?.should be_true
+          @ineligible_participant.should be_ineligible
         end
       end
 
       context "A person is eligible when they have" do
         it "all eligible responses" do
-          @eligible_participant.stub!(:birth_cohort => true)
+          @eligible_participant.stub!(:birth_cohort? => true)
           eligible_response_set = Factory(:response_set, :person => @eligible_person)
 
           @positive_age_eligible_response.update_attribute(:response_set, eligible_response_set)
           @positive_psu_county_eligible_response.update_attribute(:response_set, eligible_response_set)
           @positive_provider_in_frame_response.update_attribute(:response_set, eligible_response_set)
 
-          @eligible_participant.ineligible?.should be_false
+          @eligible_participant.should_not be_ineligible
         end
       end
     end


### PR DESCRIPTION
### Summary

Consolidating the transitioning of participant state with the method used during import from field, `Participant#advance`, removing `Participant#update_state_after_survey`.
##### Actions
- eliminated `Participant#eligible?`, replaced functionality with `Participant#ineligible?`
- refactored places where `Participant#eligible?` was used
- eliminated `SurveyorController#update_participant_based_on_survey`
- moved `#adjudicated_eligibility` from `SurveyorController#update_participant_based_on_survey` to inside `SurveyorController#surveyor_finish` => Eligibility is now determined after the end of each instrument
- spec'd behavior
