### PR TITLE
A mechanism for defining migrations to perform when changing the MDES version of a deployment, plus the migration for 3.0 to 3.2 (#3465)

### DIFF
--- a/db/ncs_codes-3.1.yml
+++ b/db/ncs_codes-3.1.yml
@@ -15187,6 +15187,9 @@
 - list_name: STUDY_INTRODCTN_OUTCOME_CL1
   local_code: 4
   display_text: Female undecided about SC contact
+- list_name: STUDY_INTRODCTN_OUTCOME_CL1
+  local_code: 5
+  display_text: Provider able to release patient information without contacting patient
 - list_name: STUDY_MNGMNT_TSK_TYPE_CL1
   local_code: -5
   display_text: Other

--- a/db/ncs_codes-3.2.yml
+++ b/db/ncs_codes-3.2.yml
@@ -912,6 +912,27 @@
 - list_name: BABY_FEEDING_PLAN_CL1
   local_code: 3
   display_text: Both breast milk and formula
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: -4
+  display_text: Missing in Error
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: -3
+  display_text: Legitimate Skip
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: -2
+  display_text: Don't Know
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: -1
+  display_text: Refused
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: 1
+  display_text: Breast milk
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: 2
+  display_text: Formula
+- list_name: BABY_FEEDING_PLAN_CL2
+  local_code: 3
+  display_text: Both breast milk and formula
 - list_name: BABY_FORMULA_CL1
   local_code: -4
   display_text: Missing in Error
@@ -6860,6 +6881,36 @@
 - list_name: INFORMATION_SOURCE_CL8
   local_code: 7
   display_text: No one
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: -7
+  display_text: Not Applicable
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: -5
+  display_text: Other
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: -4
+  display_text: Missing in Error
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 1
+  display_text: Person/Self
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 2
+  display_text: Provider
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 3
+  display_text: Household Member
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 4
+  display_text: Other Person Associated
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 5
+  display_text: Web
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 6
+  display_text: Returned Mail
+- list_name: INFORMATION_SOURCE_CL9
+  local_code: 7
+  display_text: Tracing vendor
 - list_name: INFORMATION_TYPE_CL1
   local_code: -4
   display_text: Missing in Error
@@ -7385,6 +7436,81 @@
   local_code: 21
   display_text: Taiwanese
 - list_name: LANGUAGE_CL10
+  local_code: 22
+  display_text: Turkish
+- list_name: LANGUAGE_CL11
+  local_code: -5
+  display_text: Other
+- list_name: LANGUAGE_CL11
+  local_code: -4
+  display_text: Missing in Error
+- list_name: LANGUAGE_CL11
+  local_code: -3
+  display_text: Legitimate Skip
+- list_name: LANGUAGE_CL11
+  local_code: -2
+  display_text: Don't Know
+- list_name: LANGUAGE_CL11
+  local_code: -1
+  display_text: Refused
+- list_name: LANGUAGE_CL11
+  local_code: 1
+  display_text: Spanish
+- list_name: LANGUAGE_CL11
+  local_code: 2
+  display_text: Arabic
+- list_name: LANGUAGE_CL11
+  local_code: 3
+  display_text: Chinese
+- list_name: LANGUAGE_CL11
+  local_code: 4
+  display_text: French
+- list_name: LANGUAGE_CL11
+  local_code: 5
+  display_text: French Creole
+- list_name: LANGUAGE_CL11
+  local_code: 6
+  display_text: German
+- list_name: LANGUAGE_CL11
+  local_code: 7
+  display_text: Italian
+- list_name: LANGUAGE_CL11
+  local_code: 8
+  display_text: Korean
+- list_name: LANGUAGE_CL11
+  local_code: 9
+  display_text: Polish
+- list_name: LANGUAGE_CL11
+  local_code: 10
+  display_text: Russian
+- list_name: LANGUAGE_CL11
+  local_code: 11
+  display_text: Tagalog
+- list_name: LANGUAGE_CL11
+  local_code: 12
+  display_text: Vietnamese
+- list_name: LANGUAGE_CL11
+  local_code: 13
+  display_text: Urdu
+- list_name: LANGUAGE_CL11
+  local_code: 14
+  display_text: Punjabi
+- list_name: LANGUAGE_CL11
+  local_code: 15
+  display_text: Bengali
+- list_name: LANGUAGE_CL11
+  local_code: 16
+  display_text: Farsi
+- list_name: LANGUAGE_CL11
+  local_code: 19
+  display_text: Mandarin
+- list_name: LANGUAGE_CL11
+  local_code: 20
+  display_text: Portuguese
+- list_name: LANGUAGE_CL11
+  local_code: 21
+  display_text: Taiwanese
+- list_name: LANGUAGE_CL11
   local_code: 22
   display_text: Turkish
 - list_name: LANGUAGE_CL2
@@ -8131,6 +8257,24 @@
 - list_name: MEDIA_TYPE_CL1
   local_code: 3
   display_text: Paper documents
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: -7
+  display_text: Not Applicable
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: -4
+  display_text: Missing in Error
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: -3
+  display_text: Legitimate Skip
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: 1
+  display_text: Electronic
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: 2
+  display_text: Paper
+- list_name: MEDICAL_RECORDS_CL1
+  local_code: 3
+  display_text: Combination - electronic and paper
 - list_name: MILK_TYPE_CL1
   local_code: -5
   display_text: Some other kind of milk
@@ -9928,6 +10072,9 @@
   local_code: 6
   display_text: Ineligible Dwelling Unit
 - list_name: PRACTICE_CHARACTERISTIC_CL1
+  local_code: -7
+  display_text: Not applicable
+- list_name: PRACTICE_CHARACTERISTIC_CL1
   local_code: -4
   display_text: Missing in Error
 - list_name: PRACTICE_CHARACTERISTIC_CL1
@@ -10002,6 +10149,48 @@
 - list_name: PRACTICE_CHARACTERISTIC_CL3
   local_code: 7
   display_text: Public clinic with university/academic affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: -5
+  display_text: Other
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: -4
+  display_text: Missing in Error
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: -3
+  display_text: Legitimate Skip
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: -2
+  display_text: Don't Know
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: -1
+  display_text: Refused
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 1
+  display_text: Private with no health system or university affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 2
+  display_text: Private with health system or university affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 3
+  display_text: Health system with no university affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 4
+  display_text: Health system with university affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 5
+  display_text: Academic medical center
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 6
+  display_text: Federally qualified health center
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 7
+  display_text: Public clinic with no university/academic affiliation
+- list_name: PRACTICE_CHARACTERISTIC_CL4
+  local_code: 8
+  display_text: Public clinic with university/academic affiliation
+- list_name: PRACTICE_LOAD_RANGE_CL1
+  local_code: -7
+  display_text: Not applicable
 - list_name: PRACTICE_LOAD_RANGE_CL1
   local_code: -4
   display_text: Missing in Error
@@ -10020,6 +10209,9 @@
 - list_name: PRACTICE_LOAD_RANGE_CL1
   local_code: 5
   display_text: 500 or more
+- list_name: PRACTICE_SIZE_RANGE_CL1
+  local_code: -7
+  display_text: Not applicable
 - list_name: PRACTICE_SIZE_RANGE_CL1
   local_code: -4
   display_text: Missing in Error
@@ -10591,6 +10783,21 @@
 - list_name: PROVIDER_STUDY_ROLE_CL2
   local_code: 10
   display_text: Provider will not participate in NCS
+- list_name: PROVIDER_STUDY_ROLE_CL2
+  local_code: 11
+  display_text: Provider agrees to collect cord blood sample
+- list_name: PROVIDER_STUDY_ROLE_CL2
+  local_code: 12
+  display_text: Provider agrees to collect placental tissue sample
+- list_name: PROVIDER_STUDY_ROLE_CL2
+  local_code: 13
+  display_text: Provider agrees to collect mother's blood sample
+- list_name: PROVIDER_STUDY_ROLE_CL2
+  local_code: 14
+  display_text: Provider agrees to collect mother's urine sample
+- list_name: PROVIDER_STUDY_ROLE_CL2
+  local_code: 15
+  display_text: Provider agrees to collect infant blood spot
 - list_name: PROVIDER_TYPE_CL1
   local_code: -5
   display_text: Other
@@ -15029,6 +15236,9 @@
 - list_name: STUDY_DATA_CLLCTN_TSK_TYPE_CL1
   local_code: 23
   display_text: PBS Frame Questionnaire
+- list_name: STUDY_DATA_CLLCTN_TSK_TYPE_CL1
+  local_code: 24
+  display_text: Training
 - list_name: STUDY_ENTRY_METHOD_CL1
   local_code: -5
   display_text: Other
@@ -15193,6 +15403,9 @@
 - list_name: STUDY_INTRODCTN_OUTCOME_CL1
   local_code: 4
   display_text: Female undecided about SC contact
+- list_name: STUDY_INTRODCTN_OUTCOME_CL1
+  local_code: 5
+  display_text: Provider able to release patient information without contacting patient
 - list_name: STUDY_MNGMNT_TSK_TYPE_CL1
   local_code: -5
   display_text: Other
@@ -15241,6 +15454,12 @@
 - list_name: STUDY_MNGMNT_TSK_TYPE_CL1
   local_code: 14
   display_text: PBS Frame Questionnaire
+- list_name: STUDY_MNGMNT_TSK_TYPE_CL1
+  local_code: 15
+  display_text: Hospital Recruitment
+- list_name: STUDY_MNGMNT_TSK_TYPE_CL1
+  local_code: 16
+  display_text: Training
 - list_name: STUDY_STAFF_TYPE_CL1
   local_code: -5
   display_text: Other

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -3,6 +3,7 @@ require 'ncs_navigator/core'
 module NcsNavigator::Core
   module Mdes
     autoload :Version, 'ncs_navigator/core/mdes/version'
+    autoload :VersionMigrator, 'ncs_navigator/core/mdes/version_migrator'
     autoload :MdesDate, 'ncs_navigator/core/mdes/mdes_date'
     autoload :MdesRecord, 'ncs_navigator/core/mdes/mdes_record'
     autoload :InstrumentOwner, 'ncs_navigator/core/mdes/instrument_owner'

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -7,7 +7,8 @@ module NcsNavigator::Core
     autoload :MdesDate,        'ncs_navigator/core/mdes/mdes_date'
     autoload :MdesRecord,      'ncs_navigator/core/mdes/mdes_record'
 
-    autoload :Version,         'ncs_navigator/core/mdes/version'
-    autoload :VersionMigrator, 'ncs_navigator/core/mdes/version_migrator'
+    autoload :Version,           'ncs_navigator/core/mdes/version'
+    autoload :VersionMigrator,   'ncs_navigator/core/mdes/version_migrator'
+    autoload :VersionMigrations, 'ncs_navigator/core/mdes/version_migrations'
   end
 end

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -2,11 +2,12 @@ require 'ncs_navigator/core'
 
 module NcsNavigator::Core
   module Mdes
-    autoload :Version, 'ncs_navigator/core/mdes/version'
-    autoload :VersionMigrator, 'ncs_navigator/core/mdes/version_migrator'
-    autoload :MdesDate, 'ncs_navigator/core/mdes/mdes_date'
-    autoload :MdesRecord, 'ncs_navigator/core/mdes/mdes_record'
-    autoload :InstrumentOwner, 'ncs_navigator/core/mdes/instrument_owner'
     autoload :HumanReadablePublicIdGenerator, 'ncs_navigator/core/mdes/human_readable_public_id_generator'
+    autoload :InstrumentOwner, 'ncs_navigator/core/mdes/instrument_owner'
+    autoload :MdesDate,        'ncs_navigator/core/mdes/mdes_date'
+    autoload :MdesRecord,      'ncs_navigator/core/mdes/mdes_record'
+
+    autoload :Version,         'ncs_navigator/core/mdes/version'
+    autoload :VersionMigrator, 'ncs_navigator/core/mdes/version_migrator'
   end
 end

--- a/lib/ncs_navigator/core/mdes/version_migrations.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations.rb
@@ -1,0 +1,7 @@
+require 'ncs_navigator/core'
+
+module NcsNavigator::Core::Mdes
+  module VersionMigrations
+    autoload :Basic, 'ncs_navigator/core/mdes/version_migrations/basic'
+  end
+end

--- a/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
@@ -1,0 +1,43 @@
+require 'ncs_navigator/core'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  ##
+  # A migrator that does the minimum steps that are required for any version
+  # change:
+  #
+  # * Change the code lists to the ones for the new version
+  # * Change the stored version number to the new version
+  #
+  # N.b.: using this migration for a pair of versions is a claim that there are
+  # NO semantic modifications of specified values between them. DO NOT use it
+  # for any pair of versions without rigorously verifying that this is the case.
+  #
+  # @see VersionMigrator
+  class Basic
+    attr_reader :from, :to
+
+    def initialize(from_version, to_version)
+      @from = from_version
+      @to = to_version
+    end
+
+    def run
+      ActiveRecord::Base.transaction do
+        switch_code_lists
+        change_registered_version
+      end
+    end
+
+    def switch_code_lists
+      NcsNavigator::Core::MdesCodeListLoader.
+        new(:mdes_version => to, :interactive => true).
+        load_from_yaml
+    end
+    protected :switch_code_lists
+
+    def change_registered_version
+      NcsNavigator::Core::Mdes::Version.change!(to)
+    end
+    protected :change_registered_version
+  end
+end

--- a/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
@@ -16,9 +16,10 @@ module NcsNavigator::Core::Mdes::VersionMigrations
   class Basic
     attr_reader :from, :to
 
-    def initialize(from_version, to_version)
+    def initialize(from_version, to_version, options={})
       @from = from_version
       @to = to_version
+      @interactive = options[:interactive]
     end
 
     def run
@@ -30,7 +31,7 @@ module NcsNavigator::Core::Mdes::VersionMigrations
 
     def switch_code_lists
       NcsNavigator::Core::MdesCodeListLoader.
-        new(:mdes_version => to, :interactive => true).
+        new(:mdes_version => to, :interactive => @interactive).
         load_from_yaml
     end
     protected :switch_code_lists

--- a/lib/ncs_navigator/core/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrator.rb
@@ -16,15 +16,23 @@ module NcsNavigator::Core::Mdes
     # - #from: the version this migration expects Cases to be in before it
     #   starts executing.
     # - #to: the version this migration will leave Cases in after #run is complete.
-    KNOWN_MIGRATIONS = [
-    ]
+    #
+    # @return [Array<#run,#to#from>]
+    def self.default_migrations(options={})
+      [
+        # No semantic differences 3.0 -> 3.2
+        VersionMigrations::Basic.new('3.0', '3.2', options)
+      ]
+    end
 
     attr_reader :start_version, :known_migrations
 
     def initialize(options={})
-      @start_version = options.delete(:start_version) || NcsNavigatorCore.mdes_version.number
-      @known_migrations = options.delete(:known_migrations) || KNOWN_MIGRATIONS
       @interactive = options.delete(:interactive)
+      @start_version = options.delete(:start_version) ||
+        NcsNavigatorCore.mdes_version.number
+      @known_migrations = options.delete(:known_migrations) ||
+        self.class.default_migrations(:interactive => @interactive)
     end
 
     ##

--- a/lib/ncs_navigator/core/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrator.rb
@@ -90,9 +90,12 @@ module NcsNavigator::Core::Mdes
       end
 
       all.each do |migration|
-        $stderr.print "Migrating from #{migration.from} to #{migration.to}..." if interactive?
+        $stderr.puts "Migrating from #{migration.from} to #{migration.to}." if interactive?
         migration.run
-        $stderr.puts "done." if interactive?
+      end
+
+      if interactive?
+        $stderr.puts "MDES version migration complete. Registered MDES version for this deployment is now #{Version.new.number}."
       end
     end
   end

--- a/lib/ncs_navigator/core/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrator.rb
@@ -1,0 +1,91 @@
+module NcsNavigator::Core::Mdes
+  ##
+  # The component which takes an existing Cases deployment and safely
+  # updates its MDES version. This may involve stepwise migration through
+  # several intermediate versions.
+  class VersionMigrator
+    ##
+    # The objects registered here migrate Cases from one MDES version to the
+    # an adjacent one. Each migration object must implement three methods:
+    #
+    # - #run: the method that actually performs the migration. It must do
+    #   everything that's required to safely change Cases from one version to
+    #   the next. In addition to whatever version-specific migrations are
+    #   required, this includes changing the stored MDES version value and
+    #   updating the code lists.
+    # - #from: the version this migration expects Cases to be in before it
+    #   starts executing.
+    # - #to: the version this migration will leave Cases in after #run is complete.
+    KNOWN_MIGRATIONS = [
+    ]
+
+    attr_reader :start_version, :known_migrations
+
+    def initialize(options={})
+      @start_version = options.delete(:start_version) || NcsNavigatorCore.mdes_version.number
+      @known_migrations = options.delete(:known_migrations) || KNOWN_MIGRATIONS
+      @interactive = options.delete(:interactive)
+    end
+
+    ##
+    # Returns the chain of migration instances which take the system from
+    # {#start_version} to {target_version}. If no chain can be determined
+    # it throws an exception.
+    #
+    # @param [String] target_version
+    # @return [Array<#to,#from,#run>] the migrations to use
+    def migrations(target_version)
+      unless known_migrations.collect(&:to).include?(target_version)
+        fail "There is no migration path to #{target_version} from any version."
+      end
+      unless known_migrations.collect(&:from).include?(start_version)
+        fail "There is no migration path from #{start_version} to any version."
+      end
+
+      best_path = migration_paths(start_version, target_version).
+        sort_by { |path| path.size }.
+        first
+
+      best_path or fail "There is no migration path from #{start_version} to #{target_version}."
+    end
+
+    def migration_paths(from, to)
+      if sole_migration = known_migrations.find { |m| m.to == to && m.from == from }
+        return [[sole_migration]]
+      end
+
+      known_migrations.
+        select { |m| m.from == from }.
+        each_with_object([]) { |m, acc| acc.concat(migration_paths(m.to, to).reject { |sub| sub.empty? }.collect { |sub| [m] + sub }) }.
+        select { |path| path.last.try(:to) == to }
+    end
+    private :migration_paths
+
+    def interactive?
+      @interactive
+    end
+    private :interactive?
+
+    ##
+    # Determines the appropriate migrations to execute, then executes them.
+    # Throws an exception if no path from {#start_version} to {target_version}.
+    #
+    # @return [void]
+    def migrate!(target_version)
+      all = migrations(target_version)
+
+      if interactive?
+        steps = [start_version] + migrations(target_version).collect(&:to)
+        if steps.size > 2
+          $stderr.puts "Migrating from #{steps.first} to #{steps.last} via #{steps[1,steps.size - 2].join(', ')}"
+        end
+      end
+
+      all.each do |migration|
+        $stderr.print "Migrating from #{migration.from} to #{migration.to}..." if interactive?
+        migration.run
+        $stderr.puts "done." if interactive?
+      end
+    end
+  end
+end

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -50,5 +50,12 @@ namespace :mdes do
     task :set, [:version] => [:base] do |t, args|
       NcsNavigator::Core::Mdes::Version.set!(args[:version])
     end
+
+    desc 'Convert this instance to the named MDES version'
+    task :migrate, [:to_version] => [:environment] do |t, args|
+      fail "Please specify :to_version" unless args[:to_version]
+      NcsNavigator::Core::Mdes::VersionMigrator.
+        new(:interactive => true).migrate!(args[:to_version])
+    end
   end
 end

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -12,7 +12,7 @@ namespace :mdes do
 
     desc 'Generate the code list YAML file for the all supported MDES versions'
     task :all_yaml => :base do
-      %w(2.0 2.1 2.2 3.0 3.1).each do |mdes_version|
+      %w(2.0 2.1 2.2 3.0 3.1 3.2).each do |mdes_version|
         $stderr.print "Creating for #{mdes_version}..."; $stderr.flush
         NcsNavigator::Core::MdesCodeListLoader.new(:interactive => true, :mdes_version => mdes_version).create_yaml
         $stderr.puts 'done.'

--- a/spec/lib/ncs_navigator/core/mdes/version_migrations/basic_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrations/basic_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  describe Basic do
+    let(:migrator) { Basic.new(NcsNavigatorCore.mdes_version.number, '2.2') }
+
+    describe '#initialize' do
+      it 'sets #from' do
+        migrator.from.should == NcsNavigatorCore.mdes_version.number
+      end
+
+      it 'sets #to' do
+        migrator.to.should == '2.2'
+      end
+    end
+
+    describe '#run' do
+      before do
+        NcsNavigator::Core::Mdes::Version.set!(migrator.from)
+        migrator.run
+      end
+
+      after do
+        # restore the code list to the current version
+        NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+      end
+
+      it 'updates the MDES version in the database' do
+        NcsNavigator::Core::Mdes::Version.new.number.should == migrator.to
+      end
+
+      let(:target_version_code_lists) {
+        NcsNavigator::Mdes(migrator.to).types.
+          select { |vt| vt.code_list }.collect { |vt| vt.name.upcase }.sort
+      }
+
+      def select_one_column(query)
+        ActiveRecord::Base.connection.select_all(query).
+          collect { |row| row.values.first }
+      end
+
+      it "changes the code lists to the targeted version's lists" do
+        select_one_column("SELECT DISTINCT list_name FROM ncs_codes ORDER BY list_name").
+          should == target_version_code_lists
+      end
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/core/mdes/version_migrator_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrator_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Mdes
+  describe VersionMigrator do
+    def dummy_migration(from, to)
+      stub("dummy_migration #{from} -> #{to}").tap do |m|
+        m.stub!(:from => from, :to => to)
+      end
+    end
+
+    describe '#initialize' do
+      before do
+        NcsNavigatorCore.stub!(:mdes_version => Version.new('1.1'))
+      end
+
+      describe ':start_version' do
+        it 'can be set' do
+          VersionMigrator.new(:start_version => '7.8').start_version.should == '7.8'
+        end
+
+        it 'defaults to the current deployed version' do
+          VersionMigrator.new.start_version.should == '1.1'
+        end
+      end
+
+      describe ':known_migrations' do
+        it 'can be set' do
+          VersionMigrator.new(:known_migrations => [dummy_migration('3', 'forks'), dummy_migration('tacos', '8')]).
+            known_migrations.collect(&:from).should == %w(3 tacos)
+        end
+
+        it 'defaults to the KNOWN_MIGRATIONS constant' do
+          VersionMigrator.new.known_migrations.should be(VersionMigrator::KNOWN_MIGRATIONS)
+        end
+      end
+    end
+
+    describe '#migrations' do
+      let(:known_migrations) {
+        [
+          dummy_migration('8.0', '8.1'),
+          dummy_migration('8.1', '8.2'),
+          dummy_migration('8.2', '8.3'),
+          dummy_migration('8.3', '9.0'),
+          dummy_migration('8.1', '9.0'),
+          dummy_migration('9.0', '9.1'),
+          dummy_migration('9.0', '9.2'),
+          dummy_migration('9.1', '9.2'),
+          dummy_migration('9.1', '10.0'),
+          dummy_migration('9.5', '11.0'),
+        ]
+      }
+
+      let(:options) {
+        { :known_migrations => known_migrations, :start_version => '8.1' }
+      }
+
+      let(:migrator) {
+        VersionMigrator.new(options)
+      }
+
+      def series_string(target_version)
+        migrator.migrations(target_version).collect { |m| [m.from, m.to].join(" -> ") }.join(", ")
+      end
+
+      it 'can find a single migration that matches the request' do
+        series_string('9.0').should == "8.1 -> 9.0"
+      end
+
+      it 'can find a migration chain that requires several migrations' do
+        series_string('8.3').should == "8.1 -> 8.2, 8.2 -> 8.3"
+      end
+
+      it 'picks the shortest path when there are several options' do
+        series_string('9.2').should == "8.1 -> 9.0, 9.0 -> 9.2"
+      end
+
+      it 'throws an exception if there is no migration chain because the target version does not exist' do
+        expect { migrator.migrations('9.3') }.to raise_error("There is no migration path to 9.3 from any version.")
+      end
+
+      it 'throws an exception if there is no migration chain because there is a missing link' do
+        expect { migrator.migrations('11.0') }.to raise_error("There is no migration path from 8.1 to 11.0.")
+      end
+
+      it 'throws an exception if there is no migration chain because the start version does not exist' do
+        options[:start_version] = '8.5'
+
+        expect { migrator.migrations('9.0') }.to raise_error("There is no migration path from 8.5 to any version.")
+      end
+    end
+
+    describe '#migrate!' do
+      let(:known_migrations) {
+        [
+          dummy_migration('8.0', '8.1'),
+          dummy_migration('8.1', '8.2'),
+          m82_83,
+          m83_90,
+          dummy_migration('8.1', '9.0'),
+          m90_91,
+          dummy_migration('9.0', '9.2'),
+          dummy_migration('9.1', '9.2'),
+          dummy_migration('9.1', '10.0'),
+          dummy_migration('9.5', '11.0'),
+        ]
+      }
+
+      let(:options) {
+        { :known_migrations => known_migrations, :start_version => '8.2' }
+      }
+
+      let(:migrator) {
+        VersionMigrator.new(options)
+      }
+
+      let(:m82_83) { dummy_migration('8.2', '8.3') }
+      let(:m83_90) { dummy_migration('8.3', '9.0') }
+      let(:m90_91) { dummy_migration('9.0', '9.1') }
+
+      let(:expected_used_migrations) { [m82_83, m83_90, m90_91] }
+
+      it 'runs exactly the appropriate migrations' do
+        # RSpec mocks can't verify order across objects, so this will have to be
+        # good enough.
+        expected_used_migrations.each { |m| m.should_receive(:run) }
+        (known_migrations - expected_used_migrations).each { |m| m.should_not_receive(:run) }
+
+        migrator.migrate!('9.1')
+      end
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/core/mdes/version_migrator_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrator_spec.rb
@@ -29,8 +29,11 @@ module NcsNavigator::Core::Mdes
             known_migrations.collect(&:from).should == %w(3 tacos)
         end
 
-        it 'defaults to the KNOWN_MIGRATIONS constant' do
-          VersionMigrator.new.known_migrations.should be(VersionMigrator::KNOWN_MIGRATIONS)
+        it 'defaults to the list returned by .default_migrations' do
+          expected_defaults = VersionMigrator.default_migrations.collect { |m| [m.from, m.to] }
+          actual_defaults   = VersionMigrator.new.known_migrations.collect { |m| [m.from, m.to] }
+
+          actual_defaults.should == expected_defaults
         end
       end
     end

--- a/spec/lib/ncs_navigator/core/mdes/version_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_spec.rb
@@ -67,12 +67,31 @@ module NcsNavigator::Core::Mdes
 
         it 'throws an exception if the new version is different' do
           expect { Version.set!('2.1') }.
-            should raise_error(/This deployment already has an MDES version \(2\.0\)\. Upgrades aren't implemented yet \(#2090\)\./)
+            should raise_error(/This deployment already has an MDES version \(2\.0\)\. Use a migrator to change MDES versions\./)
         end
 
         it 'does nothing if the new version is the same' do
           expect { Version.set!('2.0') }.should_not raise_error
         end
+      end
+    end
+
+    describe '.change!' do
+      it 'fails if changed to nil' do
+        expect { Version.change!(nil) }.should raise_error(/MDES version cannot be blank./)
+      end
+
+      it 'fails if no version is set' do
+        remove_db_version_number
+
+        expect { Version.change!('3.0') }.to raise_error('No MDES version set for this deployment yet.')
+      end
+
+      it 'when a version is already set it changes the version' do
+        set_db_version_number '2.0'
+
+        Version.change!('2.1')
+        Version.new.number.should == '2.1'
       end
     end
   end


### PR DESCRIPTION
Defines `Mdes::VersionMigrator`, a utility which has a list of possible MDES version migrations and which can find the correct series to go from the current version to a requested version.

Also includes the migration for MDES 3.0 to 3.2. This is an example of the simplest possible migration — it has no semantic changes to existing value elements. A generic migration implementation is provided for situations like this one. An instance of that generic migration is registered as applying to a 3.0 to 3.2 conversion.
