### PR TITLE
Change all recruited women to MDES 3.2's p_type 14 during version migration. (#3513)

### DIFF
--- a/lib/ncs_navigator/core/mdes/version_migrations.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations.rb
@@ -2,6 +2,7 @@ require 'ncs_navigator/core'
 
 module NcsNavigator::Core::Mdes
   module VersionMigrations
-    autoload :Basic, 'ncs_navigator/core/mdes/version_migrations/basic'
+    autoload :Basic,               'ncs_navigator/core/mdes/version_migrations/basic'
+    autoload :ThreeZeroToThreeTwo, 'ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two'
   end
 end

--- a/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two.rb
@@ -1,0 +1,25 @@
+require 'ncs_navigator/core'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  class ThreeZeroToThreeTwo < Basic
+    def initialize(options={})
+      super('3.0', '3.2', options)
+    end
+
+    def run_after_code_list_changes
+      # The recruitment strategy is always PBS for MDES 3.0, otherwise this
+      # would need to be guarded.
+      change_existing_participants_to_use_new_pbs_participant_type
+    end
+    protected :run_after_code_list_changes
+
+    def change_existing_participants_to_use_new_pbs_participant_type
+      # Have do do this inefficient way to ensure changes are logged
+      Participant.where(:p_type_code => 3).order(:id).find_each do |p|
+        p.p_type_code = 14
+        p.save!
+      end
+    end
+    private :change_existing_participants_to_use_new_pbs_participant_type
+  end
+end

--- a/lib/ncs_navigator/core/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrator.rb
@@ -20,8 +20,7 @@ module NcsNavigator::Core::Mdes
     # @return [Array<#run,#to#from>]
     def self.default_migrations(options={})
       [
-        # No semantic differences 3.0 -> 3.2
-        VersionMigrations::Basic.new('3.0', '3.2', options)
+        VersionMigrations::ThreeZeroToThreeTwo.new(options)
       ]
     end
 

--- a/spec/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  describe ThreeZeroToThreeTwo do
+    let(:migration) {
+      ThreeZeroToThreeTwo.new
+    }
+
+    it 'goes from 3.0' do
+      migration.from.should == '3.0'
+    end
+
+    it 'goes to 3.2' do
+      migration.to.should == '3.2'
+    end
+
+    describe '#run' do
+      let!(:p_neg4) { Factory(:participant, :p_type_code => -4) }
+      let!(:p1) { Factory(:participant, :p_type_code => 1) }
+      let!(:p2) { Factory(:participant, :p_type_code => 2) }
+      let!(:p3) { Factory(:participant, :p_type_code => 3) }
+      let!(:p4) { Factory(:participant, :p_type_code => 4) }
+      let!(:p5) { Factory(:participant, :p_type_code => 5) }
+      let!(:p6) { Factory(:participant, :p_type_code => 6) }
+
+      before do
+        NcsNavigator::Core::Mdes::Version.set!(migration.from)
+        with_versioning do
+          migration.run
+        end
+      end
+
+      after do
+        # restore the code list to the current version
+        NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+      end
+
+      describe 'changing p_type' do
+        it 'changes eligible pregnant women to PBS Provider participants' do
+          p3.reload.p_type_code.should == 14
+        end
+
+        it 'leaves all other p_types alone' do
+          [p_neg4, p1, p2, p4, p5, p6].collect { |p| p.reload.p_type_code }.
+            should == [-4, 1, 2, 4, 5, 6]
+        end
+
+        describe 'auditing' do
+          let(:preg_woman_revision) { p3.reload.versions.last }
+          let(:preg_woman_changes) { YAML.load(preg_woman_revision.object_changes) }
+
+          it 'audits the change for eligible pregnant women' do
+            preg_woman_changes['p_type_code'].should == [3, 14]
+          end
+
+          it 'records the change as coming from the 3.0 to 3.2 migration' do
+            preg_woman_revision.whodunnit.should == described_class.to_s
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
MDES 3.2 introduces two special p_types for PBS-recruited participants. One of them -- 14 -- applies to all women who could have been recruited under MDES 3.0. MDES 3.0 was only ever used for PBS, so it is safe to convert all PBS-eligible women to p_type 14 when upgrading to MDES 3.2.
