### PR TITLE
Introduce NcsNavigator::Core::Surveyor::SurveyTaker and use it in specs

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -31,6 +31,10 @@ class Response < ActiveRecord::Base
 
   default_scope includes(:answer, :question)
 
+  with_options(:as => :system) do |r|
+    r.attr_accessible :answer, :question, :value
+  end
+
   def self.for_merge
     includes(:answer, :question, :response_set)
   end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -31,6 +31,9 @@ class Survey < ActiveRecord::Base
 
   attr_accessible :instrument_version, :instrument_type
 
+  has_many :questions, :through => :sections
+  has_many :answers, :through => :questions
+
   def self.most_recent
     maximums = unscoped.select(['title AS t', 'MAX(survey_version) AS ver']).
       group('t')

--- a/lib/ncs_navigator/core/surveyor.rb
+++ b/lib/ncs_navigator/core/surveyor.rb
@@ -1,4 +1,5 @@
 module NcsNavigator::Core::Surveyor
   autoload :HasPublicId,    'ncs_navigator/core/surveyor/has_public_id'
   autoload :ResponseValue,  'ncs_navigator/core/surveyor/response_value'
+  autoload :SurveyTaker,    'ncs_navigator/core/surveyor/survey_taker'
 end

--- a/lib/ncs_navigator/core/surveyor/survey_taker.rb
+++ b/lib/ncs_navigator/core/surveyor/survey_taker.rb
@@ -1,0 +1,275 @@
+module NcsNavigator::Core::Surveyor
+  ##
+  # Records responses for a survey.  This is intended to be used by any
+  # process in Cases that must deal with filling out surveys.  Examples:
+  #
+  # - response set prepopulation
+  # - tests for operational data extractors
+  module SurveyTaker
+    ##
+    # Records responses for a survey in a given response set.  If the response
+    # set is already associated with a survey, you can omit the survey
+    # parameter.
+    #
+    #
+    # Usage
+    # -----
+    #
+    # You MUST pass a block to this method.  The block will receive an object
+    # for recording answers in the response set.  Usage looks like this:
+    #
+    #     respond(rs) do |r|
+    #       r.answer 'prepopulated_mode_of_contact', 'cati'
+    #     end
+    #
+    # You can set additional data beyond an answer choice:
+    #
+    #     respond(rs) do |r|
+    #       r.answer 'monthly_income', 'other', :value => 9001
+    #     end
+    #
+    # Answers are matched using their reference identifiers, except in the case
+    # where only one answer is present for a given question and that answer has
+    # no reference identifier.  In that case, the reference identifier on the
+    # answer is optional:
+    #
+    #     q_foo 'what?'
+    #     a :string
+    #
+    #     respond(rs) do |r|
+    #       r.answer 'foo', :value => 'bar'  # => will fill in "bar" for foo's single answer
+    #     end
+    #
+    # If foo had more than one answer _or_ that single answer had a reference
+    # identifier, a SurveyTaker::UnresolvableAnswer would be raised.
+    #
+    # By default, questions are also matched using reference identifiers.  If
+    # needed, you can use data export identifiers to match questions:
+    #
+    #     respond(rs) do |r|
+    #       r.using_data_export_identifiers do |r|
+    #         r.answer "#{BABY_NAME_PREFIX}.BABY_LNAME", :value => person.last_name
+    #       end
+    #
+    #       # Naturally, you can switch back and forth.  This'll use reference
+    #       # identifiers.
+    #       r.answer "prepopulated_mode_of_contact", "cati"
+    #     end
+    #
+    #
+    # Data access behavior
+    # --------------------
+    #
+    # Because surveys can potentially be very large, this method does not
+    # perform any database access until the supplied block returns.
+    #
+    # Once it returns, all referenced questions and answers are retrieved
+    # according to their reference or data export identifiers.  Answer lookup
+    # is scoped by question.  Responses are then built (not persisted) in the
+    # supplied response set.  To save those responses, invoke #save on the
+    # response set.
+    #
+    #
+    # Errors raised
+    # -------------
+    #
+    # A SurveyTaker::UnresolvableQuestion will be raised for unresolvable
+    # questions.
+    # A SurveyTaker::UnresolvableAnswer will be raised for unresolvable
+    # answers.
+    # A SurveyTaker::AmbiguousAnswer will raised when an answer cannot be
+    # unambiguously resolved, i.e. when no answer reference identifier is
+    # provided and the question has multiple answers with null reference
+    # identifiers.
+    #
+    # @return [ResponseSet] the given response set, modified
+    def respond(rs, survey = rs.survey)
+      rs.tap do
+        rp = Respondent.new(survey)
+
+        yield rp
+
+        Resolver.new(rp).resolve do |rh|
+          rs.responses.build(rh, :as => :system)
+        end
+      end
+    end
+
+    ##
+    # @private
+    class Respondent
+      attr_reader :survey
+
+      ##
+      # Promises made on a question's data export identifier.
+      attr_reader :dindex
+
+      ##
+      # Promises made on a question's reference identifier.
+      attr_reader :rindex
+
+      ##
+      # All recorded promises.
+      attr_reader :promises
+
+      def initialize(survey)
+        @dindex = {}
+        @promises = []
+        @rindex = {}
+        @survey = survey
+        @index = rindex
+      end
+
+      ##
+      # Ad-hoc polymorphism can be a mess, so here's a quick refresher on the
+      # handled forms of answer:
+      #
+      #   answer(qref, aref, :value => foo)
+      #   answer(qref, aref)
+      #   answer(qref, :value => foo)
+      def answer(*args)
+        if args.length == 3
+          valid_keywords!(args[2])
+          record(args[0], args[1], args[2][:value])
+        elsif args.length == 2
+          if args[1].respond_to?(:has_key?)
+            valid_keywords!(args[1])
+            record(args[0], nil, args[1][:value])
+          else
+            record(args[0], args[1], nil)
+          end
+        else
+          raise ArgumentError, "wrong number of arguments (#{args.length} for 2 or 3)"
+        end
+      end
+
+      def using_data_export_identifiers
+        begin
+          @index = dindex
+          yield self
+        ensure
+          @index = rindex
+        end
+      end
+
+      private
+
+      def valid_keywords!(kw)
+        if !kw.respond_to?(:keys)
+          raise ArgumentError, "expected keyword arguments, not #{kw.inspect}"
+
+          if !kw.keys.blank? && kw.keys != [:value]
+            raise ArgumentError, "unrecognized keyword arguments: #{kw.keys.inspect}"
+          end
+        end
+      end
+
+      def record(qref, aref, value)
+        Response.new(qref, aref, value).tap do |r|
+          @index[qref] ||= []
+          @index[qref] << r
+          @promises << r
+        end
+      end
+
+      class Response < Struct.new(:qref, :aref, :value, :question, :answer)
+        def question_id
+          question.id
+        end
+      end
+    end
+
+    ##
+    # @private
+    class Resolver
+      extend Forwardable
+
+      def_delegators :@respondent, :rindex, :dindex, :promises, :survey
+
+      def initialize(respondent)
+        @respondent = respondent
+      end
+
+      def resolve
+        resolve_questions
+        resolve_answers
+
+        promises.each do |p|
+          yield({ :answer => p.answer, :question => p.question, :value => p.value })
+        end
+      end
+
+      # Wouldn't it be nice if ActiveRecord scopes handled ORs?
+      def resolve_questions
+        eds = dindex.keys
+        ers = rindex.keys
+
+        qscope = survey.questions
+        qd = (qscope.where(:data_export_identifier => eds) unless eds.empty?) || []
+        qr = (qscope.where(:reference_identifier => ers) unless ers.empty?) || []
+
+        qrefs_ok!(eds, qd.map(&:data_export_identifier))
+        qrefs_ok!(ers, qr.map(&:reference_identifier))
+
+        fulfill(qd, dindex) { |q| q.data_export_identifier }
+        fulfill(qr, rindex) { |q| q.reference_identifier }
+      end
+
+      def fulfill(questions, index)
+        questions.each do |q|
+          index[yield q].each { |p| p.question = q }
+        end
+      end
+
+      def resolve_answers
+        ers = promises.map(&:aref)
+        eqs = promises.map(&:question_id)
+
+        as = survey.answers.where(:reference_identifier => ers,
+                                  :question_id => eqs)
+
+        index = as.group_by { |a| [a.question_id, a.reference_identifier] }
+
+        arefs_ok!(ers, index)
+
+        promises.each do |p|
+          p.answer = index[[p.question_id, p.aref]].first
+        end
+      end
+
+      def qrefs_ok!(expected, actual)
+        refs_ok!(expected, actual, UnresolvableQuestion)
+      end
+
+      def arefs_ok!(expected, aindex)
+        refs_ok!(expected, aindex.keys.map(&:last), UnresolvableAnswer)
+        unambiguous!(aindex)
+      end
+
+      def refs_ok!(expected, actual, error)
+        diff = expected - actual
+
+        if !diff.empty?
+          raise error, "Unresolvable identifiers: #{diff.inspect}"
+        end
+      end
+
+      def unambiguous!(aindex)
+        ambiguous = aindex.select { |_, c| c.length > 1 }
+
+        if !ambiguous.empty?
+          raise AmbiguousAnswer, "Ambiguous (question ID, aref) pairs: #{ambiguous.keys.inspect}"
+        end
+      end
+    end
+
+    class UnresolvableQuestion < StandardError
+    end
+
+    class UnresolvableAnswer < StandardError
+    end
+
+    class AmbiguousAnswer < StandardError
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/core/mustache/instrument_context_spec.rb
+++ b/spec/lib/ncs_navigator/core/mustache/instrument_context_spec.rb
@@ -194,8 +194,8 @@ module NcsNavigator::Core::Mustache
 
       describe ".response_for" do
         it "returns the value of the response for the given data_export_identifier" do
-          take_survey(@survey, @response_set) do |a|
-            a.str baby_fname, 'Mary'
+          take_survey(@survey, @response_set) do |r|
+            r.a baby_fname, 'Mary'
           end
           instrument_context.response_for(baby_fname).should == 'Mary'
         end
@@ -600,25 +600,25 @@ module NcsNavigator::Core::Mustache
         let(:birth_deliver) { "BIRTH_VISIT_3.BIRTH_DELIVER" }
 
         it "returns 'Hospital' as the most recent response for BIRTH_VISIT_3.BIRTH_DELIVER" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             at_home = mock(NcsCode, :local_code => 1)
-            a.choice birth_deliver, at_home
+            r.a birth_deliver, at_home
           end
           instrument_context.birthing_place.should == 'hospital'
         end
 
         it "returns 'Birthing center' as the most recent response for BIRTH_VISIT_3.BIRTH_DELIVER" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             at_home = mock(NcsCode, :local_code => 2)
-            a.choice birth_deliver, at_home
+            r.a birth_deliver, at_home
           end
           instrument_context.birthing_place.should == 'birthing center'
         end
 
         it "returns 'Other place' as the most recent response for BIRTH_VISIT_3.BIRTH_DELIVER" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             at_home = mock(NcsCode, :local_code => -5)
-            a.choice birth_deliver, at_home
+            r.a birth_deliver, at_home
           end
           instrument_context.birthing_place.should == 'other place'
         end
@@ -679,10 +679,10 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Does' and name or baby if single birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             mom = @response_set.person
             mom.participant.p_type_code = 1 # 1 age eligilble woman
@@ -698,8 +698,8 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'When' and 'name or baby' if single birth, released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             mom = @response_set.person
 
@@ -717,18 +717,18 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Do your babies' if multiple birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "Do your babies live with you?"
           end
 
           it "returns 'When your babies leave the' if multiple birth, and released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "When your babies leave the "+ instrument_context.birthing_place + " will " + instrument_context.he_she_they + " live with you?"
@@ -752,10 +752,10 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Does' and name or baby if single birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             mom = @response_set.person
             mom.participant.p_type_code = 1 # 1 age eligilble woman
@@ -771,8 +771,8 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'When' and 'name or baby' if single birth, released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             mom = @response_set.person
 
@@ -790,18 +790,18 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Do your babies' if multiple birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "Do your babies live with you?"
           end
 
           it "returns 'When your babies leave the' if multiple birth, and released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "When your babies leave the "+ instrument_context.birthing_place + " will " + instrument_context.he_she_they + " live with you?"
@@ -825,10 +825,10 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Does' and name or baby if single birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             mom = @response_set.person
             mom.participant.p_type_code = 1 # 1 age eligilble woman
@@ -844,8 +844,8 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'When' and 'name or baby' if single birth, released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             mom = @response_set.person
 
@@ -863,18 +863,18 @@ module NcsNavigator::Core::Mustache
           end
 
           it "returns 'Do your babies' if multiple birth, released is 'yes' and delivered 'at home'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.yes release
+            take_survey(@survey, @response_set) do |r|
+              r.yes release
               at_home = mock(NcsCode, :local_code => 3)
-              a.choice birth_deliver, at_home
+              r.a birth_deliver, at_home
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "Do your babies live with you?"
           end
 
           it "returns 'When your babies leave the' if multiple birth, and released is 'no'"  do
-            take_survey(@survey, @response_set) do |a|
-              a.no release
+            take_survey(@survey, @response_set) do |r|
+              r.no release
             end
             create_multiple_birth
             instrument_context.do_when_will_live_with_you.should == "When your babies leave the "+ instrument_context.birthing_place + " will " + instrument_context.he_she_they + " live with you?"
@@ -1155,8 +1155,8 @@ module NcsNavigator::Core::Mustache
 
       describe ".f_fname" do
         it "returns the entered father's first name" do
-          take_survey(@survey, @response_set) do |a|
-            a.str "PREG_VISIT_1_SAQ_2.FATHER_NAME", 'Fred Sanford'
+          take_survey(@survey, @response_set) do |r|
+            r.a "PREG_VISIT_1_SAQ_2.FATHER_NAME", 'Fred Sanford'
           end
           instrument_context.f_fname.should == "Fred"
         end
@@ -1400,8 +1400,8 @@ module NcsNavigator::Core::Mustache
         let(:work_name) { "PREG_VISIT_1_3.WORK_NAME" }
 
         it "returns work name as the most recent response for PREG_VISIT_1_3.WORK_NAME" do
-          take_survey(@survey, @response_set) do |a|
-            a.str work_name, 'NWU'
+          take_survey(@survey, @response_set) do |r|
+            r.a work_name, 'work_name', :value => 'NWU'
           end
           # @response_set.instrument.event = Factory(:event, :event_type_code => 15)
           instrument_context.work_place_name.should == 'NWU'
@@ -1419,8 +1419,8 @@ module NcsNavigator::Core::Mustache
 
 
         it "returns work name as the most recent response for PREG_VISIT_2_3.WORK_NAME" do
-          take_survey(@survey, @response_set) do |a|
-            a.str work_name, 'NUBIC'
+          take_survey(@survey, @response_set) do |r|
+            r.a work_name, 'work_name', :value => 'NUBIC'
           end
           # @response_set.instrument.event = Factory(:event, :event_type_code => 18)
           instrument_context.work_place_name.should == 'NUBIC'
@@ -1636,8 +1636,8 @@ module NcsNavigator::Core::Mustache
 
       it "returns if child's date of birth" do
         dob = Date.parse("2012-12-25")
-        take_survey(@survey, @response_set) do |a|
-          a.date('PARTICIPANT_VERIF_CHILD.CHILD_DOB', "2012-12-25")
+        take_survey(@survey, @response_set) do |r|
+          r.a('PARTICIPANT_VERIF_CHILD.CHILD_DOB', "2012-12-25")
         end
         @response_set.completed_at = "2013-01-25"
         @response_set.save!
@@ -1757,32 +1757,32 @@ module NcsNavigator::Core::Mustache
 
       describe ".boys_girls" do
         it "returns 'boys' if CHILD_SEX set to MALE (1)" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             male = mock(NcsCode, :local_code => 1)
-            a.choice("PARTICIPANT_VERIF_CHILD.CHILD_SEX", male)
+            r.a("PARTICIPANT_VERIF_CHILD.CHILD_SEX", male)
           end
           instrument_context.boys_girls.should == "boys"
         end
 
         it "returns 'girls' if CHILD_SEX set to FEMALE (2)" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             female = mock(NcsCode, :local_code => 2)
-            a.choice("PARTICIPANT_VERIF_CHILD.CHILD_SEX", female)
+            r.a("PARTICIPANT_VERIF_CHILD.CHILD_SEX", female)
           end
           instrument_context.boys_girls.should == "girls"
         end
 
         it "returns 'boys/girls' if CHILD_SEX set to REFUSED" do
-          take_survey(@survey, @response_set) do |a|
-            a.refused("PARTICIPANT_VERIF_CHILD.CHILD_SEX")
+          take_survey(@survey, @response_set) do |r|
+            r.refused("PARTICIPANT_VERIF_CHILD.CHILD_SEX")
           end
           instrument_context.boys_girls.should == "boys/girls"
         end
 
         it "returns 'boys/girls' if CHILD_SEX set to DON'T KNOW" do
-          take_survey(@survey, @response_set) do |a|
+          take_survey(@survey, @response_set) do |r|
             could_not_obtain= mock(NcsCode, :local_code => "neg_2")
-            a.choice("PARTICIPANT_VERIF_CHILD.CHILD_SEX", could_not_obtain)
+            r.a("PARTICIPANT_VERIF_CHILD.CHILD_SEX", could_not_obtain)
           end
           instrument_context.boys_girls.should == "boys/girls"
         end
@@ -1796,61 +1796,61 @@ module NcsNavigator::Core::Mustache
 
 
     def create_single_birth
-      take_survey(@survey, @response_set) do |a|
-        a.no multiple
+      take_survey(@survey, @response_set) do |r|
+        r.no multiple
       end
     end
 
     def create_multiple_birth
-      take_survey(@survey, @response_set) do |a|
-        a.yes multiple
+      take_survey(@survey, @response_set) do |r|
+        r.yes multiple
       end
     end
 
     def create_singleton_gestation
       @singleton = NcsCode.for_list_name_and_local_code("GESTATION_TYPE_CL1", 1)
-      take_survey(@survey, @response_set) do |a|
-        a.choice(multiple_gestation, @singleton)
+      take_survey(@survey, @response_set) do |r|
+        r.a(multiple_gestation, @singleton)
       end
     end
 
     def create_twin_gestation
       @twin = NcsCode.for_list_name_and_local_code("GESTATION_TYPE_CL1", 2)
-      take_survey(@survey, @response_set) do |a|
-        a.choice(multiple_gestation, @twin)
+      take_survey(@survey, @response_set) do |r|
+        r.a(multiple_gestation, @twin)
       end
     end
 
     def set_multiple_num mult_num
-      take_survey(@survey, @response_set) do |a|
-        a.str multiple_num, mult_num
+      take_survey(@survey, @response_set) do |r|
+        r.a multiple_num, mult_num
       end
     end
 
     def create_triplet_gestation
       @triplet = NcsCode.for_list_name_and_local_code("GESTATION_TYPE_CL1", 3)
-      take_survey(@survey, @response_set) do |a|
-        a.choice(multiple_gestation, @triplet)
+      take_survey(@survey, @response_set) do |r|
+        r.a(multiple_gestation, @triplet)
       end
     end
 
     def create_male_response
       @male = NcsCode.for_list_name_and_local_code("GENDER_CL1", 1)
-      take_survey(@survey, @response_set) do |a|
-        a.choice(baby_sex, @male)
+      take_survey(@survey, @response_set) do |r|
+        r.a(baby_sex, @male)
       end
     end
 
     def create_female_response
       @female = NcsCode.for_list_name_and_local_code("GENDER_CL1", 2)
-      take_survey(@survey, @response_set) do |a|
-        a.choice(baby_sex, @female)
+      take_survey(@survey, @response_set) do |r|
+        r.a(baby_sex, @female)
       end
     end
 
     def set_first_name first_name
-      take_survey(@survey, @response_set) do |a|
-        a.str baby_fname, first_name
+      take_survey(@survey, @response_set) do |r|
+        r.a baby_fname, first_name
       end
     end
 

--- a/spec/lib/ncs_navigator/core/response_set_populator/birth_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/birth_spec.rb
@@ -47,8 +47,9 @@ module NcsNavigator::Core
         it "should be set to the response from part_one for instrument MDES version 3.0" do
           prepare_surveys("INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_ONE", "BIRTH_VISIT_3", "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_TWO")
           some_other_place = mock(NcsCode, :local_code => 'some_other_place')
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.choice "BIRTH_VISIT_3.BIRTH_DELIVER", some_other_place
+
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.a "BIRTH_VISIT_3.BIRTH_DELIVER", some_other_place
           end
 
           assert_response_value(@rsp.populate, "prepopulated_birth_deliver_from_birth_visit_part_one", "SOME OTHER PLACE")
@@ -66,8 +67,8 @@ module NcsNavigator::Core
         it "should be set to the response from part_one for instrument MDES version 3.1" do
           prepare_surveys("INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_ONE", "BIRTH_VISIT_LI_2", "INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_TWO")
           some_other_place = mock(NcsCode, :local_code => 'some_other_place')
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.choice "BIRTH_VISIT_LI_2.BIRTH_DELIVER", some_other_place
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.a "BIRTH_VISIT_LI_2.BIRTH_DELIVER", some_other_place
           end
 
           assert_response_value(@rsp.populate, "prepopulated_birth_deliver_from_birth_visit_part_one", "SOME OTHER PLACE")
@@ -85,8 +86,8 @@ module NcsNavigator::Core
         it "should be set to the response from part_one for instrument MDES version 3.2" do
           prepare_surveys("INS_QUE_Birth_INT_M3.2_V3.1_PART_ONE", "BIRTH_VISIT_4", "INS_QUE_Birth_INT_M3.2_V3.1_PART_TWO")
           some_other_place = mock(NcsCode, :local_code => 'some_other_place')
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.choice "BIRTH_VISIT_4.BIRTH_DELIVER", some_other_place
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.a "BIRTH_VISIT_4.BIRTH_DELIVER", some_other_place
           end
 
           assert_response_value(@rsp.populate, "prepopulated_birth_deliver_from_birth_visit_part_one", "SOME OTHER PLACE")
@@ -107,8 +108,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version prior to 3.0" do
           prepare_surveys("INS_QUE_Birth_INT_LI_P2_V10_PART_ONE", "BIRTH_VISIT_LI", "INS_QUE_Birth_INT_LI_P2_V10_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.yes "BIRTH_VISIT_LI.RELEASE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.yes "BIRTH_VISIT_LI.RELEASE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_release_from_birth_visit_part_one", "YES")
@@ -125,8 +126,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.0" do
           prepare_surveys("INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_ONE", "BIRTH_VISIT_3", "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.yes "BIRTH_VISIT_3.RELEASE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.yes "BIRTH_VISIT_3.RELEASE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_release_from_birth_visit_part_one", "YES")
@@ -143,8 +144,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.1" do
           prepare_surveys("INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_ONE", "BIRTH_VISIT_LI_2", "INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.yes "BIRTH_VISIT_LI_2.RELEASE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.yes "BIRTH_VISIT_LI_2.RELEASE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_release_from_birth_visit_part_one", "YES")
@@ -161,8 +162,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.2" do
           prepare_surveys("INS_QUE_Birth_INT_M3.2_V3.1_PART_ONE", "BIRTH_VISIT_4", "INS_QUE_Birth_INT_M3.2_V3.1_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.yes "BIRTH_VISIT_4.RELEASE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.yes "BIRTH_VISIT_4.RELEASE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_release_from_birth_visit_part_one", "YES")
@@ -183,8 +184,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version prior ot 3.0" do
           prepare_surveys("INS_QUE_Birth_INT_LI_P2_V10_PART_ONE", "BIRTH_VISIT_LI", "INS_QUE_Birth_INT_LI_P2_V10_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.no "BIRTH_VISIT_LI.MULTIPLE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.no "BIRTH_VISIT_LI.MULTIPLE"
           end
         end
 
@@ -199,8 +200,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.0" do
           prepare_surveys("INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_ONE", "BIRTH_VISIT_3", "INS_QUE_Birth_INT_EHPBHIPBS_M3.0_V3.0_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.no "BIRTH_VISIT_3.MULTIPLE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.no "BIRTH_VISIT_3.MULTIPLE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_multiple_from_birth_visit_part_one", "NO")
@@ -217,8 +218,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.1" do
           prepare_surveys("INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_ONE", "BIRTH_VISIT_LI_2", "INS_QUE_Birth_INT_LI_M3.1_V2.0_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.no "BIRTH_VISIT_LI_2.MULTIPLE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.no "BIRTH_VISIT_LI_2.MULTIPLE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_multiple_from_birth_visit_part_one", "NO")
@@ -235,8 +236,8 @@ module NcsNavigator::Core
 
         it "should be set to the response from part_one for instrument MDES version 3.2" do
           prepare_surveys("INS_QUE_Birth_INT_M3.2_V3.1_PART_ONE", "BIRTH_VISIT_4", "INS_QUE_Birth_INT_M3.2_V3.1_PART_TWO")
-          take_survey(@survey_pt1, @response_set_pt1) do |a|
-            a.no "BIRTH_VISIT_4.MULTIPLE"
+          take_survey(@survey_pt1, @response_set_pt1) do |r|
+            r.no "BIRTH_VISIT_4.MULTIPLE"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_multiple_from_birth_visit_part_one", "NO")
@@ -273,8 +274,8 @@ module NcsNavigator::Core
         it "should be FALSE if work name was previously answered as refused" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.refused "PREG_VISIT_1_3.WORK_NAME"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.refused "PREG_VISIT_1_3.WORK_NAME"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_name_provided", "FALSE")
@@ -283,8 +284,8 @@ module NcsNavigator::Core
         it "should be FALSE if work name was previously answered as don't know" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.dont_know "PREG_VISIT_1_3.WORK_NAME"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.dont_know "PREG_VISIT_1_3.WORK_NAME"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_name_provided", "FALSE")
@@ -293,8 +294,8 @@ module NcsNavigator::Core
         it "should be TRUE if work name was previously answered" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.str "PREG_VISIT_1_3.WORK_NAME", "work_name"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.a "PREG_VISIT_1_3.WORK_NAME", "work_name"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_name_provided", "TRUE")
@@ -311,8 +312,8 @@ module NcsNavigator::Core
         it "should be FALSE if work address was previously answered as refused" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.refused "PREG_VISIT_1_3.WORK_ADDRESS_1"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.refused "PREG_VISIT_1_3.WORK_ADDRESS_1"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_address_provided", "FALSE")
@@ -321,8 +322,8 @@ module NcsNavigator::Core
         it "should be FALSE if work address was previously answered as don't know" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.dont_know "PREG_VISIT_1_3.WORK_ADDRESS_1"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.dont_know "PREG_VISIT_1_3.WORK_ADDRESS_1"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_address_provided", "FALSE")
@@ -331,8 +332,8 @@ module NcsNavigator::Core
         it "should be TRUE if work address was previously answered" do
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.str "PREG_VISIT_1_3.WORK_ADDRESS_1", "work_address"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.a "PREG_VISIT_1_3.WORK_ADDRESS_1", "work_address"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_valid_work_address_provided", "TRUE")

--- a/spec/lib/ncs_navigator/core/response_set_populator/child_and_adhoc_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/child_and_adhoc_spec.rb
@@ -342,12 +342,12 @@ module NcsNavigator::Core
                                                         survey)
           response_set.responses.should be_empty
 
-          take_survey(survey, response_set) do |a|
+          take_survey(survey, response_set) do |r|
             if !answer
               neg_8 = mock(NcsCode, :local_code => 'neg_8')
-              a.choice("CHILD_ANTHRO.AN_MID_UPPER_ARM_CIRC1", neg_8)
+              r.a "CHILD_ANTHRO.AN_MID_UPPER_ARM_CIRC1", neg_8
             else
-              a.str("CHILD_ANTHRO.AN_MID_UPPER_ARM_CIRC1", answer)
+              r.a "CHILD_ANTHRO.AN_MID_UPPER_ARM_CIRC1", '1', :value => answer
             end
           end
         end

--- a/spec/lib/ncs_navigator/core/response_set_populator/participant_verification_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/participant_verification_spec.rb
@@ -77,8 +77,8 @@ module NcsNavigator::Core
           person.middle_name.should be_nil
 
           none = mock(NcsCode, :local_code => '-7')
-          take_survey(survey_pt1, @response_set_pt1) do |a|
-            a.choice "PARTICIPANT_VERIF.R_MNAME", none
+          take_survey(survey_pt1, @response_set_pt1) do |r|
+            r.a "PARTICIPANT_VERIF.R_MNAME", none
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt1, survey_pt1)
@@ -87,10 +87,10 @@ module NcsNavigator::Core
 
         it "is TRUE if the person has responded previously" do
 
-          take_survey(survey_pt1, @response_set_pt1) do |a|
-            a.str "PARTICIPANT_VERIF.R_FNAME", "fname"
-            a.str "PARTICIPANT_VERIF.R_MNAME", "mname"
-            a.str "PARTICIPANT_VERIF.R_LNAME", "lname"
+          take_survey(survey_pt1, @response_set_pt1) do |r|
+            r.a "PARTICIPANT_VERIF.R_FNAME", :value => "fname"
+            r.a "PARTICIPANT_VERIF.R_MNAME", :value => "mname"
+            r.a "PARTICIPANT_VERIF.R_LNAME", :value => "lname"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt1, survey_pt1)
@@ -147,8 +147,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if the person has responded previously" do
-          take_survey(survey_pt1, @response_set_pt1) do |a|
-            a.date "PARTICIPANT_VERIF.PERSON_DOB", Date.new(2001,1,1)
+          take_survey(survey_pt1, @response_set_pt1) do |r|
+            r.a "PARTICIPANT_VERIF.PERSON_DOB", :value => Date.new(2001,1,1)
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt1, survey_pt1)
@@ -156,8 +156,8 @@ module NcsNavigator::Core
         end
 
         it "is FALSE if the person has responded refused previously" do
-          take_survey(survey_pt1, @response_set_pt1) do |a|
-            a.refused "PARTICIPANT_VERIF.PERSON_DOB"
+          take_survey(survey_pt1, @response_set_pt1) do |r|
+            r.refused "PARTICIPANT_VERIF.PERSON_DOB"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt1, survey_pt1)
@@ -165,8 +165,8 @@ module NcsNavigator::Core
         end
 
         it "is FALSE if the person has responded don't know previously" do
-          take_survey(survey_pt1, @response_set_pt1) do |a|
-            a.dont_know "PARTICIPANT_VERIF.PERSON_DOB"
+          take_survey(survey_pt1, @response_set_pt1) do |r|
+            r.dont_know "PARTICIPANT_VERIF.PERSON_DOB"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt1, survey_pt1)
@@ -240,9 +240,9 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.str "PARTICIPANT_VERIF_CHILD.C_FNAME", "cfname"
-            a.str "PARTICIPANT_VERIF_CHILD.C_LNAME", "clname"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF_CHILD.C_FNAME", :value => "cfname"
+            r.a "PARTICIPANT_VERIF_CHILD.C_LNAME", :value => "clname"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -254,9 +254,9 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.refused "PARTICIPANT_VERIF_CHILD.C_FNAME"
-            a.refused "PARTICIPANT_VERIF_CHILD.C_LNAME"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.refused "PARTICIPANT_VERIF_CHILD.C_FNAME"
+            r.refused "PARTICIPANT_VERIF_CHILD.C_LNAME"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -267,9 +267,9 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF_CHILD.C_FNAME"
-            a.dont_know "PARTICIPANT_VERIF_CHILD.C_LNAME"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF_CHILD.C_FNAME"
+            r.dont_know "PARTICIPANT_VERIF_CHILD.C_LNAME"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -299,8 +299,8 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.date "PARTICIPANT_VERIF_CHILD.CHILD_DOB", Date.new(2001,1,1)
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF_CHILD.CHILD_DOB", :value => Date.new(2001,1,1)
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -309,8 +309,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if the person has responded refused previously" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.refused "PARTICIPANT_VERIF_CHILD.CHILD_DOB"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.refused "PARTICIPANT_VERIF_CHILD.CHILD_DOB"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -318,8 +318,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if the person has responded don't know previously" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF_CHILD.CHILD_DOB"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF_CHILD.CHILD_DOB"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -347,8 +347,8 @@ module NcsNavigator::Core
         it "is FALSE if the person has previously responded" do
           Person.any_instance.stub(:sex_code).and_return(-4)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.choice "PARTICIPANT_VERIF_CHILD.CHILD_SEX", mock(NcsCode, :local_code => 1)
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF_CHILD.CHILD_SEX", mock(NcsCode, :local_code => 1)
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -358,8 +358,8 @@ module NcsNavigator::Core
         it "is TRUE if the person has responded refused previously" do
           Person.any_instance.stub(:sex_code).and_return(-4)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.refused "PARTICIPANT_VERIF_CHILD.CHILD_SEX"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.refused "PARTICIPANT_VERIF_CHILD.CHILD_SEX"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -369,8 +369,8 @@ module NcsNavigator::Core
         it "is TRUE if the person has responded don't know previously" do
           Person.any_instance.stub(:sex_code).and_return(-4)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF_CHILD.CHILD_SEX"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF_CHILD.CHILD_SEX"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -409,8 +409,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for RESP_GUARD" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.RESP_GUARD"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.RESP_GUARD"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_resp_guard_previously_collected", "TRUE")
@@ -428,8 +428,8 @@ module NcsNavigator::Core
         it "is TRUE if the person has responded refused previously" do
           Person.any_instance.stub(:sex_code).and_return(-4)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.refused "PARTICIPANT_VERIF.RESP_PCARE"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.refused "PARTICIPANT_VERIF.RESP_PCARE"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -439,16 +439,16 @@ module NcsNavigator::Core
         it "is TRUE if the person has responded don't know previously" do
           Person.any_instance.stub(:sex_code).and_return(-4)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF.RESP_PCARE"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF.RESP_PCARE"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_should_show_resp_pcare", "TRUE")
         end
 
         it "is FALSE if there is a valid response for RESP_PCARE" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.RESP_PCARE"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.RESP_PCARE"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_should_show_resp_pcare", "FALSE")
@@ -463,20 +463,22 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is only one previous response with a value of one" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.RESP_PCARE"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.RESP_PCARE"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_resp_pcare_equals_one_in_previous_survey", "TRUE")
         end
 
         it "is TRUE if there is any one previous response with a value of one" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF.RESP_PCARE"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF.RESP_PCARE"
           end
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.RESP_PCARE"
+
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.RESP_PCARE"
           end
+
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_resp_pcare_equals_one_in_previous_survey", "TRUE")
         end
@@ -490,8 +492,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for PCARE_REL" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.choice "PARTICIPANT_VERIF.PCARE_REL", mock(NcsCode, :local_code => 1)
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF.PCARE_REL", mock(NcsCode, :local_code => 1)
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_pcare_rel_previously_collected", "TRUE")
@@ -506,11 +508,12 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is any one previous response with a value of one" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.dont_know "PARTICIPANT_VERIF.OCARE_CHILD"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.dont_know "PARTICIPANT_VERIF.OCARE_CHILD"
           end
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.OCARE_CHILD"
+
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.OCARE_CHILD"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_ocare_child_previously_collected_and_equals_one", "TRUE")
@@ -523,8 +526,8 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.OCARE_CHILD"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.OCARE_CHILD"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -536,11 +539,11 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.OCARE_CHILD"
-            a.dont_know "PARTICIPANT_VERIF.O_FNAME"
-            a.dont_know "PARTICIPANT_VERIF.O_MNAME"
-            a.dont_know "PARTICIPANT_VERIF.O_LNAME"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.OCARE_CHILD"
+            r.dont_know "PARTICIPANT_VERIF.O_FNAME"
+            r.dont_know "PARTICIPANT_VERIF.O_MNAME"
+            r.dont_know "PARTICIPANT_VERIF.O_LNAME"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -551,11 +554,11 @@ module NcsNavigator::Core
           Person.any_instance.stub(:first_name).and_return(nil)
           Person.any_instance.stub(:last_name).and_return(nil)
 
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.yes "PARTICIPANT_VERIF.OCARE_CHILD"
-            a.str "PARTICIPANT_VERIF.O_FNAME", "ofname"
-            a.str "PARTICIPANT_VERIF.O_MNAME", "omname"
-            a.str "PARTICIPANT_VERIF.O_LNAME", "olname"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.yes "PARTICIPANT_VERIF.OCARE_CHILD"
+            r.a "PARTICIPANT_VERIF.O_FNAME", :value => "ofname"
+            r.a "PARTICIPANT_VERIF.O_MNAME", :value => "omname"
+            r.a "PARTICIPANT_VERIF.O_LNAME", :value => "olname"
           end
 
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
@@ -572,8 +575,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for OCARE_REL" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.choice "PARTICIPANT_VERIF.OCARE_REL", mock(NcsCode, :local_code => 1)
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF.OCARE_REL", mock(NcsCode, :local_code => 1)
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_ocare_rel_previously_collected", "TRUE")
@@ -589,8 +592,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for CHILD_TIME" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.choice "PARTICIPANT_VERIF.CHILD_TIME", mock(NcsCode, :local_code => 1)
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF.CHILD_TIME", mock(NcsCode, :local_code => 1)
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_child_time_previously_collected", "TRUE")
@@ -606,8 +609,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for S_ADDRESS_1" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.str "PARTICIPANT_VERIF.S_ADDRESS_1", "caddr1"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF.S_ADDRESS_1", :value => "caddr1"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_child_secondary_address_variables_previously_collected", "TRUE")
@@ -623,8 +626,8 @@ module NcsNavigator::Core
         end
 
         it "is TRUE if there is a previous response for SA_PHONE" do
-          take_survey(survey_pt2, @response_set_pt2) do |a|
-            a.str "PARTICIPANT_VERIF.SA_PHONE", "867-5309"
+          take_survey(survey_pt2, @response_set_pt2) do |r|
+            r.a "PARTICIPANT_VERIF.SA_PHONE", :value => "867-5309"
           end
           rsp = ResponseSetPopulator::ParticipantVerification.new(person, @instrument_pt2, survey_pt2)
           assert_response_value(rsp.populate, "prepopulated_sa_phone_previously_collected", "TRUE")

--- a/spec/lib/ncs_navigator/core/response_set_populator/postnatal_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/postnatal_spec.rb
@@ -33,7 +33,7 @@ module NcsNavigator::Core
 
       unless block_given?
         answer_code = mock(NcsCode, :local_code => answer)
-        block = Proc.new { |a| a.choice(question_dexp_identifier, answer_code) }
+        block = Proc.new { |r| r.a question_dexp_identifier, answer_code }
       end
 
       take_survey(survey, response_set, &block)
@@ -61,13 +61,13 @@ module NcsNavigator::Core
       create_num_hh_for_18_and_24_month(survey_type
                                             ) do |survey, data_export_id|
         if valid_answers
-          prepare_and_take_survey(nil, nil, nil, survey) do |a|
-            a.int(data_export_id, 5)
+          prepare_and_take_survey(nil, nil, nil, survey) do |r|
+            r.a data_export_id, 'number', :value => 5
           end
         else
           answer_code = mock(NcsCode, :local_code => "neg_1")
-          prepare_and_take_survey(nil, nil, nil, survey) do |a|
-            a.choice(data_export_id, answer_code)
+          prepare_and_take_survey(nil, nil, nil, survey) do |r|
+            r.a data_export_id, answer_code
           end
         end
       end
@@ -78,12 +78,12 @@ module NcsNavigator::Core
         create_work_name_or_address_24_month(reference_id
                                             ) do |survey, data_export_id|
           if valid_answers
-            prepare_and_take_survey(nil, nil, nil, survey) do |a|
-              a.str(data_export_id, "work_name") 
+            prepare_and_take_survey(nil, nil, nil, survey) do |r|
+              r.a data_export_id, 'work_name', :value => "work_name"
             end 
           else
-            prepare_and_take_survey(nil, nil, nil, survey) do |a|
-              a.refused(data_export_id)
+            prepare_and_take_survey(nil, nil, nil, survey) do |r|
+              r.refused(data_export_id)
             end
           end
         end
@@ -302,8 +302,8 @@ module NcsNavigator::Core
 
         it "should be TRUE if child number is 1" do
           prepare_and_take_survey(nil, nil,
-                                  :create_participant_verif_child_qnum) do |a|
-            a.int("PARTICIPANT_VERIF.CHILD_QNUM", 1)
+                                  :create_participant_verif_child_qnum) do |r|
+            r.a "PARTICIPANT_VERIF.CHILD_QNUM", 'number', :value => 1
           end
           rsp = ResponseSetPopulator::Postnatal.new(@person, @instrument,
                                                     @survey)
@@ -313,8 +313,8 @@ module NcsNavigator::Core
 
         it "should be FALSE if child number is not 1" do
           prepare_and_take_survey(nil, nil,
-                                  :create_participant_verif_child_qnum) do |a|
-            a.int("PARTICIPANT_VERIF.CHILD_QNUM", 2)
+                                  :create_participant_verif_child_qnum) do |r|
+            r.a "PARTICIPANT_VERIF.CHILD_QNUM", 'number', :value => 2
           end
           rsp = ResponseSetPopulator::Postnatal.new(@person, @instrument,
                                                     @survey)

--- a/spec/lib/ncs_navigator/core/response_set_populator/pregnancy_visit_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/pregnancy_visit_spec.rb
@@ -40,8 +40,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.refused "PREG_VISIT_1_3.WORK_NAME"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.refused "PREG_VISIT_1_3.WORK_NAME"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_name_previously_collected_and_valid", "FALSE")
@@ -51,8 +51,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.dont_know "PREG_VISIT_1_3.WORK_NAME"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.dont_know "PREG_VISIT_1_3.WORK_NAME"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_name_previously_collected_and_valid", "FALSE")
@@ -62,8 +62,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.str "PREG_VISIT_1_3.WORK_NAME", "work_name"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.a "PREG_VISIT_1_3.WORK_NAME", :value => "work_name"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_name_previously_collected_and_valid", "TRUE")
@@ -81,8 +81,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.refused "PREG_VISIT_1_3.WORK_ADDRESS_1"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.refused "PREG_VISIT_1_3.WORK_ADDRESS_1"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_address_previously_collected_and_valid", "FALSE")
@@ -92,8 +92,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.dont_know "PREG_VISIT_1_3.WORK_ADDRESS_1"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.dont_know "PREG_VISIT_1_3.WORK_ADDRESS_1"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_address_previously_collected_and_valid", "FALSE")
@@ -103,8 +103,8 @@ module NcsNavigator::Core
           pv1_survey = create_pv1_with_fields_for_pv2_prepopulation
           pv1_response_set, pv1_instrument = prepare_instrument(person, participant, pv1_survey)
 
-          take_survey(pv1_survey, pv1_response_set) do |a|
-            a.str "PREG_VISIT_1_3.WORK_ADDRESS_1", "work_address"
+          take_survey(pv1_survey, pv1_response_set) do |r|
+            r.a "PREG_VISIT_1_3.WORK_ADDRESS_1", :value => "work_address"
           end
 
           assert_response_value(@rsp.populate, "prepopulated_is_work_address_previously_collected_and_valid", "TRUE")
@@ -163,9 +163,8 @@ module NcsNavigator::Core
               pre_preg_survey = create_pre_preg_survey_with_fields_used_in_pv1_prepopulation
               pre_preg_response_set, pre_preg_instrument = prepare_instrument(person, participant, pre_preg_survey)
 
-              yes = mock(NcsCode, :local_code => 1)
-              take_survey(pre_preg_survey, pre_preg_response_set) do |a|
-                a.choice "PRE_PREG.OWN_HOME", yes
+              take_survey(pre_preg_survey, pre_preg_response_set) do |r|
+                r.yes "PRE_PREG.OWN_HOME"
               end
 
               rsp = ResponseSetPopulator::PregnancyVisit.new(person, @instrument, survey)
@@ -188,9 +187,8 @@ module NcsNavigator::Core
                 pre_preg_survey = create_pre_preg_survey_with_fields_used_in_pv1_prepopulation
                 pre_preg_response_set, pre_preg_instrument = prepare_instrument(person, participant, pre_preg_survey)
 
-                yes = mock(NcsCode, :local_code => 1)
-                take_survey(pre_preg_survey, pre_preg_response_set) do |a|
-                  a.choice "PRE_PREG.RECENT_MOVE", yes
+                take_survey(pre_preg_survey, pre_preg_response_set) do |r|
+                  r.yes "PRE_PREG.RECENT_MOVE"
                 end
 
                 rsp = ResponseSetPopulator::PregnancyVisit.new(person, @instrument, survey)
@@ -205,9 +203,8 @@ module NcsNavigator::Core
                 pre_preg_survey = create_pre_preg_survey_with_fields_used_in_pv1_prepopulation
                 pre_preg_response_set, pre_preg_instrument = prepare_instrument(person, participant, pre_preg_survey)
 
-                no = mock(NcsCode, :local_code => 2)
-                take_survey(pre_preg_survey, pre_preg_response_set) do |a|
-                  a.choice "PRE_PREG.RECENT_MOVE", no
+                take_survey(pre_preg_survey, pre_preg_response_set) do |r|
+                  r.no "PRE_PREG.RECENT_MOVE"
                 end
 
                 rsp = ResponseSetPopulator::PregnancyVisit.new(person, @instrument, survey)

--- a/spec/lib/ncs_navigator/core/response_set_populator/tracing_module_spec.rb
+++ b/spec/lib/ncs_navigator/core/response_set_populator/tracing_module_spec.rb
@@ -146,8 +146,8 @@ module NcsNavigator::Core
 
           it "should be provided if the question had previously been answered" do
 
-            take_survey(@survey, @response_set) do |a|
-              a.dont_know "TRACING_INT.CELL_PHONE_2"
+            take_survey(@survey, @response_set) do |r|
+              r.dont_know "TRACING_INT.CELL_PHONE_2"
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -165,8 +165,8 @@ module NcsNavigator::Core
 
           it "should be provided if the question had previously been answered" do
 
-            take_survey(@survey, @response_set) do |a|
-              a.dont_know "TRACING_INT.CELL_PHONE_3"
+            take_survey(@survey, @response_set) do |r|
+              r.dont_know "TRACING_INT.CELL_PHONE_3"
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -184,8 +184,8 @@ module NcsNavigator::Core
 
           it "should be provided if the question had previously been answered" do
 
-            take_survey(@survey, @response_set) do |a|
-              a.dont_know "TRACING_INT.CELL_PHONE_4"
+            take_survey(@survey, @response_set) do |r|
+              r.dont_know "TRACING_INT.CELL_PHONE_4"
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -230,8 +230,8 @@ module NcsNavigator::Core
 
           it "should be provided if the question had previously been answered" do
 
-            take_survey(@survey, @response_set) do |a|
-              a.dont_know "TRACING_INT.EMAIL_APPT"
+            take_survey(@survey, @response_set) do |r|
+              r.dont_know "TRACING_INT.EMAIL_APPT"
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -249,8 +249,8 @@ module NcsNavigator::Core
 
           it "should be provided if the question had previously been answered" do
 
-            take_survey(@survey, @response_set) do |a|
-              a.dont_know "TRACING_INT.EMAIL_QUEST"
+            take_survey(@survey, @response_set) do |r|
+              r.dont_know "TRACING_INT.EMAIL_QUEST"
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -284,10 +284,10 @@ module NcsNavigator::Core
             friend = mock(NcsCode, :local_code => 6)
             mother = mock(NcsCode, :local_code => 1)
             sister = mock(NcsCode, :local_code => 2)
-            take_survey(@survey, @response_set) do |a|
-              a.choice "TRACING_INT.CONTACT_RELATE_1", mother
-              a.choice "TRACING_INT.CONTACT_RELATE_2", sister
-              a.choice "TRACING_INT.CONTACT_RELATE_3", friend
+            take_survey(@survey, @response_set) do |r|
+              r.a "TRACING_INT.CONTACT_RELATE_1", mother
+              r.a "TRACING_INT.CONTACT_RELATE_2", sister
+              r.a "TRACING_INT.CONTACT_RELATE_3", friend
             end
 
 
@@ -303,8 +303,8 @@ module NcsNavigator::Core
           it "should know that NOT all contacts have been provided if one contact has previously been given" do
 
             mother = mock(NcsCode, :local_code => 1)
-            take_survey(@survey, @response_set) do |a|
-              a.choice "TRACING_INT.CONTACT_RELATE_1", mother
+            take_survey(@survey, @response_set) do |r|
+              r.a "TRACING_INT.CONTACT_RELATE_1", mother
             end
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
             assert_response_value(rsp.populate, "prepopulated_is_valid_contact_for_all_provided", "FALSE")
@@ -314,9 +314,9 @@ module NcsNavigator::Core
 
             friend = mock(NcsCode, :local_code => 6)
             mother = mock(NcsCode, :local_code => 1)
-            take_survey(@survey, @response_set) do |a|
-              a.choice "TRACING_INT.CONTACT_RELATE_1", mother
-              a.choice "TRACING_INT.CONTACT_RELATE_2", friend
+            take_survey(@survey, @response_set) do |r|
+              r.a "TRACING_INT.CONTACT_RELATE_1", mother
+              r.a "TRACING_INT.CONTACT_RELATE_2", friend
             end
 
             rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -334,8 +334,8 @@ module NcsNavigator::Core
 
         it "should be provided if the question had previously been answered" do
 
-          take_survey(@survey, @response_set) do |a|
-            a.dont_know "TRACING_INT.PREV_CITY"
+          take_survey(@survey, @response_set) do |r|
+            r.dont_know "TRACING_INT.PREV_CITY"
           end
 
           rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)
@@ -353,8 +353,8 @@ module NcsNavigator::Core
 
         it "should be provided if the question had previously been answered" do
 
-          take_survey(@survey, @response_set) do |a|
-            a.dont_know "TRACING_INT.DR_LICENSE_NUM"
+          take_survey(@survey, @response_set) do |r|
+            r.dont_know "TRACING_INT.DR_LICENSE_NUM"
           end
 
           rsp = ResponseSetPopulator::TracingModule.new(@person, @instrument, @survey)

--- a/spec/lib/ncs_navigator/core/surveyor/kitchen_sink_survey.rb
+++ b/spec/lib/ncs_navigator/core/surveyor/kitchen_sink_survey.rb
@@ -1,0 +1,274 @@
+# encoding: UTF-8
+# Question#is_mandatory is now false by default. The default_mandatory option allows you to set
+#   is_mandatory for all questions in a survey.
+survey "Kitchen Sink survey", :default_mandatory => false do
+
+  section "Basic questions" do
+    # A label is a question that accepts no answers
+    label "These questions are examples of the basic supported input types"
+
+    # A basic question with radio buttons
+    question "What is your favorite color?", :pick => :one
+    answer "red"
+    answer "blue"
+    answer "green"
+    answer "yellow"
+    answer :other
+
+    # A basic question with checkboxes
+    # The "question" and "answer" methods may be abbreviated as "q" and "a".
+    # Append a reference identifier (a short string used for dependencies and validations) using the "_" underscore.
+    # Question reference identifiers must be unique within a survey.
+    # Answer reference identifiers must be unique within a question
+    q_2 "Choose the colors you don't like", :pick => :any
+    a_1 "red"
+    a_2 "blue"
+    a_3 "green"
+    a_4 "yellow"
+    a :omit
+
+    # A dependent question, with conditions and rule to logically join them
+    # If the conditions, logically joined into the rule, are met, then the question will be shown.
+    q_2a "Please explain why you don't like this color?"
+    a_1 "explanation", :text, :help_text => "Please give an explanation for each color you don't like"
+    dependency :rule => "A or B or C or D"
+    condition_A :q_2, "==", :a_1
+    condition_B :q_2, "==", :a_2
+    condition_C :q_2, "==", :a_3
+    condition_D :q_2, "==", :a_4
+
+    # The count operator checks how many responses exist for the referenced question.
+    # It understands conditions of the form: count== count!= count> count< count>= count<=
+    q_2b "Please explain why you dislike so many colors?"
+    a "explanation", :text
+    dependency :rule => "Z"
+    condition_Z :q_2, "count>2"
+
+    # When :pick isn't specified, the default is :none (no checkbox or radio button)
+    q_montypython3 "What... is your name? (e.g. It is 'Arthur', King of the Britons)"
+    a_1 :string
+
+    # Dependency conditions can refer to any value, not just answer_id. An answer_reference still needs to be specified, to know which answer you would like to check
+    q_montypython4 "What... is your quest? (e.g. To seek the Holy Grail)"
+    a_1 :string
+    dependency :rule => "A"
+    condition_A :q_montypython3, "==", {:string_value => "It is 'Arthur', King of the Britons", :answer_reference => "1"}
+
+    # http://www.imdb.com/title/tt0071853/quotes
+    q_montypython5 "What... is the air-speed velocity of an unladen swallow? (e.g. What do you mean? An African or European swallow?)"
+    a_1 :string
+    dependency :rule => "A"
+    condition_A :q_montypython4, "==", {:string_value => "To seek the Holy Grail", :answer_reference => "1"}
+
+    label "Huh? I-- I don't know that! Auuuuuuuugh!"
+    dependency :rule => "A"
+    condition_A :q_montypython5, "==", {:string_value => "What do you mean? An African or European swallow?", :answer_reference => "1"}
+
+    q_cooling_1 "How do you cool your home?", :pick => :one, :data_export_identifier => 'COOLING'
+    a_1 "Fans"
+    a_2 "Window AC"
+    a_3 "Central AC"
+    a_4 "Passive"
+    a_other :string
+
+    # When using !=, also use count>0 if you want to make sure the user responds
+    q_cooling_2 "How much does it cost to run your non-passive cooling solutions? (This question hidden until you respond 'How do you cool your home?')"
+    dependency :rule => "A and B"
+    condition_A :q_cooling_1, "!=", :a_4
+    condition_B :q_cooling_1, "count>0"
+    a_1 "$", :float
+
+    # Using != alone means the dependent question is shown by default
+    label "Please consider passive cooling solutions (This question always shown, unless you respond 'Passive')"
+    dependency :rule => "A"
+    condition_A :q_cooling_1, "!=", :a_4
+    # Surveys, sections, questions, groups, and answers all take the following reference arguments
+    # :reference_identifier   # used for parsing references, usually derived from the paper version
+    # :data_export_identifier # used for data export
+    # :common_namespace       # maping to a common vocabulary - the namespace
+    # :common_identifier      # maping to a common vocabulary - the identifier within the namespace
+    q "Get me started on an improv sketch", :reference_identifier => "improv_start", :data_export_identifier => "i_s", :common_namespace => "sketch comedy questions", :common_identifier => "get me started"
+    a "who", :string
+    a "what", :string
+    a "where", :string
+
+    # Various types of responses can be accepted, and validated
+    q_pet "How many pets do you own?"
+    a_pet :integer
+
+    # Surveys, sections, questions, groups, and answers also take a custom css class for covenience in custom styling
+    q "What is your address?", :custom_class => 'address'
+    a :text, :custom_class => 'mapper'
+    # validations can use regexp values
+    validation :rule => "A"
+    condition_A "=~", :regexp => "[0-9a-zA-z\. #]"
+
+    # Questions, groups, and answers take a custom renderer (a partial in the application's views dir)
+    # defaults are "/partials/question_group", "/partials/question", "/partials/answer", so the custom renderers should have a different name
+    q "Pick your favorite date AND time" #, :custom_renderer => "/partials/custom_question"
+    a :datetime
+
+    q_time_lunch "What time do you usually take a lunch break?"
+    a_1 :time
+
+    q "When would you like to meet for dinner?"
+    a :date
+
+    # Sliders deprecate to select boxes when javascript is off
+    # Valid Ruby code may be used to shorten repetitive tasks
+    q "Adjust the slider to reflect your level of awesomeness", :pick => :one, :display_type => :slider
+    (1..10).to_a.each{|num| a num.to_s}
+
+    q "How much do you like Ruby?", :pick => :one, :display_type => :slider
+    ["not at all", "a little", "some", "a lot", "a ton"].each{|level| a level}
+
+    # The "|" pipe is used to place labels before or after the input elements
+    q "How much money do you want?"
+    a "$|USD", :float
+
+    # Questions may be grouped
+    group "How much oil do you use per day?", :display_type => :inline do
+      q "Quantity"
+      a :float
+
+      q "Unit", :pick => :one, :display_type => :dropdown
+      a "Barrels"
+      a "Gallons"
+      a "Quarts"
+    end
+
+    q "Choose your Illinois county", :pick => :one, :display_type => :dropdown
+    ["Adams","Alexander","Bond", "Boone",
+        "Brown","Bureau","Calhoun","Carroll","Cass",
+        "Champaign", "Christian", "Clark","Clay",
+        "Clinton", "Coles", "Cook", "Crawford","Cumberland","DeKalb",
+        "De Witt","Douglas","DuPage","Edgar", "Edwards",
+        "Effingham","Fayette", "Ford","Franklin","Fulton",
+        "Gallatin","Greene", "Grundy", "Hamilton","Hancock",
+        "Hardin","Henderson","Henry","Iroquois","Jackson",
+        "Jasper", "Jefferson","Jersey","Jo Daviess","Johnson",
+        "Kane","Kankakee","Kendall","Knox", "La Salle",
+        "Lake", "Lawrence", "Lee","Livingston","Logan",
+        "Macon","Macoupin","Madison","Marion","Marshall", "Mason",
+        "Massac","McDonough","McHenry","McLean","Menard",
+        "Mercer","Monroe", "Montgomery","Morgan","Moultrie",
+        "Ogle","Peoria","Perry","Piatt","Pike","Pope",
+        "Pulaski","Putnam","Randolph","Richland","Rock Island",
+        "Saline","Sangamon","Schuyler","Scott","Shelby",
+        "St. Clair","Stark", "Stephenson","Tazewell","Union",
+        "Vermilion","Wabash","Warren","Washington","Wayne",
+        "White","Whiteside","Will","Williamson","Winnebago","Woodford"].each{ |county| a county}
+
+    # When an is_exclusive answer is checked, it unchecks all other options and disables them (using Javascript)
+    q "Choose your favorite meats", :display_type => :inline, :pick => :any
+    a "Chicken"
+    a "Pork"
+    a "Beef"
+    a "Shellfish"
+    a "Fish"
+    a "I don't eat meats!!!", :is_exclusive => true
+
+    q_allout "All out of ideas for questions?", :pick => :one, :display_type => :inline
+    a_yes "yes"
+    a "maybe"
+    a_no "no"
+    a_refused "Refused"
+    a_dont_know "I don't know"
+  end
+
+  section "Complicated questions" do
+
+    # Grids are useful for repeated questions with the same set of answers, which are specified before the questions
+    grid "Tell us how often do you cover these each day" do
+      a "1"
+      a "2"
+      a "3"
+      q "Head", :pick => :one
+      q "Knees", :pick => :one
+      q "Toes", :pick => :one
+    end
+
+    # "grid" is a shortcut for group with :display_type => :grid
+    # The answers will be repeated every 10 rows, but long grids aren't recommended as they are generally tedious
+    grid "Tell us how you feel today day" do
+      a "-2"
+      a "-1"
+      a "0"
+      a "1"
+      a "2"
+      q "down|up" , :pick => :one
+      q "sad|happy", :pick => :one
+      q "limp|perky", :pick => :one
+    end
+
+    grid "For each of the car types checked, what type of options would you prefer?" do
+      a "Leather seats"
+      a "Shiny rims"
+      a "Subwoofer"
+      a "Sunroof"
+      a "Turbocharger"
+      q "SUV", :pick => :any
+      q "Sedan", :pick => :any
+      q "Coupe", :pick => :any
+      q "Convertible", :pick => :any
+      q "Minivan", :pick => :any
+      q "Crossover", :pick => :any
+      q "Wagon", :pick => :any
+      q "Other", :pick => :any
+    end
+
+    q "Please rank the following foods based on how much you like them"
+    a "|pizza", :integer
+    a "|salad", :integer
+    a "|sushi", :integer
+    a "|ice cream", :integer
+    a "|breakfast ceral", :integer
+
+    # :other, :string allows someone to specify both the "other" and some other information
+    q "Choose your favorite utensils and enter frequency of use (daily, weekly, monthly, etc...)", :pick => :any
+    a "spoon", :string
+    a "fork", :string
+    a "knife", :string
+    a :other, :string
+
+    q_birthdate "What is your birth date?", :pick => :one
+    a_bornon "I was born on", :date
+    a_refused "Refused"
+
+    q "At what time were you born?", :pick => :any
+    a "I was born at", :time
+    a "This time is approximate"
+
+    q "When would you like to schedule your next appointment?"
+    a :datetime
+
+    q_car "Do you own a car?", :pick => :one
+    a_y "Yes"
+    a_n "No"
+
+    # Repeaters allow multiple responses to a question or set of questions
+    repeater "Tell us about the cars you own" do
+      dependency :rule => "A"
+      condition_A :q_car, "==", :a_y
+      q "Make", :pick => :one, :display_type => :dropdown
+      a "Toyota"
+      a "Ford"
+      a "GMChevy"
+      a "Ferrari"
+      a "Tesla"
+      a "Honda"
+      a "Other weak brand"
+      q "Model"
+      a :string
+      q "Year"
+      a :string
+    end
+
+    repeater "Tell us the name and age of your siblings" do
+      q "Sibling"
+      a "Name", :string
+      a "Age|years", :integer
+    end
+
+  end
+end

--- a/spec/lib/ncs_navigator/core/surveyor/survey_taker_spec.rb
+++ b/spec/lib/ncs_navigator/core/surveyor/survey_taker_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Surveyor
+  describe SurveyTaker do
+    let(:taker) { Object.new.extend(SurveyTaker) }
+    let(:s) { @survey }
+    let(:rs) { ResponseSet.new(:survey => s) }
+
+    before(:all) do
+      # Reduce log spam for easier profiling.
+      ActiveRecord::Base.silence do
+        @survey = Surveyor::Parser.new.parse(File.read(File.expand_path('../kitchen_sink_survey.rb', __FILE__)))
+      end
+    end
+
+    it 'fills in a single choice' do
+      taker.respond(rs) do |r|
+        r.answer '2', '1'
+      end
+
+      rs.should have_response('2', '1')
+    end
+
+    it 'fills in multiple choices' do
+      taker.respond(rs) do |r|
+        r.answer '2', '1'
+        r.answer '2', '3'
+      end
+
+      rs.should have_response('2', '1')
+      rs.should have_response('2', '3')
+    end
+
+    describe 'using data export identifiers' do
+      it 'fills in single choices' do
+        taker.respond(rs) do |r|
+          r.using_data_export_identifiers do |r|
+            r.answer 'COOLING', '2'
+          end
+        end
+
+        rs.should have_response('cooling_1', '2')
+      end
+
+      it 'fills in string fields' do
+        taker.respond(rs) do |r|
+          r.using_data_export_identifiers do |r|
+            r.answer 'COOLING', 'other', :value => 'Aliens'
+          end
+        end
+
+        rs.should have_response('cooling_1', 'other', 'Aliens')
+      end
+    end
+
+    it 'fills in integer fields' do
+      taker.respond(rs) do |r|
+        r.answer 'pet', 'pet', :value => 3
+      end
+
+      rs.should have_response('pet', 'pet', 3)
+    end
+
+    it 'fills in string fields' do
+      taker.respond(rs) do |r|
+        r.answer 'montypython3', '1', :value => 'Brave Sir Robin'
+      end
+
+      rs.should have_response('montypython3', '1', 'Brave Sir Robin')
+    end
+
+    describe 'for questions with a single answer' do
+      it 'fills in string fields' do
+        taker.respond(rs) do |r|
+          r.answer '2b', :value => 'What colors?'
+        end
+
+        rs.should have_response('2b', nil, 'What colors?')
+      end
+    end
+
+    describe 'UnresolvableQuestion' do
+      it 'is raised when reference identifiers cannot be resolved' do
+        code = lambda do
+          taker.respond(rs) do |r|
+            r.answer 'wrong', :value => 'what'
+          end
+        end
+
+        code.should raise_error(SurveyTaker::UnresolvableQuestion)
+      end
+
+      it 'is raised when data export identifiers cannot be resolved' do
+        code = lambda do
+          taker.respond(rs) do |r|
+            r.using_data_export_identifiers do
+              r.answer 'cooling_1', :value => 'what'
+            end
+          end
+        end
+
+        code.should raise_error(SurveyTaker::UnresolvableQuestion)
+      end
+
+      it 'does not shadow data export identifiers with reference identifiers' do
+        # cooling_1 is a valid reference identifier, but it isn't a valid data
+        # export identifier.
+        code = lambda do
+          taker.respond(rs) do |r|
+            r.using_data_export_identifiers do
+              r.answer 'cooling_1', :value => 'what'
+            end
+
+            r.answer 'cooling_1', '1'
+          end
+        end
+
+        code.should raise_error(SurveyTaker::UnresolvableQuestion)
+      end
+    end
+
+    describe 'UnresolvableAnswer' do
+      it 'is raised when answer reference identifiers cannot be resolved' do
+        code = lambda do
+          taker.respond(rs) do |r|
+            r.answer 'cooling_1', 'wrong'
+          end
+        end
+
+        code.should raise_error(SurveyTaker::UnresolvableAnswer)
+      end
+    end
+
+    describe 'AmbiguousAnswer' do
+      it 'is raised when an implicit target is given for a question with multiple answers' do
+        code = lambda do
+          taker.respond(rs) do |r|
+            r.answer 'improv_start', :value => 'All'
+          end
+        end
+
+        code.should raise_error(SurveyTaker::AmbiguousAnswer)
+      end
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -40,8 +40,6 @@ require File.expand_path('../../shared/models/a_time_bounded_task', __FILE__)
 require File.expand_path('../../shared/models/an_optimistically_locked_record', __FILE__)
 
 describe Contact do
-  include SurveyCompletion
-
   it "should create a new instance given valid attributes" do
     c = Factory(:contact)
     c.should_not be_nil

--- a/spec/models/operational_data_extractor/base_spec.rb
+++ b/spec/models/operational_data_extractor/base_spec.rb
@@ -283,13 +283,13 @@ describe OperationalDataExtractor::Base do
           hospital = NcsCode.for_list_name_and_local_code("ORGANIZATION_TYPE_CL1", 1)
           state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-          take_survey(@survey, @response_set) do |a|
-            a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", hospital
-            a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-            a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", "123 Any Street"
-            a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", "Springfield"
-            a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", state
-            a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", "65445"
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", hospital
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", "123 Any Street"
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", "Springfield"
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", state
+            r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", "65445"
           end
           @response_set.save!
 
@@ -557,13 +557,13 @@ describe OperationalDataExtractor::Base do
       @hospital = NcsCode.for_list_name_and_local_code("ORGANIZATION_TYPE_CL1", 1)
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", "123 Any Street"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", "Springfield"
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", "65445"
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", "123 Any Street"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", "Springfield"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", "65445"
       end
       @response_set.save!
 
@@ -658,11 +658,11 @@ describe OperationalDataExtractor::Base do
       @survey = create_birth_survey_with_person_race_operational_data
       @response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW_OTH", "Chinese"
-        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Korean"
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW_OTH", "Chinese"
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Korean"
       end
 
       @response_set.save!
@@ -687,10 +687,10 @@ describe OperationalDataExtractor::Base do
         before do
           @response_set_multiple_responses, instrument = prepare_instrument(@person, @participant, @survey)
 
-          take_survey(@survey, @response_set_multiple_responses) do |a|
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", black_race
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", asian_race
+          take_survey(@survey, @response_set_multiple_responses) do |r|
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", black_race
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", asian_race
           end
           @response_set_multiple_responses.save!
 
@@ -713,9 +713,9 @@ describe OperationalDataExtractor::Base do
         before do
           @response_set_multiple_mixed_type, instrument = prepare_instrument(@person, @participant, @survey)
 
-          take_survey(@survey, @response_set_multiple_mixed_type) do |a|
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
+          take_survey(@survey, @response_set_multiple_mixed_type) do |r|
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
           end
           @response_set_multiple_mixed_type.save!
 
@@ -738,9 +738,9 @@ describe OperationalDataExtractor::Base do
         before do
           @response_set_on_and_off_code_list, instrument = prepare_instrument(@person, @participant, @survey)
 
-          take_survey(@survey, @response_set_on_and_off_code_list) do |a|
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", vietnamese_race
+          take_survey(@survey, @response_set_on_and_off_code_list) do |r|
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", vietnamese_race
           end
           @response_set_on_and_off_code_list.save!
 
@@ -777,9 +777,9 @@ describe OperationalDataExtractor::Base do
         before do
           @response_set_other_race_type, instrument = prepare_instrument(@person, @participant, @survey)
 
-          take_survey(@survey, @response_set_other_race_type) do |a|
-            a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", other_race
-            a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Aborigine"
+          take_survey(@survey, @response_set_other_race_type) do |r|
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", other_race
+            r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Aborigine"
           end
           @response_set_other_race_type.save!
 
@@ -899,10 +899,10 @@ describe OperationalDataExtractor::Base do
     describe "#collect_race_responses" do
       before do
         @response_set2, instrument = prepare_instrument(@person, @participant, @survey)
-        take_survey(@survey, @response_set2) do |a|
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", black_race
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", asian_race
+        take_survey(@survey, @response_set2) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", black_race
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", asian_race
         end
         @response_set2.save!
         @birth_extractor2 = OperationalDataExtractor::Birth.new(@response_set2)

--- a/spec/models/operational_data_extractor/birth_spec.rb
+++ b/spec/models/operational_data_extractor/birth_spec.rb
@@ -28,11 +28,11 @@ describe OperationalDataExtractor::Birth do
       survey = create_birth_survey_with_child_operational_data
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_FNAME", 'Mary'
-        a.str "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_MNAME", 'Jane'
-        a.str "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_LNAME", 'Williams'
-        a.choice "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_SEX", @female
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_FNAME", 'Mary'
+        r.a "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_MNAME", 'Jane'
+        r.a "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_LNAME", 'Williams'
+        r.a "#{OperationalDataExtractor::Birth::BABY_NAME_PREFIX}.BABY_SEX", @female
       end
 
       response_set.responses.reload
@@ -82,9 +82,9 @@ describe OperationalDataExtractor::Birth do
     it "extracts person operational data from the survey responses" do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.R_FNAME", 'Jocelyn'
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.R_LNAME", 'Goldsmith'
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.R_FNAME", 'Jocelyn'
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.R_LNAME", 'Goldsmith'
       end
 
       response_set.responses.reload
@@ -106,14 +106,14 @@ describe OperationalDataExtractor::Birth do
 
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS1", '123 Easy St.'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS2", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_UNIT", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_CITY", 'Chicago'
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_STATE", state
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP", '65432'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP4", '1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS1", '123 Easy St.'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS2", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_UNIT", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_CITY", 'Chicago'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_STATE", state
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP", '65432'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP4", '1234'
         end
 
         response_set.responses.reload
@@ -134,14 +134,14 @@ describe OperationalDataExtractor::Birth do
 
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS1", '123 Easy St.'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS2", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_UNIT", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_CITY", 'Chicago'
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_STATE", state
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP", '65432'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP4", '1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS1", '123 Easy St.'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS2", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_UNIT", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_CITY", 'Chicago'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_STATE", state
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP", '65432'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP4", '1234'
         end
 
         response_set.responses.reload
@@ -162,22 +162,22 @@ describe OperationalDataExtractor::Birth do
 
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS1", '123 Easy St.'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS2", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_UNIT", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_CITY", 'Chicago'
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_STATE", state
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP", '65432'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP4", '1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS1", '123 Easy St.'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ADDRESS2", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_UNIT", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_CITY", 'Chicago'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_STATE", state
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP", '65432'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.MAIL_ZIP4", '1234'
 
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS1", '312 Hard St.'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS2", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_UNIT", ''
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_CITY", 'Chicago'
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_STATE", state
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP", '65432'
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP4", '1234'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS1", '312 Hard St.'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ADDRESS2", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_UNIT", ''
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_CITY", 'Chicago'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_STATE", state
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP", '65432'
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.WORK_ZIP4", '1234'
         end
 
         response_set.responses.reload
@@ -198,15 +198,15 @@ describe OperationalDataExtractor::Birth do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       @person.telephones.size.should == 0
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_NBR", '3125551234'
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_NBR_OTH", ''
-        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_TYPE", cell
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_TYPE_OTH", ''
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.HOME_PHONE", '3125554321'
-        a.yes "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE_2"
-        a.yes "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE_4"
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE", '3125557890'
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_NBR", '3125551234'
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_NBR_OTH", ''
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_TYPE", cell
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.PHONE_TYPE_OTH", ''
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.HOME_PHONE", '3125554321'
+        r.yes "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE_2"
+        r.yes "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE_4"
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.CELL_PHONE", '3125557890'
       end
 
       response_set.responses.reload
@@ -232,9 +232,9 @@ describe OperationalDataExtractor::Birth do
 
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.EMAIL", 'email@dev.null'
-        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.EMAIL_TYPE", home
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.EMAIL", 'email@dev.null'
+        r.a"#{OperationalDataExtractor::Birth::BIRTH_VISIT_PREFIX}.EMAIL_TYPE", home
       end
 
       response_set.responses.reload
@@ -257,8 +257,8 @@ describe OperationalDataExtractor::Birth do
 
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
 
-      take_survey(@survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.BIRTH_DELIVER", hospital
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_3_PREFIX}.BIRTH_DELIVER", hospital
       end
 
       response_set.save!
@@ -286,24 +286,24 @@ describe OperationalDataExtractor::Birth do
     end
 
     it "sets the mode to CAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => 'capi'
       end
       OperationalDataExtractor::Birth.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.capi
     end
 
     it "sets the mode to CATI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => "cati"
       end
       OperationalDataExtractor::Birth.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.cati
     end
 
     it "sets the mode to PAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => 'papi'
       end
       OperationalDataExtractor::Birth.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.papi
@@ -327,10 +327,10 @@ describe OperationalDataExtractor::Birth do
 
     describe "processing standard racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", other_race
-          a.str "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", "Aborigine"
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", black_race
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1", other_race
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_1_3_PREFIX}.BABY_RACE_1_OTH", 'Aborigine'
         end
 
         OperationalDataExtractor::Birth.new(@response_set).extract_data
@@ -355,9 +355,9 @@ describe OperationalDataExtractor::Birth do
 
     describe "processing new type racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
-          a.choice "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", vietnamese_race
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", white_race
+          r.a "#{OperationalDataExtractor::Birth::BIRTH_VISIT_BABY_RACE_NEW_3_PREFIX}.BABY_RACE_NEW", vietnamese_race
         end
 
         OperationalDataExtractor::Birth.new(@response_set).extract_data

--- a/spec/models/operational_data_extractor/informed_consent_spec.rb
+++ b/spec/models/operational_data_extractor/informed_consent_spec.rb
@@ -32,16 +32,16 @@ describe OperationalDataExtractor::InformedConsent do
         consent = prepare_consent(person, participant, survey, contact)
         response_set = consent.response_set
 
-        take_survey(survey, response_set) do |a|
-          a.choice "PARTICIPANT_CONSENT.CONSENT_FORM_TYPE_CODE", consent_form_type
-          a.choice "PARTICIPANT_CONSENT.CONSENT_GIVEN_CODE", yes
-          a.str "PARTICIPANT_CONSENT.CONSENT_DATE", date
-          a.str "PARTICIPANT_CONSENT.CONSENT_VERSION", "version"
-          a.choice "PARTICIPANT_CONSENT.WHO_CONSENTED_CODE", who
-          a.choice "PARTICIPANT_CONSENT.CONSENT_LANGUAGE_CODE", en
-          a.choice "PARTICIPANT_CONSENT.CONSENT_TRANSLATE_CODE", no_trans
-          a.choice "PARTICIPANT_CONSENT.RECONSIDERATION_SCRIPT_USE_CODE", no2
-          a.txt "PARTICIPANT_CONSENT.CONSENT_COMMENTS", "comments"
+        take_survey(survey, response_set) do |r|
+          r.a "PARTICIPANT_CONSENT.CONSENT_FORM_TYPE_CODE", consent_form_type
+          r.a "PARTICIPANT_CONSENT.CONSENT_GIVEN_CODE", yes
+          r.a "PARTICIPANT_CONSENT.CONSENT_DATE", "consent_date", :value => date
+          r.a "PARTICIPANT_CONSENT.CONSENT_VERSION", "consent_version", :value => "version"
+          r.a "PARTICIPANT_CONSENT.WHO_CONSENTED_CODE", who
+          r.a "PARTICIPANT_CONSENT.CONSENT_LANGUAGE_CODE", en
+          r.a "PARTICIPANT_CONSENT.CONSENT_TRANSLATE_CODE", no_trans
+          r.a "PARTICIPANT_CONSENT.RECONSIDERATION_SCRIPT_USE_CODE", no2
+          r.a "PARTICIPANT_CONSENT.CONSENT_COMMENTS", "consent_comments", :value => "comments"
         end
 
         response_set.responses.reload
@@ -81,11 +81,11 @@ describe OperationalDataExtractor::InformedConsent do
         consent = prepare_consent(person, participant, survey, contact)
         response_set = consent.response_set
 
-        take_survey(survey, response_set) do |a|
-          a.choice "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_CODE", yes
-          a.choice "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_TYPE_CODE", wdraw1
-          a.choice "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_REASON_CODE", wdraw2
-          a.str "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_DATE", date
+        take_survey(survey, response_set) do |r|
+          r.a "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_CODE", yes
+          r.a "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_TYPE_CODE", wdraw1
+          r.a "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_REASON_CODE", wdraw2
+          r.a "PARTICIPANT_CONSENT.CONSENT_WITHDRAW_DATE", "consent_date", :value => date
         end
 
         response_set.responses.reload
@@ -117,10 +117,10 @@ describe OperationalDataExtractor::InformedConsent do
         consent = prepare_consent(person, participant, survey, contact)
         response_set = consent.response_set
 
-        take_survey(survey, response_set) do |a|
-          a.choice "PARTICIPANT_CONSENT.CONSENT_RECONSENT_CODE", yes
-          a.choice "PARTICIPANT_CONSENT.CONSENT_RECONSENT_REASON_CODE", reason
-          a.str "PARTICIPANT_CONSENT.CONSENT_RECONSENT_REASON_OTHER", "other"
+        take_survey(survey, response_set) do |r|
+          r.a "PARTICIPANT_CONSENT.CONSENT_RECONSENT_CODE", yes
+          r.a "PARTICIPANT_CONSENT.CONSENT_RECONSENT_REASON_CODE", reason
+          r.a "PARTICIPANT_CONSENT.CONSENT_RECONSENT_REASON_OTHER", "consent_reconsent_reason_other", :value => "other"
         end
 
         response_set.responses.reload

--- a/spec/models/operational_data_extractor/low_intensity_spec.rb
+++ b/spec/models/operational_data_extractor/low_intensity_spec.rb
@@ -56,9 +56,9 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
     end
 
     it "updates the ppg status to 1 if the person responds that they are pregnant" do
-      take_survey(@survey, @response_set) do |a|
-        a.yes "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT"
-        a.date "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.DUE_DATE", '2011-12-25'
+      take_survey(@survey, @response_set) do |r|
+        r.yes "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT"
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.DUE_DATE", '2011-12-25'
       end
 
       @response_set.responses.reload
@@ -76,8 +76,8 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
     end
 
     it "updates the ppg status to 3 if the person responds that they recently lost their child during pregnancy" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg3
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg3
       end
 
       @response_set.responses.reload
@@ -95,8 +95,8 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
     end
 
     it "updates the ppg status to 2 if the person responds that they are trying" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg2
       end
 
       @response_set.responses.reload
@@ -114,8 +114,8 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
     end
 
     it "updates the ppg status to 4 if the person responds that they recently gave birth" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg4
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg4
       end
 
       @response_set.responses.reload
@@ -133,8 +133,8 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
     end
 
     it "updates the ppg status to 5 if the person responds that they are medically unable to become pregnant" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg5
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.PREGNANT", @ppg5
       end
 
       @response_set.responses.reload
@@ -167,14 +167,14 @@ describe OperationalDataExtractor::LowIntensityPregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
-        a.str "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_STATE", @state
-        a.str "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_STATE", @state
+        r.a "#{OperationalDataExtractor::LowIntensityPregnancyVisit::PREGNANCY_VISIT_LI_2_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
       end
 
       response_set.responses.reload

--- a/spec/models/operational_data_extractor/participant_verification_spec.rb
+++ b/spec/models/operational_data_extractor/participant_verification_spec.rb
@@ -30,11 +30,11 @@ describe OperationalDataExtractor::ParticipantVerification do
     it "updates the person (Child) record" do
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
-        a.date "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.CHILD_DOB", '01/01/2013'
-        a.choice "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.CHILD_SEX", @female
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.CHILD_DOB", '01/01/2013'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.CHILD_SEX", @female
       end
 
       response_set.responses.reload
@@ -66,16 +66,15 @@ describe OperationalDataExtractor::ParticipantVerification do
     it "creates an address record and associates it with the child" do
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ADDRESS_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_STATE", state
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ZIP", '65432'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ZIP4", '1234'
-
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ADDRESS_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_STATE", state
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ZIP", '65432'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.C_ZIP4", '1234'
       end
 
       response_set.responses.reload
@@ -95,16 +94,15 @@ describe OperationalDataExtractor::ParticipantVerification do
     it "creates a 2ndary address record and associates it with the child" do
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ADDRESS_1", '444 Easy St.'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ADDRESS_2", 'Apt 2D'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_STATE", state
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ZIP", '65432'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ZIP4", '6789'
-
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ADDRESS_1", '444 Easy St.'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ADDRESS_2", 'Apt 2D'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_STATE", state
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ZIP", '65432'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.S_ZIP4", '6789'
       end
 
       response_set.responses.reload
@@ -125,10 +123,10 @@ describe OperationalDataExtractor::ParticipantVerification do
     it "creates a telephone record and associates it with the child" do
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.PA_PHONE", '312-555-1212'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.PA_PHONE", '312-555-1212'
       end
 
       response_set.responses.reload
@@ -144,10 +142,10 @@ describe OperationalDataExtractor::ParticipantVerification do
     it "creates a 2ndary telephone record and associates it with the child" do
       response_set, instrument = prepare_instrument(@person, @child_participant, survey)
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.SA_PHONE", '312-555-4444'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_FNAME", 'Baby'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_CHILD_PREFIX}.C_LNAME", 'James'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.SA_PHONE", '312-555-4444'
       end
 
       response_set.responses.reload
@@ -175,12 +173,12 @@ describe OperationalDataExtractor::ParticipantVerification do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_MNAME", 'Anna'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
-        a.str "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.MAIDEN_NAME", 'Hitler'
-        a.date "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_MNAME", 'Anna'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.MAIDEN_NAME", 'Hitler'
+        r.a "#{OperationalDataExtractor::ParticipantVerification::INTERVIEW_PREFIX}.PERSON_DOB", '1981-01-01'
       end
 
       response_set.responses.reload
@@ -210,28 +208,27 @@ describe OperationalDataExtractor::ParticipantVerification do
     end
 
     it "sets the mode to CAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => 'capi'
       end
       OperationalDataExtractor::ParticipantVerification.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.capi
     end
 
     it "sets the mode to CATI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => 'cati'
       end
       OperationalDataExtractor::ParticipantVerification.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.cati
     end
 
     it "sets the mode to PAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", :reference_identifier => 'papi'
       end
       OperationalDataExtractor::ParticipantVerification.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.papi
     end
-
   end
 end

--- a/spec/models/operational_data_extractor/pbs_eligibility_screener_spec.rb
+++ b/spec/models/operational_data_extractor/pbs_eligibility_screener_spec.rb
@@ -30,15 +30,15 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_MNAME", 'Anna'
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
-        a.date "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_RANGE_PBS", age_range
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ETHNIC_ORIGIN", ethnic_group
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_LANG_NEW", language
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_MNAME", 'Anna'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_RANGE_PBS", age_range
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ETHNIC_ORIGIN", ethnic_group
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_LANG_NEW", language
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
       end
 
       response_set.responses.reload
@@ -67,15 +67,15 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_FNAME"
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_MNAME"
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_LNAME"
-        a.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_DOB"
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_RANGE_PBS", age_range_refused
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ETHNIC_ORIGIN", ethnic_group_refused
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_LANG_NEW", language
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
+      take_survey(@survey, response_set) do |r|
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_FNAME"
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_MNAME"
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_LNAME"
+        r.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_DOB"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_RANGE_PBS", age_range_refused
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ETHNIC_ORIGIN", ethnic_group_refused
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PERSON_LANG_NEW", language
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
       end
 
       response_set.responses.reload
@@ -106,14 +106,14 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(person, participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT", ''
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP", '65432'
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4", '1234'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT", ''
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP", '65432'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4", '1234'
       end
 
       response_set.responses.reload
@@ -137,14 +137,14 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(person, participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2"
-        a.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT"
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP"
-        a.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4"
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2"
+        r.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP"
+        r.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4"
       end
 
       response_set.responses.reload
@@ -168,14 +168,14 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(person, participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2"
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT", "123456789987654321"
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
-        a.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP"
-        a.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4"
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ADDRESS_2"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.UNIT", "123456789987654321"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.STATE", state
+        r.refused "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP"
+        r.dont_know "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ZIP4"
       end
 
       response_set.responses.reload
@@ -210,13 +210,13 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_1", '3125551234'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE1", home
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE1_OTH", ''
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_2", '3125554321'
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE2", cell
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE2_OTH", ''
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_1", '3125551234'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE1", home
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE1_OTH", ''
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_2", '3125554321'
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE2", cell
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_PHONE_TYPE2_OTH", ''
       end
 
       response_set.responses.reload
@@ -246,8 +246,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_EMAIL", 'email@dev.null'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.R_EMAIL", 'email@dev.null'
     end
 
     response_set.responses.reload
@@ -276,8 +276,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
     end
 
     response_set.responses.reload
@@ -333,8 +333,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
           response_set, instrument = prepare_instrument(person, participant, survey)
           response_set.save!
-          take_survey(survey, response_set) do |a|
-            a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+          take_survey(survey, response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
           end
           response_set.responses.reload
           OperationalDataExtractor::PbsEligibilityScreener.new(response_set).extract_data
@@ -355,8 +355,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
           response_set, instrument = prepare_instrument(person, participant, survey)
           response_set.save!
-          take_survey(survey, response_set) do |a|
-            a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+          take_survey(survey, response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
           end
           response_set.responses.reload
           OperationalDataExtractor::PbsEligibilityScreener.new(response_set).extract_data
@@ -385,8 +385,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg2
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg2
     end
 
     response_set.responses.reload
@@ -418,8 +418,8 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg5
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg5
     end
 
     response_set.responses.reload
@@ -434,7 +434,6 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     participant.ppg_status.local_code.should == 5
     participant.due_date.should be_nil
   end
-
 
   context "determining the due date of a pregnant woman" do
 
@@ -459,11 +458,11 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     it "sets the due date to the date provided by the participant" do
       due_date = Date.parse("2012-02-29")
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => due_date.month)
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", due_date.day
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", due_date.year
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => due_date.month)
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", due_date.day
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", due_date.year
       end
 
       @response_set.responses.reload
@@ -477,11 +476,11 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "does not set the due date if the format of the day is not two digits" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => 2)
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", "First"
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", "2525"
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => 2)
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", "First"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", "2525"
       end
 
       @response_set.responses.reload
@@ -495,11 +494,11 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "does not set the due date if the format of the year is not four digits" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => 2)
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", "02"
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", "2525 CE"
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", mock_model(NcsCode, :local_code => 2)
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", "02"
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", "2525 CE"
       end
 
       @response_set.responses.reload
@@ -517,15 +516,14 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
       last_period = 20.weeks.ago
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
       end
 
       @response_set.responses.reload
@@ -544,16 +542,15 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
       weeks_pregnant = 8
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-
-        a.int "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", weeks_pregnant
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", weeks_pregnant
       end
 
       @response_set.responses.reload
@@ -571,16 +568,16 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     it "calculates the due date based on the number of months pregnant" do
       months_pregnant = 4
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.int "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
       end
 
       @response_set.responses.reload
@@ -599,17 +596,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     # 3RD TRIMESTER:      ORIG_DUE_DATE = TODAY’S DATE + (280 DAYS – 235 DAYS).
     # DON’T KNOW/REFUSED: ORIG_DUE_DATE = TODAY’S DATE + (280 DAYS – 140 DAYS)
     it "calculates the due date based on the 1st trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri1
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri1
       end
 
       @response_set.responses.reload
@@ -624,17 +621,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "calculates the due date based on the 2nd trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri2
       end
 
       @response_set.responses.reload
@@ -648,17 +645,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "calculates the due date based on the 3rd trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri3
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", tri3
       end
 
       @response_set.responses.reload
@@ -672,17 +669,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "calculates the due date when refused" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_2
       end
 
       @response_set.responses.reload
@@ -696,17 +693,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "calculates the due date when don't know" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_1
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", neg_1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_1
       end
 
       @response_set.responses.reload
@@ -753,19 +750,17 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
       it "collects all the responses and maps them to their associated data_export_identifier" do
         last_period = 2.weeks.ago
 
-        take_survey(@survey, @response_set) do |a|
-          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
-          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
 
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
 
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
         end
-
-
 
         @response_set.responses.reload
 
@@ -782,16 +777,16 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
       last_period = 20.weeks.ago
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
-        a.str "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_YY", last_period.year
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_MM", mock(NcsCode, :local_code => last_period.month)
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.DATE_PERIOD_DD", last_period.day
 
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
 
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_DD", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_MM", neg_2
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE_YY", neg_2
       end
 
       @response_set.responses.reload
@@ -821,24 +816,24 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
     end
 
     it "sets the mode to CAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
       end
       OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.capi
     end
 
     it "sets the mode to CATI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
       end
       OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.cati
     end
 
     it "sets the mode to PAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
       end
       OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.papi
@@ -869,10 +864,10 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     describe "processing standard racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", black_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", other_race
-          a.str "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1_OTH", "Aborigine"
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", black_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", other_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
@@ -897,9 +892,9 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     describe "processing new type racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", white_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", vietnamese_race
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", white_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_NEW_PREFIX}.RACE_NEW", vietnamese_race
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
@@ -909,7 +904,7 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
         @person.races.should have(2).races
       end
 
-      it "the record with a choice that is on the standard race code list is represented as a simple code" do
+      it "the record with an answer on the standard race code list is represented as a simple code" do
         @person.races.map(&:race_code).should include(white_race.local_code)
       end
 
@@ -933,10 +928,10 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     describe "processing with multiple specific asian records" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", asian_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_2_PREFIX}.RACE_2", filipino_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_2_PREFIX}.RACE_2", asian_indian_race
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", asian_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_2_PREFIX}.RACE_2", filipino_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_2_PREFIX}.RACE_2", asian_indian_race
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data
@@ -962,10 +957,10 @@ describe OperationalDataExtractor::PbsEligibilityScreener do
 
     describe "processing with multiple specific pacific islander records" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", pacific_islander_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_3_PREFIX}.RACE_3", samoan_race
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_3_PREFIX}.RACE_3", native_hawaiian_race
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_1_PREFIX}.RACE_1", pacific_islander_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_3_PREFIX}.RACE_3", samoan_race
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::PBS_ELIG_SCREENER_RACE_3_PREFIX}.RACE_3", native_hawaiian_race
         end
 
         OperationalDataExtractor::PbsEligibilityScreener.new(@response_set).extract_data

--- a/spec/models/operational_data_extractor/post_natal_spec.rb
+++ b/spec/models/operational_data_extractor/post_natal_spec.rb
@@ -20,10 +20,10 @@ describe OperationalDataExtractor::PostNatal do
       response_set, instrument = prepare_instrument(@person, @child_participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.C_FNAME", 'Jo'
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.C_LNAME", 'Stafford'
-        a.date "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.CHILD_DOB", '01/01/2012'
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.C_FNAME", 'Jo'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.C_LNAME", 'Stafford'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_CHILD_SECTION_PREFIX}.CHILD_DOB", '2012-01-01'
       end
 
       response_set.responses.reload
@@ -53,8 +53,8 @@ describe OperationalDataExtractor::PostNatal do
       @response_set, instrument = prepare_instrument(@person, @participant, @survey)
       @response_set.save!
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.EMAIL", 'email@dev.null'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.EMAIL", 'email@dev.null'
       end
 
       @response_set.responses.reload
@@ -79,11 +79,11 @@ describe OperationalDataExtractor::PostNatal do
       @response_set, instrument = prepare_instrument(@person, @participant, @survey)
       @response_set.save!
 
-      take_survey(@survey, @response_set) do |a|
-        a.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_1"
-        a.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_2"
-        a.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_4"
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE", '3125557890'
+      take_survey(@survey, @response_set) do |r|
+        r.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_1"
+        r.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_2"
+        r.yes "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE_4"
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CELL_PHONE", '3125557890'
       end
 
       @response_set.responses.reload
@@ -117,18 +117,18 @@ describe OperationalDataExtractor::PostNatal do
 
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_FNAME_1", 'Donna'
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_LNAME_1", 'Noble'
-        a.choice "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_RELATE_1", @contact_neighbor
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ADDR_1_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ADDR_2_1", ''
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_UNIT_1", ''
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_CITY_1", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_STATE_1", state
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ZIP_1", '65432'
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ZIP4_1", '1234'
-        a.str "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_PHONE_1", '3125551212'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_FNAME_1", 'Donna'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_LNAME_1", 'Noble'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_RELATE_1", @contact_neighbor
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ADDR_1_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ADDR_2_1", ''
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_UNIT_1", ''
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_CITY_1", 'Chicago'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_STATE_1", state
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ZIP_1", '65432'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.C_ZIP4_1", '1234'
+        r.a "#{OperationalDataExtractor::PostNatal::SIX_MONTH_MOTHER_SECTION_PREFIX}.CONTACT_PHONE_1", '3125551212'
       end
 
       @response_set.responses.reload
@@ -170,10 +170,10 @@ describe OperationalDataExtractor::PostNatal do
 
     describe "processing racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", black_race
-          a.choice "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", other_race
-          a.str "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH", "Aborigine"
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", black_race
+          r.a "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE", other_race
+          r.a "#{OperationalDataExtractor::PostNatal::THREE_MONTH_MOTHER_RACE_PREFIX}.RACE_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PostNatal.new(@response_set).extract_data

--- a/spec/models/operational_data_extractor/ppg_follow_up_spec.rb
+++ b/spec/models/operational_data_extractor/ppg_follow_up_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe OperationalDataExtractor::PpgFollowUp do
@@ -26,9 +25,9 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 1 if the person responds that they are pregnant" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PREGNANT", @ppg1
-        a.date "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PPG_DUE_DATE_1", '2011-12-25'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PREGNANT", @ppg1
+        r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PPG_DUE_DATE_1", '2011-12-25'
       end
 
       @response_set.responses.reload
@@ -46,8 +45,8 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 3 if the person responds that they recently lost their child during pregnancy" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PREGNANT", @ppg3
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PREGNANT", @ppg3
       end
 
       @response_set.responses.reload
@@ -65,8 +64,8 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 2 if the person responds that they are trying" do
-      take_survey(@survey, @response_set) do |a|
-        a.yes "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING"
+      take_survey(@survey, @response_set) do |r|
+        r.yes "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING"
       end
 
       @response_set.responses.reload
@@ -84,8 +83,8 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 3 if the person responds that they recently lost their child" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING", @ppg3
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING", @ppg3
       end
 
       @response_set.responses.reload
@@ -103,8 +102,8 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 4 if the person responds that they recently gave birth" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING", @ppg4
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.TRYING", @ppg4
       end
 
       @response_set.responses.reload
@@ -122,8 +121,8 @@ describe OperationalDataExtractor::PpgFollowUp do
     end
 
     it "updates the ppg status to 5 if the person responds that they are medically unable to become pregnant" do
-      take_survey(@survey, @response_set) do |a|
-        a.yes "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.MED_UNABLE"
+      take_survey(@survey, @response_set) do |r|
+        r.yes "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.MED_UNABLE"
       end
 
       @response_set.responses.reload
@@ -159,9 +158,9 @@ describe OperationalDataExtractor::PpgFollowUp do
     response_set.save!
     response_set.responses.size.should == 0
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PHONE_NBR", '3125551234'
-      a.choice "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PHONE_TYPE", cell
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PHONE_NBR", '3125551234'
+      r.a "#{OperationalDataExtractor::PpgFollowUp::INTERVIEW_PREFIX}.PHONE_TYPE", cell
     end
 
     response_set.responses.reload
@@ -195,12 +194,12 @@ describe OperationalDataExtractor::PpgFollowUp do
     response_set.save!
     response_set.responses.size.should == 0
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.HOME_PHONE", '3125551234'
-      a.str "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.CELL_PHONE", '3125555678'
-      a.str "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.WORK_PHONE", '3125559012'
-      a.str "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.OTHER_PHONE", '3125553456'
-      a.str "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.EMAIL", 'email@dev.null'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.HOME_PHONE", '3125551234'
+      r.a "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.CELL_PHONE", '3125555678'
+      r.a "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.WORK_PHONE", '3125559012'
+      r.a "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.OTHER_PHONE", '3125553456'
+      r.a "#{OperationalDataExtractor::PpgFollowUp::SAQ_PREFIX}.EMAIL", 'email@dev.null'
     end
 
     response_set.responses.reload

--- a/spec/models/operational_data_extractor/pre_pregnancy_spec.rb
+++ b/spec/models/operational_data_extractor/pre_pregnancy_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe OperationalDataExtractor::PrePregnancy do
@@ -23,11 +22,11 @@ describe OperationalDataExtractor::PrePregnancy do
     response_set.save!
     response_set.responses.size.should == 0
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
-      a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
-      a.date "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
-      a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.MARISTAT", married
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.PERSON_DOB", '1981-01-01'
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.MARISTAT", married
     end
 
     response_set.responses.reload
@@ -59,10 +58,10 @@ describe OperationalDataExtractor::PrePregnancy do
     response_set.save!
     response_set.responses.size.should == 0
 
-    take_survey(survey, response_set) do |a|
-      a.yes "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE_2"
-      a.yes "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE_4"
-      a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
+    take_survey(survey, response_set) do |r|
+      r.yes "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE_2"
+      r.yes "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE_4"
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
     end
 
     response_set.responses.reload
@@ -92,8 +91,8 @@ describe OperationalDataExtractor::PrePregnancy do
     response_set.save!
     response_set.responses.size.should == 0
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
     end
 
     response_set.responses.reload
@@ -154,18 +153,18 @@ describe OperationalDataExtractor::PrePregnancy do
     it "creates a new person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Donna'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Noble'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_friend
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_1_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_2_1", ''
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_UNIT_1", ''
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_CITY_1", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_STATE_1", state
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP_1", '65432'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP4_1", '1234'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_PHONE_1", '3125551212'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Donna'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Noble'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_friend
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_1_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_2_1", ''
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_UNIT_1", ''
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_CITY_1", 'Chicago'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_STATE_1", state
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP_1", '65432'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP4_1", '1234'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_PHONE_1", '3125551212'
       end
 
       @response_set.responses.reload
@@ -191,18 +190,18 @@ describe OperationalDataExtractor::PrePregnancy do
     it "creates another new person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_2", 'Carole'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_2", 'King'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_1_2", '123 Tapestry St.'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_2_2", ''
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_UNIT_2", ''
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_CITY_2", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_STATE_2", state
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP_2", '65432'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP4_2", '1234'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_PHONE_2", '3125551212'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_2", 'Carole'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_2", 'King'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_1_2", '123 Tapestry St.'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ADDR_2_2", ''
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_UNIT_2", ''
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_CITY_2", 'Chicago'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_STATE_2", state
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP_2", '65432'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.C_ZIP4_2", '1234'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_PHONE_2", '3125551212'
       end
 
       @response_set.responses.reload
@@ -227,10 +226,10 @@ describe OperationalDataExtractor::PrePregnancy do
     it "creates an other relative person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Ivy'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Anderson'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_aunt_uncle
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Ivy'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Anderson'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_aunt_uncle
       end
 
       @response_set.responses.reload
@@ -250,10 +249,10 @@ describe OperationalDataExtractor::PrePregnancy do
     it "creates a grandparent person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Billie'
-        a.str "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Holiday'
-        a.choice "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_grandparent
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Billie'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Holiday'
+        r.a "#{OperationalDataExtractor::PrePregnancy::INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_grandparent
       end
 
       @response_set.responses.reload

--- a/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_screener_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe OperationalDataExtractor::PregnancyScreener do
@@ -34,15 +33,15 @@ describe OperationalDataExtractor::PregnancyScreener do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
-        a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
-        a.int "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE", entered_age
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE_RANGE", age_range
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ETHNICITY", ethnic_group
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_LANG", language
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.R_FNAME", 'Jo'
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_DOB", '1981-01-01'
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE", entered_age
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE_RANGE", age_range
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ETHNICITY", ethnic_group
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_LANG", language
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
       end
 
       response_set.responses.reload
@@ -66,54 +65,6 @@ describe OperationalDataExtractor::PregnancyScreener do
       person.participant.pid_age_eligibility.display_text.should == age_eligible.display_text
       person.participant.pid_age_eligibility.local_code.should == age_eligible.local_code
     end
-
-    describe "parsing datetime values" do
-
-      it "handles YYYY-MM-DD" do
-        entered_dob = "1981-01-11"
-        response_set, instrument = prepare_instrument(@person, @participant, @survey)
-        response_set.save!
-
-        take_survey(@survey, response_set) do |a|
-          a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_DOB", entered_dob
-        end
-
-        response_set.responses.reload
-        response_set.responses.size.should == 1
-
-        OperationalDataExtractor::PregnancyScreener.new(response_set).extract_data
-
-        person = Person.find(@person.id)
-        person.person_dob.should == Date.parse(entered_dob).to_s
-        person.person_dob_date.should == Date.parse(entered_dob)
-      end
-
-      it "handles YYYYMMDD"
-
-      it "handles MM/DD/YYYY" do
-        entered_dob = "01/11/1981"
-        response_set, instrument = prepare_instrument(@person, @participant, @survey)
-        response_set.save!
-
-        take_survey(@survey, response_set) do |a|
-          a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PERSON_DOB", entered_dob
-        end
-
-        response_set.responses.reload
-        response_set.responses.size.should == 1
-
-        OperationalDataExtractor::PregnancyScreener.new(response_set).extract_data
-
-        person = Person.find(@person.id)
-        person.person_dob.class.should == String
-        person.person_dob.should == Date.parse(entered_dob).to_s
-        person.person_dob_date.should == Date.parse(entered_dob)
-      end
-
-      it "handles MM/DD/YY"
-
-    end
-
   end
 
   # ADDRESS_1             Address.address_one
@@ -134,14 +85,14 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ADDRESS_2", ''
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.UNIT", ''
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
-      a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.STATE", state
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ZIP", '65432'
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ZIP4", '1234'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ADDRESS_1", '123 Easy St.'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ADDRESS_2", ''
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.UNIT", ''
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CITY", 'Chicago'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.STATE", state
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ZIP", '65432'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ZIP4", '1234'
     end
 
     response_set.responses.reload
@@ -170,14 +121,14 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ADDRESS_1", '123 Easy St.'
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ADDRESS_2", ''
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_UNIT", ''
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_CITY", 'Chicago'
-      a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_STATE", state
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ZIP", '65432'
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ZIP4", '1234'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ADDRESS_1", '123 Easy St.'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ADDRESS_2", ''
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_UNIT", ''
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_CITY", 'Chicago'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_STATE", state
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ZIP", '65432'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MAIL_ZIP4", '1234'
     end
 
     response_set.responses.reload
@@ -214,15 +165,15 @@ describe OperationalDataExtractor::PregnancyScreener do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '3125551234'
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR_OTH", ''
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_TYPE", cell
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_TYPE_OTH", ''
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.HOME_PHONE", '3125554321'
-        a.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE_2"
-        a.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE_4"
-        a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '3125551234'
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR_OTH", ''
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_TYPE", cell
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_TYPE_OTH", ''
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.HOME_PHONE", '3125554321'
+        r.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE_2"
+        r.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE_4"
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
       end
 
       response_set.responses.reload
@@ -246,8 +197,8 @@ describe OperationalDataExtractor::PregnancyScreener do
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
         response_set.save!
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '312.555.1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '312.555.1234'
         end
 
         response_set.responses.reload
@@ -268,8 +219,8 @@ describe OperationalDataExtractor::PregnancyScreener do
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
         response_set.save!
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '(312) 555-1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '(312) 555-1234'
         end
 
         response_set.responses.reload
@@ -290,8 +241,8 @@ describe OperationalDataExtractor::PregnancyScreener do
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
         response_set.save!
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '(312) 5551234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '(312) 5551234'
         end
 
         response_set.responses.reload
@@ -312,8 +263,8 @@ describe OperationalDataExtractor::PregnancyScreener do
         response_set, instrument = prepare_instrument(@person, @participant, @survey)
         response_set.save!
 
-        take_survey(@survey, response_set) do |a|
-          a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '312-555-1234'
+        take_survey(@survey, response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PHONE_NBR", '312-555-1234'
         end
 
         response_set.responses.reload
@@ -346,9 +297,9 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
-      a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.EMAIL_TYPE", home
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.EMAIL_TYPE", home
     end
 
     response_set.responses.reload
@@ -390,9 +341,9 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-      a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", '2011-12-25'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+      r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", '2011-12-25'
     end
 
     response_set.responses.reload
@@ -424,8 +375,8 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRYING"
+    take_survey(survey, response_set) do |r|
+      r.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRYING"
     end
 
     response_set.responses.reload
@@ -455,8 +406,8 @@ describe OperationalDataExtractor::PregnancyScreener do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.HYSTER"
+    take_survey(survey, response_set) do |r|
+      r.yes "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.HYSTER"
     end
 
     response_set.responses.reload
@@ -497,9 +448,9 @@ describe OperationalDataExtractor::PregnancyScreener do
 
       due_date = "2012-02-29"
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", due_date
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", due_date
       end
 
       @response_set.responses.reload
@@ -518,10 +469,10 @@ describe OperationalDataExtractor::PregnancyScreener do
 
       last_period = 20.weeks.ago
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.date "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", last_period
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", last_period.strftime('%Y-%m-%d')
       end
 
       @response_set.responses.reload
@@ -540,11 +491,11 @@ describe OperationalDataExtractor::PregnancyScreener do
 
       weeks_pregnant = 8
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.int "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", weeks_pregnant
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", weeks_pregnant
       end
 
       @response_set.responses.reload
@@ -562,12 +513,12 @@ describe OperationalDataExtractor::PregnancyScreener do
     it "calculates the due date based on the number of months pregnant" do
       months_pregnant = 4
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.int "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a"#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
       end
 
       @response_set.responses.reload
@@ -586,13 +537,13 @@ describe OperationalDataExtractor::PregnancyScreener do
     # 3RD TRIMESTER:      ORIG_DUE_DATE = TODAY’S DATE + (280 DAYS – 235 DAYS).
     # DON’T KNOW/REFUSED: ORIG_DUE_DATE = TODAY’S DATE + (280 DAYS – 140 DAYS)
     it "calculates the due date based on the 1st trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri1
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri1
       end
 
       @response_set.responses.reload
@@ -607,13 +558,13 @@ describe OperationalDataExtractor::PregnancyScreener do
     end
 
     it "calculates the due date based on the 2nd trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri2
       end
 
       @response_set.responses.reload
@@ -627,13 +578,13 @@ describe OperationalDataExtractor::PregnancyScreener do
     end
 
     it "calculates the due date based on the 3rd trimester" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri3
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", tri3
       end
 
       @response_set.responses.reload
@@ -647,13 +598,13 @@ describe OperationalDataExtractor::PregnancyScreener do
     end
 
     it "calculates the due date when refused" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_2
       end
 
       @response_set.responses.reload
@@ -667,13 +618,13 @@ describe OperationalDataExtractor::PregnancyScreener do
     end
 
     it "calculates the due date when don't know" do
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_1
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.TRIMESTER", neg_1
       end
 
       @response_set.responses.reload
@@ -719,12 +670,12 @@ describe OperationalDataExtractor::PregnancyScreener do
     describe "#data_export_identifier_indexed_responses" do
       it "collects all the responses and maps them to their associated data_export_identifier" do
         months_pregnant = 2
-        take_survey(@survey, @response_set) do |a|
-          a.int "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+          r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
         end
 
         @response_set.responses.reload
@@ -741,12 +692,12 @@ describe OperationalDataExtractor::PregnancyScreener do
     it "calculates the due date based on the number of months pregnant" do
       months_pregnant = 4
 
-      take_survey(@survey, @response_set) do |a|
-        a.int "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
-        a.choice "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.MONTH_PREG", months_pregnant
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.DATE_PERIOD", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.PREGNANT", ppg1
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.WEEKS_PREG", neg_2
+        r.a "#{OperationalDataExtractor::PregnancyScreener::INTERVIEW_PREFIX}.ORIG_DUE_DATE", neg_2
       end
 
       @response_set.responses.reload
@@ -778,10 +729,10 @@ describe OperationalDataExtractor::PregnancyScreener do
 
     describe "processing racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", black_race
-          a.choice "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", other_race
-          a.str "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH", "Aborigine"
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", black_race
+          r.a "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE", other_race
+          r.a "#{OperationalDataExtractor::PregnancyScreener::PREG_SCREEN_HI_RACE_2_PREFIX}.RACE_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PregnancyScreener.new(@response_set).extract_data

--- a/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
+++ b/spec/models/operational_data_extractor/pregnancy_visit_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe OperationalDataExtractor::PregnancyVisit do
@@ -21,11 +20,11 @@ describe OperationalDataExtractor::PregnancyVisit do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.R_FNAME", 'Jo'
-      a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
-      a.date "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.PERSON_DOB", '01/01/1981'
-      a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.R_FNAME", 'Jo'
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.R_LNAME", 'Stafford'
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.PERSON_DOB", '1981-01-01'
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.AGE_ELIG", age_eligible
     end
 
     response_set.responses.reload
@@ -80,17 +79,17 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.FATHER_NAME", 'Lonnie Johnson'
-        a.int "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.FATHER_AGE", 23
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ADDR1_2", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ADDR_2_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_UNIT_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_CITY_2", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_STATE_2", state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ZIPCODE_2", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ZIP4_2", '1234'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_PHONE", '3125551212'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.FATHER_NAME", 'Lonnie Johnson'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.FATHER_AGE", 23
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ADDR1_2", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ADDR_2_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_UNIT_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_CITY_2", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_STATE_2", state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ZIPCODE_2", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_ZIP4_2", '1234'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_SAQ_2_PREFIX}.F_PHONE", '3125551212'
       end
 
       response_set.responses.reload
@@ -117,18 +116,18 @@ describe OperationalDataExtractor::PregnancyVisit do
     it "creates a new person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Donna'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Noble'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_friend
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_1_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_2_1", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_UNIT_1", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_CITY_1", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_STATE_1", state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIPCODE_1", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIP4_1", '1234'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_PHONE_1", '3125551212'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Donna'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Noble'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_friend
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_1_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_2_1", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_UNIT_1", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_CITY_1", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_STATE_1", state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIPCODE_1", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIP4_1", '1234'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_PHONE_1", '3125551212'
       end
 
       @response_set.responses.reload
@@ -153,18 +152,18 @@ describe OperationalDataExtractor::PregnancyVisit do
     it "creates another new person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_2", 'Carole'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_2", 'King'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_1_2", '123 Tapestry St.'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_2_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_UNIT_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_CITY_2", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_STATE_2", state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIPCODE_2", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIP4_2", '1234'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_PHONE_2", '3125551212'
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_2", 'Carole'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_2", 'King'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_1_2", '123 Tapestry St.'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ADDR_2_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_UNIT_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_CITY_2", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_STATE_2", state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIPCODE_2", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.C_ZIP4_2", '1234'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_PHONE_2", '3125551212'
       end
 
       @response_set.responses.reload
@@ -189,10 +188,10 @@ describe OperationalDataExtractor::PregnancyVisit do
     it "creates an other relative person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Ivy'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Anderson'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_aunt_uncle
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Ivy'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Anderson'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_aunt_uncle
       end
 
       @response_set.responses.reload
@@ -212,10 +211,10 @@ describe OperationalDataExtractor::PregnancyVisit do
     it "creates a grandparent person record and associates it with the particpant" do
       state = NcsCode.for_list_name_and_local_code("STATE_CL1", 14)
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Billie'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Holiday'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_grandparent
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_FNAME_1", 'Billie'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_LNAME_1", 'Holiday'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CONTACT_RELATE_1", @contact_grandparent
       end
 
       @response_set.responses.reload
@@ -249,10 +248,10 @@ describe OperationalDataExtractor::PregnancyVisit do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_2"
-      a.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_4"
-      a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
+    take_survey(survey, response_set) do |r|
+      r.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_2"
+      r.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_4"
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
     end
 
     response_set.responses.reload
@@ -285,10 +284,10 @@ describe OperationalDataExtractor::PregnancyVisit do
     survey = create_pregnancy_visit_1_survey_with_telephone_operational_data
     response_set, instrument = prepare_instrument(person, participant, survey)
 
-    take_survey(survey, response_set) do |a|
-      a.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_2"
-      a.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_4"
-      a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
+    take_survey(survey, response_set) do |r|
+      r.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_2"
+      r.yes "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE_4"
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3125557890'
     end
 
     response_set.save!
@@ -319,8 +318,8 @@ describe OperationalDataExtractor::PregnancyVisit do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
     end
 
     response_set.responses.reload
@@ -361,11 +360,11 @@ describe OperationalDataExtractor::PregnancyVisit do
       it "sets the due date to the date provided by the participant" do
         due_date = Date.parse("2012-02-29")
 
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_MM", due_date.month
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_DD", due_date.day
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_YY", due_date.year
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_MM", due_date.month.to_s
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_DD", due_date.day.to_s
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_YY", due_date.year.to_s
         end
 
         @response_set.responses.reload
@@ -381,13 +380,13 @@ describe OperationalDataExtractor::PregnancyVisit do
       # # CALCULATE DUE DATE FROM THE FIRST DATE OF LAST MENSTRUAL PERIOD AND SET ORIG_DUE_DATE = DATE_PERIOD + 280 DAYS
       it "calculates the due date based on the date of the last menstrual period" do
         last_period = 20.weeks.ago.to_date
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_MM", neg_2
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_DD", neg_2
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_YY", neg_2
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_MM", neg_2
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_DD", neg_2
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DUE_DATE_YY", neg_2
 
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DATE_PERIOD", last_period.to_s
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DATE_PERIOD", last_period.strftime('%Y-%m-%d')
         end
 
         @response_set.responses.reload
@@ -402,9 +401,9 @@ describe OperationalDataExtractor::PregnancyVisit do
 
       it "does not set the due date if the date of the last menstrual period is not valid date" do
         last_period = "2012-92-92"
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DATE_PERIOD", last_period
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.DATE_PERIOD", last_period
         end
 
         @response_set.responses.reload
@@ -427,9 +426,9 @@ describe OperationalDataExtractor::PregnancyVisit do
 
       it "sets the due date to the date provided by the participant" do
         due_date = "2012-02-29"
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.DUE_DATE", due_date
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.DUE_DATE", due_date
         end
 
         @response_set.responses.reload
@@ -444,9 +443,9 @@ describe OperationalDataExtractor::PregnancyVisit do
 
       it "does not set the due date if date provided by the participant is not valid date" do
         due_date = "2012-92-92"
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.DUE_DATE", due_date
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.PREGNANT", ppg1
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.DUE_DATE", due_date
         end
 
         @response_set.responses.reload
@@ -487,10 +486,10 @@ describe OperationalDataExtractor::PregnancyVisit do
       @institution.response_set = response_set
       @institution.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 3
@@ -498,10 +497,10 @@ describe OperationalDataExtractor::PregnancyVisit do
       OperationalDataExtractor::PregnancyVisit.new(response_set).extract_data
       @participant.person.institutions.size.should == 2
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 6
@@ -529,10 +528,10 @@ describe OperationalDataExtractor::PregnancyVisit do
       @institution.response_set = response_set
       @institution.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 3
@@ -540,10 +539,10 @@ describe OperationalDataExtractor::PregnancyVisit do
       OperationalDataExtractor::PregnancyVisit.new(response_set).extract_data
       @participant.person.institutions.size.should == 1
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 6
@@ -560,10 +559,10 @@ describe OperationalDataExtractor::PregnancyVisit do
                                                     survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 3
@@ -571,10 +570,10 @@ describe OperationalDataExtractor::PregnancyVisit do
       OperationalDataExtractor::PregnancyVisit.new(response_set).extract_data
       @participant.person.institutions.size.should == 1
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '234 Hospital Way'
       end
       response_set.responses.reload
       response_set.responses.size.should == 6
@@ -609,8 +608,8 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant,
                                                      survey)
       response_set.save!
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3129090909'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3129090909'
       end
 
       response_set.responses.reload
@@ -621,8 +620,8 @@ describe OperationalDataExtractor::PregnancyVisit do
       @person.telephones.first.phone_rank_code.should == 1
       @person.telephones.first.phone_nbr.should == '3129090909'
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3129090999'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.CELL_PHONE", '3129090999'
       end
 
       response_set.responses.reload
@@ -641,8 +640,8 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant,
                                                      survey)
       response_set.save!
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email@dev.null'
       end
 
       response_set.responses.reload
@@ -653,8 +652,8 @@ describe OperationalDataExtractor::PregnancyVisit do
       @person.emails.first.email.should == 'email@dev.null'
       @person.emails.first.email_rank_code.should == 1
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email2@dev.null'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_2_INTERVIEW_PREFIX}.EMAIL", 'email2@dev.null'
       end
 
       response_set.responses.reload
@@ -673,14 +672,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant,
                                                      survey)
       response_set.save!
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
       end
 
       response_set.responses.reload
@@ -691,13 +690,13 @@ describe OperationalDataExtractor::PregnancyVisit do
       address = @participant.person.institutions.first.addresses.first
       address.to_s.should == "123 Hospital Way Chicago, ILLINOIS 65432"
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '321 Hospital Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", '4'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Moab'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '23456'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL 2"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '321 Hospital Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", '4'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Moab'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '23456'
       end
 
       response_set.responses.reload
@@ -728,14 +727,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
       end
 
       response_set.responses.reload
@@ -753,14 +752,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ADDRESS_1", '123 Work Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_UNIT", '3333'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ZIP", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ZIP4", '1234'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ADDRESS_1", '123 Work Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_UNIT", '3333'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ZIP", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_1_3_INTERVIEW_PREFIX}.WORK_ZIP4", '1234'
       end
 
       response_set.responses.reload
@@ -780,14 +779,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.BIRTH_PLAN", @hospital
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.BIRTH_PLACE", "FAKE HOSPITAL MEMORIAL"
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ADDRESS_1", '123 Hospital Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.B_ZIPCODE", '65432'
       end
 
       response_set.responses.reload
@@ -805,14 +804,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ADDRESS_1", '123 Work Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_UNIT", '3333'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ZIPCODE", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ZIP4", '1234'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ADDRESS_1", '123 Work Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_UNIT", '3333'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ZIPCODE", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.WORK_ZIP4", '1234'
       end
 
       response_set.responses.reload
@@ -832,14 +831,14 @@ describe OperationalDataExtractor::PregnancyVisit do
       response_set, instrument = prepare_instrument(@person, @participant, survey)
       response_set.save!
 
-      take_survey(survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ADDRESS_1", '123 Confirm Work Way'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ADDRESS_2", ''
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_UNIT", '3333'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_CITY", 'Chicago'
-        a.choice "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_STATE", @state
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ZIPCODE", '65432'
-        a.str "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ZIP4", '1234'
+      take_survey(survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ADDRESS_1", '123 Confirm Work Way'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ADDRESS_2", ''
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_UNIT", '3333'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_CITY", 'Chicago'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_STATE", @state
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ZIPCODE", '65432'
+        r.a "#{OperationalDataExtractor::PregnancyVisit::PREGNANCY_VISIT_2_3_INTERVIEW_PREFIX}.CWORK_ZIP4", '1234'
       end
 
       response_set.responses.reload
@@ -888,24 +887,24 @@ describe OperationalDataExtractor::PregnancyVisit do
     end
 
     it "sets the mode to CAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
       end
       OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.capi
     end
 
     it "sets the mode to CATI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
       end
       OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.cati
     end
 
     it "sets the mode to PAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
       end
       OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.papi
@@ -930,10 +929,10 @@ describe OperationalDataExtractor::PregnancyVisit do
 
     describe "processing standard racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", black_race
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", other_race
-          a.str "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH", "Aborigine"
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", black_race
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1", other_race
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_1_3_INTERVIEW_PREFIX}.RACE_1_OTH", "Aborigine"
         end
 
         OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data
@@ -958,9 +957,9 @@ describe OperationalDataExtractor::PregnancyVisit do
 
     describe "processing new type racial data" do
       before do
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", white_race
-          a.choice "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", vietnamese_race
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", white_race
+          r.a "#{OperationalDataExtractor::PregnancyVisit::PREG_VISIT_1_RACE_NEW_3_INTERVIEW_PREFIX}.RACE_NEW", vietnamese_race
         end
 
         OperationalDataExtractor::PregnancyVisit.new(@response_set).extract_data

--- a/spec/models/operational_data_extractor/sample_spec.rb
+++ b/spec/models/operational_data_extractor/sample_spec.rb
@@ -51,8 +51,8 @@ describe OperationalDataExtractor::Sample do
         response_set, instrument = prepare_instrument(person, participant, survey)
         expected = 'EC2345671 – DB01'
 
-        take_survey(survey, response_set) do |a|
-          a.str "VACUUM_BAG.SAMPLE_ID", expected
+        take_survey(survey, response_set) do |r|
+          r.a "VACUUM_BAG.SAMPLE_ID", expected
         end
 
         response_set.responses.reload
@@ -83,10 +83,10 @@ describe OperationalDataExtractor::Sample do
           'EC2224443 – WQ03',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
         end
 
         response_set.responses.reload
@@ -109,9 +109,9 @@ describe OperationalDataExtractor::Sample do
           'EC2224442 – WQ02',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
+        take_survey(survey, response_set) do |r|
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
         end
 
         response_set.responses.reload
@@ -132,10 +132,10 @@ describe OperationalDataExtractor::Sample do
           'EC8989898 – WQ03',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
         end
 
         response_set.responses.reload
@@ -157,8 +157,8 @@ describe OperationalDataExtractor::Sample do
           'EC2224441 – WQ01',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "TAP_WATER_TWF_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
         end
 
         response_set.responses.reload
@@ -192,10 +192,10 @@ describe OperationalDataExtractor::Sample do
           'EC2224443 – WQ03',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "TAP_WATER_TWQ_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
-          a.str "TAP_WATER_TWQ_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
-          a.str "TAP_WATER_TWQ_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "TAP_WATER_TWQ_SAMPLE[sample_number=1].SAMPLE_ID", sample_ids[0]
+          r.a "TAP_WATER_TWQ_SAMPLE[sample_number=2].SAMPLE_ID", sample_ids[1]
+          r.a "TAP_WATER_TWQ_SAMPLE[sample_number=3].SAMPLE_ID", sample_ids[2]
         end
 
         response_set.responses.reload
@@ -224,10 +224,10 @@ describe OperationalDataExtractor::Sample do
           'EC2224444-SB03',
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SAMPLE_DIST_SAMP[type=1].SAMPLE_ID", sample_ids[0]
-          a.str "SAMPLE_DIST_SAMP[type=2].SAMPLE_ID", sample_ids[1]
-          a.str "SAMPLE_DIST_SAMP[type=3].SAMPLE_ID", sample_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "SAMPLE_DIST_SAMP[type=1].SAMPLE_ID", sample_ids[0]
+          r.a "SAMPLE_DIST_SAMP[type=2].SAMPLE_ID", sample_ids[1]
+          r.a "SAMPLE_DIST_SAMP[type=3].SAMPLE_ID", sample_ids[2]
         end
 
         response_set.responses.reload

--- a/spec/models/operational_data_extractor/specimen_spec.rb
+++ b/spec/models/operational_data_extractor/specimen_spec.rb
@@ -49,8 +49,8 @@ describe OperationalDataExtractor::Specimen do
         response_set, instrument = prepare_instrument(person, participant, survey)
         expected = 'AA1234567-UR01'
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_URINE.SPECIMEN_ID", expected
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_URINE.SPECIMEN_ID", expected
         end
 
         response_set.responses.reload
@@ -84,13 +84,13 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-AD10",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
-          a.str "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
-          a.str "SPEC_BLOOD_TUBE[tube_type=5].SPECIMEN_ID", specimen_ids[4]
-          a.str "SPEC_BLOOD_TUBE[tube_type=6].SPECIMEN_ID", specimen_ids[5]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
+          r.a "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
+          r.a "SPEC_BLOOD_TUBE[tube_type=5].SPECIMEN_ID", specimen_ids[4]
+          r.a "SPEC_BLOOD_TUBE[tube_type=6].SPECIMEN_ID", specimen_ids[5]
         end
 
         response_set.responses.reload
@@ -114,8 +114,8 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-SS10",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
         end
 
         response_set.responses.reload
@@ -142,11 +142,11 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-LV10",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
-          a.str "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
+          r.a "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
         end
 
         response_set.responses.reload
@@ -170,13 +170,13 @@ describe OperationalDataExtractor::Specimen do
           "AA999999-AD10",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", update_specimen_ids[0]
-          a.str "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", update_specimen_ids[1]
-          a.str "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", update_specimen_ids[2]
-          a.str "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", update_specimen_ids[3]
-          a.str "SPEC_BLOOD_TUBE[tube_type=5].SPECIMEN_ID", update_specimen_ids[4]
-          a.str "SPEC_BLOOD_TUBE[tube_type=6].SPECIMEN_ID", update_specimen_ids[5]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", update_specimen_ids[0]
+          r.a "SPEC_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", update_specimen_ids[1]
+          r.a "SPEC_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", update_specimen_ids[2]
+          r.a "SPEC_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", update_specimen_ids[3]
+          r.a "SPEC_BLOOD_TUBE[tube_type=5].SPECIMEN_ID", update_specimen_ids[4]
+          r.a "SPEC_BLOOD_TUBE[tube_type=6].SPECIMEN_ID", update_specimen_ids[5]
         end
 
         response_set.responses.reload
@@ -204,10 +204,10 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-CB01",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_CORD_BLOOD_SPECIMEN[cord_container=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN[cord_container=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN[cord_container=3].SPECIMEN_ID", specimen_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_CORD_BLOOD_SPECIMEN[cord_container=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN[cord_container=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN[cord_container=3].SPECIMEN_ID", specimen_ids[2]
         end
 
         response_set.responses.reload
@@ -233,10 +233,10 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-CB02",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=3].SPECIMEN_ID", specimen_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_2[collection_type=3].SPECIMEN_ID", specimen_ids[2]
         end
 
         response_set.responses.reload
@@ -262,10 +262,10 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-CB03",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=3].SPECIMEN_ID", specimen_ids[2]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "SPEC_CORD_BLOOD_SPECIMEN_3[collection_type=3].SPECIMEN_ID", specimen_ids[2]
         end
 
         response_set.responses.reload
@@ -289,8 +289,8 @@ describe OperationalDataExtractor::Specimen do
           "AA123456-CB01",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "SPEC_CORD_BLOOD_SPECIMEN[cord_container=1].SPECIMEN_ID", specimen_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "SPEC_CORD_BLOOD_SPECIMEN[cord_container=1].SPECIMEN_ID", specimen_ids[0]
         end
 
         response_set.responses.reload
@@ -319,11 +319,11 @@ describe OperationalDataExtractor::Specimen do
           "AA1212122-LV21",
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "CHILD_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
-          a.str "CHILD_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
-          a.str "CHILD_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
-          a.str "CHILD_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
+        take_survey(survey, response_set) do |r|
+          r.a "CHILD_BLOOD_TUBE[tube_type=1].SPECIMEN_ID", specimen_ids[0]
+          r.a "CHILD_BLOOD_TUBE[tube_type=2].SPECIMEN_ID", specimen_ids[1]
+          r.a "CHILD_BLOOD_TUBE[tube_type=3].SPECIMEN_ID", specimen_ids[2]
+          r.a "CHILD_BLOOD_TUBE[tube_type=4].SPECIMEN_ID", specimen_ids[3]
         end
 
         response_set.responses.reload
@@ -349,8 +349,8 @@ describe OperationalDataExtractor::Specimen do
           "AA1212122-SC12"
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "CHILD_SALIVA.SPECIMEN_ID", specimen_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "CHILD_SALIVA.SPECIMEN_ID", specimen_ids[0]
         end
 
         response_set.responses.reload
@@ -375,8 +375,8 @@ describe OperationalDataExtractor::Specimen do
           "AA1212122-BU12"
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "CHILD_URINE.SPECIMEN_ID", specimen_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "CHILD_URINE.SPECIMEN_ID", specimen_ids[0]
         end
 
         response_set.responses.reload
@@ -401,8 +401,8 @@ describe OperationalDataExtractor::Specimen do
           "AA1212122-BM12"
         ]
 
-        take_survey(survey, response_set) do |a|
-          a.str "BREAST_MILK_SAQ.SPECIMEN_ID", specimen_ids[0]
+        take_survey(survey, response_set) do |r|
+          r.a "BREAST_MILK_SAQ.SPECIMEN_ID", specimen_ids[0]
         end
 
         response_set.responses.reload

--- a/spec/models/operational_data_extractor/tracing_module_spec.rb
+++ b/spec/models/operational_data_extractor/tracing_module_spec.rb
@@ -17,14 +17,14 @@ describe OperationalDataExtractor::TracingModule do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ADDRESS_1", '123 Easy St.'
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ADDRESS_2", ''
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.UNIT", ''
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CITY", 'Chicago'
-      a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.STATE", state
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ZIP", '65432'
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ZIP4", '1234'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ADDRESS_1", '123 Easy St.'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ADDRESS_2", ''
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.UNIT", ''
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CITY", 'Chicago'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.STATE", state
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ZIP", '65432'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.ZIP4", '1234'
     end
 
     response_set.responses.reload
@@ -52,14 +52,14 @@ describe OperationalDataExtractor::TracingModule do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ADDRESS1", '345 Easy St.'
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ADDRESS2", ''
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_UNIT", ''
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_CITY", 'Chicago'
-      a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_STATE", state
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ZIP", '60666'
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ZIP4", '1234'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ADDRESS1", '345 Easy St.'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ADDRESS2", ''
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_UNIT", ''
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_CITY", 'Chicago'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_STATE", state
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ZIP", '60666'
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.NEW_ZIP4", '1234'
     end
 
     response_set.responses.reload
@@ -92,11 +92,11 @@ describe OperationalDataExtractor::TracingModule do
       response_set, instrument = prepare_instrument(@person, @participant, @survey)
       response_set.save!
 
-      take_survey(@survey, response_set) do |a|
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.HOME_PHONE", '3125554321'
-        a.yes "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE_2"
-        a.yes "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE_4"
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE", '3125557890'
+      take_survey(@survey, response_set) do |r|
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.HOME_PHONE", '3125554321'
+        r.yes "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE_2"
+        r.yes "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE_4"
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CELL_PHONE", '3125557890'
       end
 
       response_set.responses.reload
@@ -126,8 +126,8 @@ describe OperationalDataExtractor::TracingModule do
     response_set, instrument = prepare_instrument(person, participant, survey)
     response_set.save!
 
-    take_survey(survey, response_set) do |a|
-      a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.EMAIL", 'email@dev.null'
+    take_survey(survey, response_set) do |r|
+      r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.EMAIL", 'email@dev.null'
     end
 
     response_set.responses.reload
@@ -175,19 +175,19 @@ describe OperationalDataExtractor::TracingModule do
 
     it "creates a new person record and associates it with the particpant" do
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_1", 'Donna'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_1", 'Noble'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_1", @contact_friend
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_1", '123 Easy St.'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR2_1", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_1", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_1", 'Chicago'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_1", state
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_1", '65432'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_1", '1234'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_1", '3125551212'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_1", home
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_1", 'Donna'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_1", 'Noble'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_1", @contact_friend
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_1", '123 Easy St.'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR2_1", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_1", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_1", 'Chicago'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_1", state
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_1", '65432'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_1", '1234'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_1", '3125551212'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_1", home
       end
 
       @response_set.responses.reload
@@ -212,21 +212,21 @@ describe OperationalDataExtractor::TracingModule do
 
     it "creates another new person record and associates it with the particpant" do
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_2", 'Carole'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_2", 'King'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_2", '123 Tapestry St.'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR_2_2", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_2", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_2", 'Chicago'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_2", state
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_2", '65432'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_2", '1234'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2", '3125551212'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_2", home
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2_2", '3125556789'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE2_TYPE_2", cell
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_2", 'Carole'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_2", 'King'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_2", @contact_neighbor
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_2", '123 Tapestry St.'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR_2_2", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_2", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_2", 'Chicago'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_2", state
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_2", '65432'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_2", '1234'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2", '3125551212'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_2", home
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2_2", '3125556789'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE2_TYPE_2", cell
       end
 
       @response_set.responses.reload
@@ -251,21 +251,21 @@ describe OperationalDataExtractor::TracingModule do
 
     it "creates a third person record and associates it with the particpant" do
 
-      take_survey(@survey, @response_set) do |a|
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_2", 'Jaka'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_2", 'Cerebus'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_2", @contact_aunt_uncle
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_2", '123 Regency St.'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR_2_2", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_2", ''
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_2", 'Chicago'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_2", state
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_2", '65432'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_2", '1234'
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2", '3125551212'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_2", home
-        a.str "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2_2", '3125556789'
-        a.choice "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE2_TYPE_2", cell
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_FNAME_2", 'Jaka'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_LNAME_2", 'Cerebus'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_RELATE_2", @contact_aunt_uncle
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR1_2", '123 Regency St.'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ADDR_2_2", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_UNIT_2", ''
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_CITY_2", 'Chicago'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_STATE_2", state
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIPCODE_2", '65432'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.C_ZIP4_2", '1234'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2", '3125551212'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE1_TYPE_2", home
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE_2_2", '3125556789'
+        r.a "#{OperationalDataExtractor::TracingModule::TRACING_MODULE_PREFIX}.CONTACT_PHONE2_TYPE_2", cell
       end
 
       @response_set.responses.reload
@@ -303,24 +303,24 @@ describe OperationalDataExtractor::TracingModule do
     end
 
     it "sets the mode to CAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "capi")
       end
       OperationalDataExtractor::TracingModule.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.capi
     end
 
     it "sets the mode to CATI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "cati")
       end
       OperationalDataExtractor::TracingModule.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.cati
     end
 
     it "sets the mode to PAPI" do
-      take_survey(survey, @response_set) do |a|
-        a.choice "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
+      take_survey(survey, @response_set) do |r|
+        r.a "prepopulated_mode_of_contact", mock(NcsCode, :local_code => "papi")
       end
       OperationalDataExtractor::TracingModule.new(@response_set).extract_data
       Instrument.find(@instrument.id).instrument_mode_code.should == Instrument.papi

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1504,12 +1504,12 @@ describe Participant do
         @not_first_visit = NcsCode.for_list_name_and_local_code("CONFIRM_TYPE_CL7", 2)
         @provider_in_frame = NcsCode.for_list_name_and_local_code("PROVIDER_OFFICE_ON_FRAME_CL1", 1)
 
-        take_survey(@survey, @response_set) do |a|
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @age_eligible
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @lives_in_county
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT",@pregnant
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @first_visit
-          a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX_PROVIDER_OFFICE}.PROVIDER_OFFICE_ON_FRAME", @provider_out_of_frame
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @age_eligible
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @lives_in_county
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT",@pregnant
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @first_visit
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX_PROVIDER_OFFICE}.PROVIDER_OFFICE_ON_FRAME", @provider_out_of_frame
         end
 
         @response_set.responses.reload
@@ -1539,7 +1539,10 @@ describe Participant do
         end
 
         it "returns false if participant is not age eligible" do
-          take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @not_age_eligible }
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @not_age_eligible
+          end
+
           @part.should_not be_age_eligible(@pers)
         end
       end
@@ -1550,7 +1553,10 @@ describe Participant do
         end
 
         it "returns false if participant coes not live in an eligible PSU" do
-          take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @does_not_live_in_county }
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @does_not_live_in_county
+          end
+
           @part.should_not be_psu_county_eligible(@pers)
         end
       end
@@ -1561,7 +1567,10 @@ describe Participant do
         end
 
         it "returns false if they are not pregnant" do
-          take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", @not_pregnant }
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PREGNANT", @not_pregnant
+          end
+
           @part.should_not be_pbs_pregnant(@pers)
         end
       end
@@ -1572,7 +1581,10 @@ describe Participant do
         end
 
         it "returns false if its not the participant's first visit" do
-          take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @not_first_visit }
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @not_first_visit
+          end
+
           @part.should_not be_first_visit(@pers)
         end
       end
@@ -1583,7 +1595,10 @@ describe Participant do
         end
 
         it "returns false if there was a former provider in frame" do
-          take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX_PROVIDER_OFFICE}.PROVIDER_OFFICE_ON_FRAME", @provider_in_frame }
+          take_survey(@survey, @response_set) do |r|
+            r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX_PROVIDER_OFFICE}.PROVIDER_OFFICE_ON_FRAME", @provider_in_frame
+          end
+
           @part.should_not be_no_preceding_providers_in_frame(@pers, "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX_PROVIDER_OFFICE}")
         end
 
@@ -1594,7 +1609,10 @@ describe Participant do
       end
 
       it "returns false if ineligible" do
-        take_survey(@survey, @response_set) { |a| a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @does_not_live_in_county }
+        take_survey(@survey, @response_set) do |r|
+          r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @does_not_live_in_county
+        end
+
         @part.should_not be_psu_county_eligible(@pers)
         @part.should be_ineligible
       end
@@ -1646,8 +1664,6 @@ describe Participant do
   end
 
   context "confirming participant eligibility for Birth Cohort" do
-    include SurveyCompletion
-
     describe "#eligible?" do
       include_context 'custom recruitment strategy'
 

--- a/spec/models/sampled_persons_ineligibility_spec.rb
+++ b/spec/models/sampled_persons_ineligibility_spec.rb
@@ -84,10 +84,10 @@ describe SampledPersonsIneligibility do
       @does_not_live_in_county = NcsCode.for_list_name_and_local_code("SCREENER_ELIG_PSU_CL1", 2)
       @not_first_visit = NcsCode.for_list_name_and_local_code("CONFIRM_TYPE_CL7", 2)
 
-      take_survey(@survey, @response_set) do |a|
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @age_eligible
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @lives_in_county
-        a.choice "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @first_visit
+      take_survey(@survey, @response_set) do |r|
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.AGE_ELIG", @age_eligible
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.PSU_ELIG_CONFIRM", @lives_in_county
+        r.a "#{OperationalDataExtractor::PbsEligibilityScreener::INTERVIEW_PREFIX}.FIRST_VISIT", @first_visit
       end
     end
 

--- a/spec/support/should_have_response.rb
+++ b/spec/support/should_have_response.rb
@@ -1,0 +1,28 @@
+require 'case'
+
+triple = Case::Struct.new(:q, :a, :v)
+
+##
+# Checks a response set for the presence of a response.  Question and answer
+# must be reference identifiers.
+RSpec::Matchers.define :have_response do |question, answer, value = Case::Any|
+  expected = triple[question, answer, value]
+
+  match do |response_set|
+    ok = response_set.responses.any? do |r|
+      actual = triple[r.question.reference_identifier, r.answer.reference_identifier, r.value]
+
+      expected === actual
+    end
+
+    ok.should be_true
+  end
+
+  failure_message_for_should do |response_set|
+    q = expected.q
+    a = expected.a
+    v = expected.v
+
+    "Did not find response qref=#{q}, aref=#{a}, value=#{v} in response set"
+  end
+end

--- a/spec/support/survey_completion.rb
+++ b/spec/support/survey_completion.rb
@@ -1,139 +1,53 @@
 # -*- coding: utf-8 -*-
 
+require 'ncs_navigator/core'
 
-##
-# A DSL for answering questions on Surveyor surveys.  See the *DataExtractor
-# specs for example usage.
 module SurveyCompletion
-  ##
-  # Invoke this to start answering questions on a survey, storing the
-  # responses in the given response_set.
-  #
-  # This method yields an object for storing responses.
-  def take_survey(survey, response_set)
-    yield Answerer.new(survey, response_set)
-  end
+  include NcsNavigator::Core::Surveyor::SurveyTaker
 
-  class Answerer
-    def initialize(survey, response_set)
-      @survey = survey
-      @rs = response_set
+  class Responder
+    def initialize(r)
+      @respondent = r
     end
 
-    def str(identifier, answer)
-      for_each_match(identifier) do |q, section|
-        create_fill_in_response(q, :string_value, answer, section)
-      end
-    end
-
-    def txt(identifier, answer)
-      for_each_match(identifier) do |q, section|
-        create_fill_in_response(q, :text_value, answer, section)
-      end
-    end
-
-    def int(identifier, answer)
-      for_each_match(identifier) do |q, section|
-        create_fill_in_response(q, :integer_value, answer, section)
-      end
-    end
-
-    def date(identifier, answer)
-      for_each_match(identifier) do |q, section|
-        create_fill_in_response(q, :datetime_value, answer, section)
-      end
-    end
-
-    def choice(identifier, answer)
-      for_each_match(identifier) do |q, section|
-        val = answer.local_code.to_s
-        # handle negative value reference identifier
-        val = val.gsub("-", "neg_") if answer.local_code.to_i < 0
-        create_choice_response(q, :reference_identifier, val, section)
-      end
-    end
-
-    def yes(identifier)
-      for_each_match(identifier) do |q, section|
-        create_choice_response(q, :text, 'Yes', section)
-      end
-    end
-
-    def no(identifier)
-      for_each_match(identifier) do |q, section|
-        create_choice_response(q, :text, 'No', section)
-      end
-    end
-
-    def refused(identifier)
-      for_each_match(identifier) do |q, section|
-        create_choice_response(q, :text, 'Refused', section)
-      end
-    end
-
-    def dont_know(identifier)
-      for_each_match(identifier) do |q, section|
-        create_choice_response(q, :text, "Don't know", section)
-      end
-    end
-
-    def for_each_match(identifier)
-      @survey.sections.each do |section|
-        section.questions.each do |q|
-          yield q, section if q.data_export_identifier == identifier
+    def a(ref, val, opts = nil)
+      if opts
+        @respondent.answer(ref, val, opts)
+      else
+        if val.respond_to?(:local_code)
+          @respondent.answer(ref, val.local_code.to_s.sub('-', 'neg_'))
+        elsif val.is_a?(Hash)
+          @respondent.answer(ref, val[:reference_identifier])
+        else
+          @respondent.answer(ref, :value => val)
         end
       end
     end
 
-    def create_fill_in_response(q, k, v, section)
-      rc = case k
-           when :datetime_value; 'date'
-           when :integer_value; 'integer'
-           when :string_value; 'string'
-           when :text_value; 'text'
-           end
-
-      answer = q.answers.detect { |a| a.response_class == rc }
-
-      assert answer, q, v, section
-
-      create_response(q, answer, section, k => v)
+    def yes(ref)
+      @respondent.answer(ref, NcsCode::YES.to_s)
     end
 
-    def create_choice_response(q, k, v, section)
-      answer = q.answers.detect { |a| a.response_class == 'answer' && value_matches(a, k, v) }
-
-      assert answer, q, { k => v }, section
-
-      create_response(q, answer, section)
+    def no(ref)
+      @respondent.answer(ref, NcsCode::NO.to_s)
     end
 
-    def value_matches(a, k, v)
-      if k == :text
-        a.send(k).upcase == v.upcase
-      else
-        a.send(k) == v
+    def refused(ref)
+      @respondent.answer(ref, 'neg_1')
+    end
+
+    def dont_know(ref)
+      @respondent.answer(ref, 'neg_2')
+    end
+  end
+
+  def take_survey(survey, response_set)
+    respond(response_set, survey) do |r|
+      r.using_data_export_identifiers do |r|
+        yield Responder.new(r)
       end
     end
 
-    def create_response(q, a, section, options = {})
-      Factory(:response, options.merge(:survey_section_id => section.id,
-                                       :question_id => q.id,
-                                       :answer_id => a.id,
-                                       :response_set_id => @rs.id))
-
-    end
-
-    def assert(answer, question, criterion, section)
-      if answer.nil?
-        raise <<-END
-An answer could not be found.
-
-Question: #{question.inspect}
-Criterion: #{criterion.inspect}
-Section: #{section.inspect}
-        END
-      end
-    end
+    response_set.save!
   end
 end

--- a/spec/support/test_surveys/birth_visit.rb
+++ b/spec/support/test_surveys/birth_visit.rb
@@ -290,11 +290,11 @@ module BirthVisit
   def create_pv2_and_birth_with_work_name
     load_survey_questions_string(<<-QUESTIONS)
       q_WORK_NAME 'text', :data_export_identifier => "PREG_VISIT_1_3.WORK_NAME", :pick => :one
-      a_string "Work Name", :string
+      a_work_name "Work Name", :string
       a_neg_1 "Refused"
 
       q_WORK_NAME_BIRTH 'text', :data_export_identifier => "PREG_VISIT_2_3.WORK_NAME", :pick => :one
-      a_string "Work Name", :string
+      a_work_name "Work Name", :string
       a_neg_1 "Refused"
     QUESTIONS
   end

--- a/spec/support/test_surveys/birth_visit.rb
+++ b/spec/support/test_surveys/birth_visit.rb
@@ -183,8 +183,7 @@ module BirthVisit
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "BABY_RACE_1_OTH", :data_export_identifier => "BIRTH_VISIT_BABY_RACE_1_3.BABY_RACE_1_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
-    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     survey
   end
@@ -202,17 +201,16 @@ module BirthVisit
 
     # RELEASE
     q = Factory(:question, :reference_identifier => "RELEASE", :data_export_identifier => "#{mdes_table}.RELEASE", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "yes")
-    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "no")
+    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "2")
 
     # MULTIPLE
     q = Factory(:question, :reference_identifier => "MULTIPLE", :data_export_identifier => "#{mdes_table}.MULTIPLE", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "yes")
-    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "no")
+    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "2")
 
     survey
   end
-
 
   def create_pv1_with_fields_for_birth_prepopulation
     survey = Factory(:survey, :title => "INS_QUE_PregVisit1_INT_EHPBHI_M3.0_V3.0", :access_code => "ins-que-pregvisit1-int-ehpbhi-m3-0-v3-0")
@@ -246,13 +244,13 @@ module BirthVisit
 
     # prepopulated_release_from_birth_visit_part_one
     q = Factory(:question, :reference_identifier => "prepopulated_release_from_birth_visit_part_one", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "yes")
-    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "no")
+    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "2")
 
     # prepopulated_multiple_from_birth_visit_part_one
     q = Factory(:question, :reference_identifier => "prepopulated_multiple_from_birth_visit_part_one", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "yes")
-    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "no")
+    a = Factory(:answer, :question_id => q.id, :text => "YES", :response_class => "answer", :reference_identifier => "1")
+    a = Factory(:answer, :question_id => q.id, :text => "NO", :response_class => "answer", :reference_identifier => "2")
 
     # prepopulated_is_valid_work_name_provided
     q = Factory(:question, :reference_identifier => "prepopulated_is_valid_work_name_provided", :survey_section_id => survey_section.id)

--- a/spec/support/test_surveys/pbs_eligibility_screener.rb
+++ b/spec/support/test_surveys/pbs_eligibility_screener.rb
@@ -81,8 +81,7 @@ module PbsEligibilityScreener
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_1.RACE_1_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
-    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     # Race Two
     q = Factory(:question, :reference_identifier => "RACE_2", :data_export_identifier => "PBS_ELIG_SCREENER_RACE_2.RACE_2", :survey_section_id => survey_section.id)
@@ -226,7 +225,6 @@ module PbsEligibilityScreener
     a = Factory(:answer, :question_id => q.id, :text => "Due Date YY", :response_class => "string")
     a = Factory(:answer, :question_id => q.id, :text => "Refused", :response_class => "answer", :reference_identifier => "neg_1")
     a = Factory(:answer, :question_id => q.id, :text => "Don't know", :response_class => "answer", :reference_identifier => "neg_2")
-
 
     # Date Last Period
     q = Factory(:question, :reference_identifier => "DATE_PERIOD_MM", :data_export_identifier => "PBS_ELIG_SCREENER.DATE_PERIOD_MM", :survey_section_id => survey_section.id)

--- a/spec/support/test_surveys/post_natal.rb
+++ b/spec/support/test_surveys/post_natal.rb
@@ -32,8 +32,7 @@ module PostNatal
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "THREE_MTH_MOTHER_RACE.RACE_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
-    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     survey
   end
@@ -444,7 +443,7 @@ module PostNatal
     pairs.each do |args|
       q = create_survey_section_question(*args)
       a = Factory(:answer, :question_id => q.id,
-                  :reference_identifier => "number",
+                  :reference_identifier => "work_name",
                   :text => "WORK NAME:", :response_class => "string")
       a = Factory(:answer, :question_id => q.id,
                   :reference_identifier => "neg_1",

--- a/spec/support/test_surveys/pregnancy_screener.rb
+++ b/spec/support/test_surveys/pregnancy_screener.rb
@@ -182,8 +182,7 @@ module PregnancyScreener
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_OTH", :data_export_identifier => "PREG_SCREEN_HI_RACE_2.RACE_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
-    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     survey
   end
@@ -286,7 +285,6 @@ module PregnancyScreener
     survey
   end
 
-
   def create_pregnancy_screener_survey_with_email_operational_data
     survey = Factory(:survey, :title => "INS_QUE_PregScreen_INT_HILI_P2_V2.0", :access_code => "ins-que-pregscreen-int-hili-p2-v2-0")
     survey_section = Factory(:survey_section, :survey_id => survey.id)
@@ -329,7 +327,6 @@ module PregnancyScreener
     a = Factory(:answer, :question_id => q.id, :text => "Specify", :response_class => "string")
     survey
   end
-
 
   def create_pregnancy_screener_survey_to_determine_due_date
     survey = Factory(:survey, :title => "INS_QUE_PregScreen_INT_HILI_P2_V2.0", :access_code => "ins-que-pregscreen-int-hili-p2-v2-0")

--- a/spec/support/test_surveys/pregnancy_visit_one.rb
+++ b/spec/support/test_surveys/pregnancy_visit_one.rb
@@ -267,7 +267,7 @@ module PregnancyVisitOne
 
     # Race New Other
     q = Factory(:question, :reference_identifier => "RACE_NEW_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_NEW_3.RACE_NEW_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Chinese", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     # Race One
     q = Factory(:question, :reference_identifier => "RACE_1", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1", :survey_section_id => survey_section.id)
@@ -277,8 +277,7 @@ module PregnancyVisitOne
 
     # Race One Other
     q = Factory(:question, :reference_identifier => "RACE_1_OTH", :data_export_identifier => "PREG_VISIT_1_RACE_1_3.RACE_1_OTH", :survey_section_id => survey_section.id)
-    a = Factory(:answer, :question_id => q.id, :text => "Korean", :response_class => "string")
-    a = Factory(:answer, :question_id => q.id, :text => "Aborigine", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :response_class => 'string', :text => 'SPECIFY')
 
     survey
   end


### PR DESCRIPTION
This PR introduces a production-ready reimplementation of the SurveyCompletion module used in OperationalDataExtractor examples.  Since survey completion and prepopulation are really two instances of the same problem, I decided to unify them.  [The populator designed to solve issue 2744](https://github.com/NUBIC/ncs_navigator_core/blob/e42c7cb22405169202a0be1dc184a85d587e947a/app/models/response_set_prepopulation/handlebars_helpers.rb) makes use of this survey-taking code. 

This module also introduces a custom scope for Response mass-assignment.  The scope is meant to be used by all Cases code that does mass-assignment on Responses, but I have my doubts that'll work out.  Feel free to suggest alternative scope names.
