### PR TITLE
added provider and staff name to csv export #3245

### DIFF
--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -8,7 +8,7 @@ class ContactLinksController < ApplicationController
   def index
     params[:page] ||= 1
 
-     @q, @contact_links = ransack_paginate(ContactLink)
+    @q, @contact_links = ransack_paginate(ContactLink)
 
     respond_to do |format|
       format.html # index.html.haml

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,19 +123,17 @@ module ApplicationHelper
     event.continuable?
   end
 
-## Displaying the Staff name that is associated with the Participant(Initiated the Contact)
-#  Used in the Participants,Contact_Links excel reports to display the Originating Staff and Current Staff.
   def staff_name(staff_id)
     return "" if staff_id.blank?
     staff_list[staff_id]
   end
 
   def staff_list
-    @staff_list || build_staff_list
+    @staff_list ||= build_staff_list
   end
 
   def build_staff_list
-    users = NcsNavigator::Authorization::Core::Authority.new.find_users
+    users = Aker.authority.find_users
     Hash[users.map{|key| [key.identifiers[:staff_id], key.full_name]}]
   end
 

--- a/app/models/contact_link.rb
+++ b/app/models/contact_link.rb
@@ -19,8 +19,6 @@
 #
 
 
-
-
 # Each Contact Link record associates a unique combination
 # of Staff Member, Person, Event, and/or Instrument that occurs during a Contact. 
 # There should be at least 1 contact link record for every contact.
@@ -71,17 +69,34 @@ class ContactLink < ActiveRecord::Base
     event.event_disposition_text
   end
 
-  comma do
 
+  comma do
     contact :contact_type => 'Contact Type', :contact_date_date => 'Contact Date'
     contact :contact_start_time => 'Start Time', :contact_end_time => 'End Time'
     person :first_name => 'First Name', :last_name => 'Last Name'
+    provider
     contact_disposition
     event :event_type => 'Event Type'
     event_disposition
     event :event_disposition_category => 'Event Disposition Category'
     contact :contact_comment => 'Contact Comment'
+    staff_name
+  end
 
+  private
+
+  def staff_name
+    return "" if staff_id.blank?
+    staff_list[staff_id]
+  end
+
+  def staff_list
+    @staff_list ||= build_staff_list
+  end
+
+  def build_staff_list
+    users = Aker.authority.find_users
+    Hash[users.map{|key| [key.identifiers[:staff_id], key.full_name]}]
   end
 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,7 +62,7 @@ describe ApplicationHelper do
     end
   end
 
-  describe "staffname" do
+  describe "staff_name" do
 
     before do
       user = mock(Aker::User)
@@ -73,9 +73,7 @@ describe ApplicationHelper do
 
 
       users_array = [user, user2]
-      x = Object.new
-      NcsNavigator::Authorization::Core::Authority.stub!(:new).and_return(x)
-      x.stub!(:find_users).and_return(users_array)
+      Aker.authority.stub!(:find_users).and_return(users_array)
     end
 
     it "should display full_name if the staff_id is present in staff_list" do


### PR DESCRIPTION
Duplicated methods in helpers/application_helper 
to help transform the staff_id attribute into
an actual name. I'd like to refactor this 
duplication out, but I'm not sure including 
the helper in the model is a good idea.
