### PR TITLE
removes PpgDetails from participant #3550 

### DIFF
--- a/app/context/eligibility_adjudicator.rb
+++ b/app/context/eligibility_adjudicator.rb
@@ -21,6 +21,8 @@ class EligibilityAdjudicator
     end
   end
 
+  private
+
   def creates_ineligibility_record(person)
     SampledPersonsIneligibility.create_from_person!(person)
   end

--- a/app/context/eligibility_adjudicator.rb
+++ b/app/context/eligibility_adjudicator.rb
@@ -13,6 +13,7 @@ class EligibilityAdjudicator
   def make_ineligible
     ActiveRecord::Base.transaction do
       creates_ineligibility_record(@person)
+      remove_ppg_details(@participant)
       delete_participant_person_links(@participant)
       disassociates_participant_from_all_events(@participant)
       disassociates_participant_from_response_sets(@participant)
@@ -22,6 +23,11 @@ class EligibilityAdjudicator
 
   def creates_ineligibility_record(person)
     SampledPersonsIneligibility.create_from_person!(person)
+  end
+
+  def remove_ppg_details(participant)
+    PpgStatusHistory.where(:participant_id => participant).destroy_all
+    PpgDetail.where(:participant_id => participant).destroy_all
   end
 
   def delete_participant_person_links(participant)

--- a/spec/context/eligibility_adjudicator_spec.rb
+++ b/spec/context/eligibility_adjudicator_spec.rb
@@ -15,6 +15,7 @@ describe EligibilityAdjudicator do
       Factory(:person_provider_link, :person => @person, :provider => provider)
       Factory(:participant_person_link, :person => father, :participant=> @participant, :relationship_code => 4)
       Factory(:participant_person_link, :person => grandparent,:participant => @participant, :relationship_code => 10)
+      Factory(:ppg_detail, :participant => @participant)
       @person.participant = @participant
       @person.save!
       screener_survey = Factory(:survey, :title => "INS_QUE_PBSamplingScreen_INT_PBS_M3.0_V1.0")
@@ -28,6 +29,11 @@ describe EligibilityAdjudicator do
 
       before do
         @participant.stub!(:ineligible? => true)
+      end
+
+      it "removes ppg_details from the participant" do
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
+        PpgDetail.where(:participant_id => @response_set.participant).count.should == 0
       end
 
       it "deletes all participant_person_links for a participant" do
@@ -66,6 +72,11 @@ describe EligibilityAdjudicator do
     context "when eligible" do
       before do
         @participant.stub!(:eligible? => true)
+      end
+
+      it "does not remove ppg_details from the participant" do
+        EligibilityAdjudicator.adjudicate_eligibility(@person)
+        PpgDetail.where(:participant_id => @response_set.participant).count.should == 1
       end
 
       it "does not delete participant_person_links for a participant" do


### PR DESCRIPTION
Included the removal of ppg_details (and its 
auto-generated ppg_status_history) from the 
participant in #make_ineligible.
