### PR TITLE
Complete use of CONSENT_TYPE_CL3 for ParticipantConsent#consent_form_type

### DIFF
--- a/app/models/ncs_code.rb
+++ b/app/models/ncs_code.rb
@@ -156,7 +156,7 @@ class NcsCode < ActiveRecord::Base
     ### participant_consent
     # :psu_code               => "PSU_CL1",             # already referenced
     :consent_type_code              => 'CONSENT_TYPE_CL1',
-    :consent_form_type_code         => 'CONSENT_TYPE_CL1',
+    :consent_form_type_code         => 'CONSENT_TYPE_CL3',
     :consent_given_code             => 'CONFIRM_TYPE_CL2',
     :consent_withdraw_code          => 'CONFIRM_TYPE_CL2',
     :consent_withdraw_type_code     => 'CONSENT_WITHDRAW_REASON_CL1',

--- a/db/ncs_codes-2.0-additions.yml
+++ b/db/ncs_codes-2.0-additions.yml
@@ -1,0 +1,32 @@
+# Manually-curated additions to the code lists for MDES 2.0.
+
+# CONSENT_TYPE_CL3 is backported from MDES 2.1. It was clearly intended to be
+# present in MDES 2.0; the variable that it uses was new in MDES 2.0 and doesn't
+# make sense with the code list it has in MDES 2.0.
+- list_name: CONSENT_TYPE_CL3
+  local_code: -7
+  display_text: Not applicable
+- list_name: CONSENT_TYPE_CL3
+  local_code: -4
+  display_text: Missing in Error
+- list_name: CONSENT_TYPE_CL3
+  local_code: 1
+  display_text: Pregnant Woman Consent
+- list_name: CONSENT_TYPE_CL3
+  local_code: 2
+  display_text: Non-Pregnant Woman Consent
+- list_name: CONSENT_TYPE_CL3
+  local_code: 3
+  display_text: Father Consent
+- list_name: CONSENT_TYPE_CL3
+  local_code: 4
+  display_text: Child Consent Birth to 6-Months
+- list_name: CONSENT_TYPE_CL3
+  local_code: 5
+  display_text: Child Consent 6-Months to Age of Majority
+- list_name: CONSENT_TYPE_CL3
+  local_code: 6
+  display_text: New Adult Consent
+- list_name: CONSENT_TYPE_CL3
+  local_code: 7
+  display_text: Low Intensity Consent

--- a/db/ncs_codes-2.0.yml
+++ b/db/ncs_codes-2.0.yml
@@ -2364,33 +2364,6 @@
 - list_name: CONSENT_TYPE_CL2
   local_code: 3
   display_text: Consent to collect genetic material
-- list_name: CONSENT_TYPE_CL3
-  local_code: -7
-  display_text: Not applicable
-- list_name: CONSENT_TYPE_CL3
-  local_code: -4
-  display_text: Missing in Error
-- list_name: CONSENT_TYPE_CL3
-  local_code: 1
-  display_text: Pregnant Woman Consent
-- list_name: CONSENT_TYPE_CL3
-  local_code: 2
-  display_text: Non-Pregnant Woman Consent
-- list_name: CONSENT_TYPE_CL3
-  local_code: 3
-  display_text: Father Consent
-- list_name: CONSENT_TYPE_CL3
-  local_code: 4
-  display_text: Child Consent Birth to 6-Months
-- list_name: CONSENT_TYPE_CL3
-  local_code: 5
-  display_text: Child Consent 6-Months to Age of Majority
-- list_name: CONSENT_TYPE_CL3
-  local_code: 6
-  display_text: New Adult Consent
-- list_name: CONSENT_TYPE_CL3
-  local_code: 7
-  display_text: Low Intensity Consent
 - list_name: CONSENT_WITHDRAW_REASON_CL1
   local_code: -4
   display_text: Missing in Error

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,5 +14,5 @@ if ENV['INITIAL_MDES_VERSION']
   NcsNavigator::Core::Mdes::Version.set!(ENV['INITIAL_MDES_VERSION'])
 end
 
-require 'ncs_navigator/core/mdes_code_list_loader'
-NcsNavigator::Core::MdesCodeListLoader.new(:interactive => true).load_from_yaml
+require 'ncs_navigator/core/mdes/code_list_loader'
+NcsNavigator::Core::Mdes::CodeListLoader.new(:interactive => true).load_from_yaml

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -79,7 +79,7 @@ Spork.each_run do
 
   DatabaseCleaner.clean_with(:truncation)
   NcsNavigatorCore.mdes_version = '2.0' # TODO: testing with different MDES versions
-  NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+  NcsNavigator::Core::Mdes::CodeListLoader.new.load_from_yaml
 
   DatabaseCleaner.strategy = :transaction
   Cucumber::Rails::Database.javascript_strategy = [:truncation, { :except => %w(ncs_codes) }]

--- a/lib/ncs_navigator/core.rb
+++ b/lib/ncs_navigator/core.rb
@@ -9,7 +9,6 @@ module NcsNavigator
     autoload :FollowedParticipantChecker, 'ncs_navigator/core/followed_participant_checker'
     autoload :HasPublicId,                'ncs_navigator/core/has_public_id'
     autoload :Mdes,                       'ncs_navigator/core/mdes'
-    autoload :MdesCodeListLoader,         'ncs_navigator/core/mdes_code_list_loader'
     autoload :MdesInstrumentSurvey,       'ncs_navigator/core/mdes_instrument_survey'
     autoload :Mustache,                   'ncs_navigator/core/mustache'
     autoload :Pbs,                        'ncs_navigator/core/pbs'

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -2,6 +2,8 @@ require 'ncs_navigator/core'
 
 module NcsNavigator::Core
   module Mdes
+    autoload :CodeListLoader, 'ncs_navigator/core/mdes/code_list_loader'
+
     autoload :HumanReadablePublicIdGenerator, 'ncs_navigator/core/mdes/human_readable_public_id_generator'
     autoload :InstrumentOwner, 'ncs_navigator/core/mdes/instrument_owner'
     autoload :MdesDate,        'ncs_navigator/core/mdes/mdes_date'

--- a/lib/ncs_navigator/core/mdes/code_list_loader.rb
+++ b/lib/ncs_navigator/core/mdes/code_list_loader.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 module NcsNavigator::Core::Mdes
   class CodeListLoader
-    attr_reader :mdes_version, :filename
+    attr_reader :mdes_version, :automatic_filename, :manual_filename
 
     def initialize(options = {})
       @interactive = options[:interactive]
@@ -15,7 +15,8 @@ module NcsNavigator::Core::Mdes
         NcsNavigatorCore.mdes_version
       end
 
-      @filename = Rails.root + 'db' + "ncs_codes-#{mdes_version.number}.yml"
+      @automatic_filename = Rails.root + 'db' + "ncs_codes-#{mdes_version.number}.yml"
+      @manual_filename = Rails.root + 'db' + "ncs_codes-#{mdes_version.number}-additions.yml"
     end
 
     def interactive?
@@ -43,13 +44,13 @@ module NcsNavigator::Core::Mdes
         }
       }.flatten.sort_by { |list_entry| [list_entry['list_name'], list_entry['local_code']] }
 
-      File.open(filename.to_s, 'w:utf-8') do |w|
+      File.open(automatic_filename.to_s, 'w:utf-8') do |w|
         w.write(yml.to_yaml)
       end
     end
 
     def load_from_yaml
-      create_yaml unless filename.exist?
+      create_yaml unless automatic_filename.exist?
 
       partitioned = select_for_insert_update_delete
 
@@ -99,7 +100,10 @@ module NcsNavigator::Core::Mdes
     private :do_update
 
     def select_for_insert_update_delete
-      yaml_entries = YAML.load(File.read(filename.to_s))
+      yaml_entries = YAML.load(automatic_filename.read)
+      if manual_filename.exist?
+        yaml_entries += YAML.load(manual_filename.read)
+      end
       existing_entries = ActiveRecord::Base.connection.
         select_all('SELECT list_name, local_code FROM ncs_codes')
 

--- a/lib/ncs_navigator/core/mdes/code_list_loader.rb
+++ b/lib/ncs_navigator/core/mdes/code_list_loader.rb
@@ -2,15 +2,15 @@
 require 'ncs_navigator/mdes'
 require 'yaml'
 
-module NcsNavigator::Core
-  class MdesCodeListLoader
+module NcsNavigator::Core::Mdes
+  class CodeListLoader
     attr_reader :mdes_version, :filename
 
     def initialize(options = {})
       @interactive = options[:interactive]
       ver = options[:mdes_version]
       @mdes_version = if ver
-        Mdes::Version.new(ver)
+        Version.new(ver)
       else
         NcsNavigatorCore.mdes_version
       end

--- a/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations/basic.rb
@@ -54,7 +54,7 @@ module NcsNavigator::Core::Mdes::VersionMigrations
     end
 
     def switch_code_lists
-      NcsNavigator::Core::MdesCodeListLoader.
+      NcsNavigator::Core::Mdes::CodeListLoader.
         new(:mdes_version => to, :interactive => @interactive).
         load_from_yaml
     end

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -1,12 +1,12 @@
 namespace :mdes do
   namespace :code_lists do
     task :base => :environment do
-      require 'ncs_navigator/core/mdes_code_list_loader'
+      require 'ncs_navigator/core/mdes/code_list_loader'
     end
 
     desc 'Generate the code list YAML file for the current MDES version'
     task :yaml => :base do
-      NcsNavigator::Core::MdesCodeListLoader.new(:interactive => true).create_yaml
+      NcsNavigator::Core::Mdes::CodeListLoader.new(:interactive => true).create_yaml
       $stderr.puts "Code list YAML regenerated. Please verify and commit it."
     end
 
@@ -14,7 +14,7 @@ namespace :mdes do
     task :all_yaml => :base do
       %w(2.0 2.1 2.2 3.0 3.1 3.2).each do |mdes_version|
         $stderr.print "Creating for #{mdes_version}..."; $stderr.flush
-        NcsNavigator::Core::MdesCodeListLoader.new(:interactive => true, :mdes_version => mdes_version).create_yaml
+        NcsNavigator::Core::Mdes::CodeListLoader.new(:interactive => true, :mdes_version => mdes_version).create_yaml
         $stderr.puts 'done.'
       end
       $stderr.puts "All code list YAML regenerated. Please verify and commit them."
@@ -26,7 +26,7 @@ namespace :mdes do
 
       require 'benchmark'
       $stderr.puts(Benchmark.measure do
-        NcsNavigator::Core::MdesCodeListLoader.new(:interactive => true).load_from_yaml
+        NcsNavigator::Core::Mdes::CodeListLoader.new(:interactive => true).load_from_yaml
       end)
     end
 

--- a/script/merge_lab.rb
+++ b/script/merge_lab.rb
@@ -4,7 +4,7 @@ require 'celluloid'
 require 'database_cleaner'
 require 'irb'
 require 'logger'
-require 'ncs_navigator/core/mdes_code_list_loader'
+require 'ncs_navigator/core/mdes/code_list_loader'
 require 'surveyor/parser'
 
 def fw(json)
@@ -48,7 +48,7 @@ Rails.logger.silence do
 
   LOG.info 'Loading code lists'
   NcsNavigatorCore.mdes_version = '3.1'
-  NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+  NcsNavigator::Core::Mdes::CodeListLoader.new.load_from_yaml
 
   surveys = Dir["#{Rails.root}/{internal_surveys,surveys}/**/*.rb"]
   surveys.map { |fn| s.future(:load_survey, fn) }.all?(&:value)

--- a/spec/lib/ncs_navigator/core/mdes/version_migrations/basic_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrations/basic_spec.rb
@@ -22,7 +22,7 @@ module NcsNavigator::Core::Mdes::VersionMigrations
 
       after do
         # restore the code list to the current version
-        NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+        NcsNavigator::Core::Mdes::CodeListLoader.new.load_from_yaml
       end
 
       it 'updates the MDES version in the database' do

--- a/spec/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two_spec.rb
@@ -32,7 +32,7 @@ module NcsNavigator::Core::Mdes::VersionMigrations
 
       after do
         # restore the code list to the current version
-        NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+        NcsNavigator::Core::Mdes::CodeListLoader.new.load_from_yaml
       end
 
       describe 'changing p_type' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,7 +115,7 @@ Spork.prefork do
     config.before(:suite) do
       DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.clean_with(:truncation)
-      NcsNavigator::Core::MdesCodeListLoader.new.load_from_yaml
+      NcsNavigator::Core::Mdes::CodeListLoader.new.load_from_yaml
 
       # The truncation wipes out the persisted event type order, so we restore
       # it here.


### PR DESCRIPTION
@pfriedman started #3531 in ff8e28de8. This completes it by moving the manually-managed code list for MDES 2.0 to a separate file and making other tiny changes.
