### PR TITLE
Set event when instrument is built so it exists before prepopulator run

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -123,10 +123,10 @@ class Instrument < ActiveRecord::Base
     rs = ResponseSet.includes(:instrument).where(where_clause, survey.id, person.id, event.id).first
 
     if !rs || event.closed?
-      person.start_instrument(survey, participant, mode)
+      person.start_instrument(survey, participant, mode, event)
     else
       rs.instrument
-    end.tap { |i| i.event = event }
+    end
   end
 
   ##
@@ -137,7 +137,7 @@ class Instrument < ActiveRecord::Base
   # @return[Instrument]
   def self.continue_instrument_associated_with_survey(person, participant, instrument_survey, current_survey, event, mode)
     instrument = find_instrument_to_continue(person, instrument_survey, event)
-    person.start_instrument(current_survey, participant, mode, instrument)
+    person.start_instrument(current_survey, participant, mode, event, instrument)
   end
 
   def self.find_instrument_to_continue(person, instrument_survey, event)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -260,6 +260,8 @@ class Person < ActiveRecord::Base
   # @param mode [Integer] Instrument mode code
   # @param [Instrument] - The instrument associated with the Survey (or Survey part)
   # @return [Instrument]
+  #
+  # event has to be set for some prepopopulation questions to work properly.
   def start_instrument(survey, participant, mode, event, instrument = nil)
     # TODO: raise Exception if survey is nil
     return if survey.nil?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -260,12 +260,12 @@ class Person < ActiveRecord::Base
   # @param mode [Integer] Instrument mode code
   # @param [Instrument] - The instrument associated with the Survey (or Survey part)
   # @return [Instrument]
-  def start_instrument(survey, participant, mode, instrument = nil)
+  def start_instrument(survey, participant, mode, event, instrument = nil)
     # TODO: raise Exception if survey is nil
     return if survey.nil?
-
     instrument = build_instrument(survey, mode) if instrument.nil?
     instrument.tap do |instr|
+      instr.event = event
       rs = instr.response_sets.build(:survey => survey, :user_id => self.id)
       rs.participant = participant
       rs.prepopulate

--- a/spec/support/test_surveys.rb
+++ b/spec/support/test_surveys.rb
@@ -15,8 +15,7 @@ module TestSurveys
   # saves it, and returns the created ResponseSet along with the Instrument.
   def prepare_instrument(person, participant, survey, mode = Instrument.capi, event = nil)
     instr = person.build_instrument(survey, mode)
-    instr.event = event
-    person.start_instrument(survey, participant, mode, instr)
+    person.start_instrument(survey, participant, mode, event, instr)
     instr.save!
 
     instr.response_sets.first.responses.clear


### PR DESCRIPTION
https://code.bioinformatics.northwestern.edu/issues/issues/show/3619

That fixes invalid determination of the event type when prepopulated questions are evaluated.
