### PR TITLE
Use PSU ID instead of SC ID for PSC site identifier. #3253.

### DIFF
--- a/lib/patient_study_calendar.rb
+++ b/lib/patient_study_calendar.rb
@@ -132,7 +132,7 @@ class PatientStudyCalendar
   end
 
   def site_identifier
-    NcsNavigator.configuration.study_center_id
+    NcsNavigatorCore.psu
   end
 
   # TODO: put in configuration

--- a/spec/fixtures/vcr_cassettes/psc/assign_subject.yml
+++ b/spec/fixtures/vcr_cassettes/psc/assign_subject.yml
@@ -342,7 +342,7 @@ http_interactions:
   recorded_at: Thu, 10 Jan 2013 18:04:42 GMT
 - request:
     method: post
-    uri: https://ncsn-psc.local/api/v1/studies/NCS+Hi-Lo/sites/20000029/subject-assignments
+    uri: https://ncsn-psc.local/api/v1/studies/NCS+Hi-Lo/sites/20000030/subject-assignments
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/psc/assignment_identfier.yml
+++ b/spec/fixtures/vcr_cassettes/psc/assignment_identfier.yml
@@ -381,7 +381,7 @@ http_interactions:
   recorded_at: Thu, 10 Jan 2013 18:04:42 GMT
 - request:
     method: get
-    uri: https://ncsn-psc.local/api/v1/studies/NCS+Hi-Lo/sites/20000029/subject-assignments
+    uri: https://ncsn-psc.local/api/v1/studies/NCS+Hi-Lo/sites/20000030/subject-assignments
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/lib/patient_study_calendar_spec.rb
+++ b/spec/lib/patient_study_calendar_spec.rb
@@ -78,8 +78,8 @@ describe PatientStudyCalendar do
     end
   end
 
-  it "use the Study Center ID for the PSC site identifier" do
-    subject.site_identifier.should == "20000029"
+  it "use the PSU ID for the PSC site identifier" do
+    subject.site_identifier.should == '20000030'
   end
 
   it "gets the segments for the study" do

--- a/spec/lib/psc_participant_spec.rb
+++ b/spec/lib/psc_participant_spec.rb
@@ -95,7 +95,7 @@ describe PscParticipant do
 
   describe '#register!' do
     let(:assignments_path) {
-      psc_url('studies', 'NCS%20Hi-Lo', 'sites', '20000029', 'subject-assignments')
+      psc_url('studies', 'NCS%20Hi-Lo', 'sites', '20000030', 'subject-assignments')
     }
 
     describe 'when already registered' do


### PR DESCRIPTION
Cases uses PSU ID instead of SC ID for PSC site identifier to accommodate multiple Cases instances against a single PSC instance (since PSC supports multiple sites).

With this change, when the new version is being deployed over existing instances,it will require a simultaneous change to the site configuration in the associated PSC instance. Associated PSC instance should be updated to the PSU ID as Site Assigned Identifier. Currently Site Assigned Identifier is set as SC ID in PSC.
