### PR TITLE
Require attribution in OperationalImporterPscSync#{import, reset}

### DIFF
--- a/app/models/field/psc_sync.rb
+++ b/app/models/field/psc_sync.rb
@@ -109,8 +109,10 @@ module Field
     #
     # @return void
     def sync_with_psc
+      raise "responsible_user is not set" unless responsible_user
+
       load_for_sync
-      psc_importer.import
+      psc_importer.import(responsible_user)
     end
 
     ##

--- a/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'forwardable'
 
 module NcsNavigator::Core::Warehouse
@@ -105,7 +104,6 @@ module NcsNavigator::Core::Warehouse
       core_updated_events_by_id = Event.where(:id => core_updated_event_ids_and_changes.collect { |e_and_c| e_and_c.first }).each_with_object({}) { |evt, index| index[evt.id] = evt }
       core_updated_event_ids_and_changes.each { |event_id, changes| reverse_changes(core_updated_events_by_id[event_id], changes) }
     end
-
 
     def reverse_changes(event, changes)
       changes.each { |att, att_changes| event.update_attributes(att.to_sym => att_changes.first) }

--- a/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
@@ -7,8 +7,6 @@ module NcsNavigator::Core::Warehouse
   class OperationalImporterPscSync
     extend Forwardable
 
-    WHODUNNIT = 'operational_importer_psc_sync'
-
     ##
     # The default Redis key generator.
     #
@@ -26,9 +24,11 @@ module NcsNavigator::Core::Warehouse
       @sync_key = sync_key
     end
 
-    def import
+    def import(responsible_user)
+      old_whodunnit = PaperTrail.whodunnit
+
       begin
-        PaperTrail.whodunnit = WHODUNNIT
+        PaperTrail.whodunnit = responsible_user
         init_participants_cache
 
         backup_participants
@@ -55,7 +55,7 @@ module NcsNavigator::Core::Warehouse
 
         report_about_indefinitely_deferred_events
       ensure
-        PaperTrail.whodunnit = nil
+        PaperTrail.whodunnit = old_whodunnit
       end
     end
 
@@ -83,7 +83,7 @@ module NcsNavigator::Core::Warehouse
     end
     private :report_about_indefinitely_deferred_events
 
-    def reset
+    def reset(responsible_user)
       p_backup_key = sync_key['participants_backup']
       if redis.exists p_backup_key
         redis.sunionstore(sync_key['participants'], p_backup_key)
@@ -98,10 +98,10 @@ module NcsNavigator::Core::Warehouse
       end
 
       core_placeholder_event_ids =
-        Version.select(:item_id).where(:whodunnit => WHODUNNIT, :item_type => 'Event', :event => 'create').collect(&:item_id)
+        Version.select(:item_id).where(:whodunnit => responsible_user, :item_type => 'Event', :event => 'create').collect(&:item_id)
       Event.where('id IN (?)', core_placeholder_event_ids).destroy_all
 
-      core_updated_event_ids_and_changes = Version.where(:whodunnit => WHODUNNIT, :item_type => 'Event', :event => 'update').order(:created_at).collect { |v| [v.item_id, v.changeset] }
+      core_updated_event_ids_and_changes = Version.where(:whodunnit => responsible_user, :item_type => 'Event', :event => 'update').order(:created_at).collect { |v| [v.item_id, v.changeset] }
       core_updated_events_by_id = Event.where(:id => core_updated_event_ids_and_changes.collect { |e_and_c| e_and_c.first }).each_with_object({}) { |evt, index| index[evt.id] = evt }
       core_updated_event_ids_and_changes.each { |event_id, changes| reverse_changes(core_updated_events_by_id[event_id], changes) }
     end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -32,6 +32,7 @@ namespace :import do
     password = hl.ask("Password for PSC: ") { |q| q.echo = '*' }
 
     t.user = cas_cli.authenticate(username, password)
+    @import_user = 'operational_importer_psc_sync'
   end
 
   task :find_participants_for_psc => :environment do |t|
@@ -108,7 +109,7 @@ namespace :import do
     require 'ncs_navigator/core'
 
     importer = NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(psc, import_wh_config)
-    importer.import
+    importer.import(@import_user)
   end
 
   desc 'Reset the PSC sync caches so that the PSC sync can be retried. (You should wipe the subject info in PSC also.)'
@@ -116,7 +117,7 @@ namespace :import do
     require 'ncs_navigator/core'
 
     importer = NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(psc, import_wh_config)
-    importer.reset
+    importer.reset(@import_user)
   end
 
   desc 'Check for imported participants which are not in PSC'

--- a/spec/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 require Rails.root + 'spec/warehouse_setup'
 
@@ -98,7 +97,6 @@ module NcsNavigator::Core::Warehouse
           )
         }
       end
-
 
       before do
         psc_participant.stub!(:registered?).and_return(true)
@@ -279,7 +277,6 @@ module NcsNavigator::Core::Warehouse
           psc_participant.stub!(:scheduled_events).and_return([])
           psc_participant.stub!(:scheduled_activities).and_return(scheduled_activities)
           psc_participant.stub!(:update_scheduled_activity_states)
-
 
           redis.sadd("#{ns}:psc_sync:participants", p_id)
           add_event_hash('e1', '2010-09-30',

--- a/spec/models/field/psc_sync_spec.rb
+++ b/spec/models/field/psc_sync_spec.rb
@@ -140,6 +140,16 @@ module Field
         with_cas_success { sp.prepare_for_sync(merge) }
       end
 
+      describe 'if #responsible_user is not set' do
+        before do
+          sp.responsible_user = nil
+        end
+
+        it 'raises an error' do
+          lambda { sp.sync_with_psc }.should raise_error
+        end
+      end
+
       it 'tells OperationalImporterPscSync to import' do
         sp.psc_importer.should_receive(:import)
 


### PR DESCRIPTION
OperationalImporterPscSync is used in different responsibility contexts, and IMO there is no appropriate default.  (In the merge code, it's the user who submitted the candidate data; in the import tasks, it's run as a general "import" user.)  Under this assumption, there's two possibilities:
1. Keep the arity of `#import` and `#reset`, but raise an error if a responsible user is not set.
2. Change the arity of`#import` and `#reset`, which raises responsibility assignment to a syntax-level requirement. (Mostly.  A check for a non-nil responsible user might also be useful.)

In this PR, I chose approach 2.
