### PR TITLE
Refactor Instrument#response_set to Instrument#response_sets #3034

### DIFF
--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -97,8 +97,8 @@ class ContactLinksController < ApplicationController
     @instrument    = @contact_link.instrument
     @event         = @contact_link.event
     @participant   = @event.participant if @event
-    @response_sets = @instrument.response_sets if @instrument
-    @surveys        = @response_sets.collect { |resp_set| resp_set.survey } if @response_sets
+    @response_sets = @instrument.response_sets.includes(:survey) if @instrument
+    @surveys       = @response_sets.collect { |resp_set| resp_set.survey } if @response_sets
     @contact_links = ContactLink.where(:contact_id => @contact_link.contact_id)
 
     if @participant && @event

--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -22,15 +22,15 @@ class ContactLinksController < ApplicationController
     @contact_link = ContactLink.find(params[:id])
     @event        = @contact_link.event
     @instrument   = @contact_link.instrument
-    @response_set = @instrument.response_set if @instrument
+    @response_sets= @instrument.response_sets if @instrument
 
     @person  = @contact_link.person
     @contact = @contact_link.contact
-    @survey  = @response_set.survey if @response_set
+    @surveys  = @response_sets.collect { |resp_set| resp_set.survey } if @response_sets
 
     # Some events (e.g. provider recruitment do not have a participant)
     if @event.participant
-      @event.populate_post_survey_attributes(@contact, @response_set) if @response_set
+      @event.populate_post_survey_attributes(@contact, @response_sets) if @response_sets
       @event.event_repeat_key = @event.determine_repeat_key
       @event_activities = psc.activities_for_event(@event)
     end
@@ -69,7 +69,7 @@ class ContactLinksController < ApplicationController
       else
         @event        = @contact_link.event
         @instrument   = @contact_link.instrument
-        @response_set = @instrument.response_set if @instrument
+        @response_sets = @instrument.response_sets if @instrument
         format.html { render :action => "edit" }
         format.json { render :json => @contact_link.errors, :status => :unprocessable_entity }
       end
@@ -97,15 +97,15 @@ class ContactLinksController < ApplicationController
     @instrument    = @contact_link.instrument
     @event         = @contact_link.event
     @participant   = @event.participant if @event
-    @response_set  = @instrument.response_set if @instrument
-    @survey        = @response_set.survey if @response_set
+    @response_sets = @instrument.response_sets if @instrument
+    @surveys        = @response_sets.collect { |resp_set| resp_set.survey } if @response_sets
     @contact_links = ContactLink.where(:contact_id => @contact_link.contact_id)
 
     if @participant && @event
       @activity_plan = psc.build_activity_plan(@participant)
       @activities_for_event = @activity_plan.activities_for_event(@event)
       @scheduled_activities = @activity_plan.scheduled_activities_for_event(@event)
-      @current_activity = @activity_plan.current_scheduled_activity(@event, @response_set)
+      @current_activity = @activity_plan.current_scheduled_activity(@event, @response_sets.first)
     end
   end
 
@@ -137,20 +137,16 @@ class ContactLinksController < ApplicationController
   end
 
   def setup_instrument_variables
-    @contact_link = ContactLink.find(params[:id])
-    @person       = @contact_link.person
-    @instrument   = @contact_link.instrument
-    @response_set = @instrument.response_set
-    @survey       = @response_set.survey if @response_set
+    @contact_link  = ContactLink.find(params[:id])
+    @person        = @contact_link.person
+    @instrument    = @contact_link.instrument
+    @response_sets = @instrument.response_sets.includes(:survey)
+    @surveys       = @response_sets.collect { |resp_set| resp_set.survey }
+
     set_instrument_time_and_date(@contact_link.contact)
-
-    repeat_key = @survey.nil? ? 0 : @person.instrument_repeat_key(@survey)
-    @instrument.instrument_repeat_key = repeat_key
-    @instrument.set_instrument_breakoff(@response_set)
-    if @instrument.instrument_type.blank? || @instrument.instrument_type_code <= 0
-      @instrument.instrument_type = @survey.instrument_type
-    end
-
+    @instrument.set_instrument_repeat_key(@person)
+    @instrument.set_instrument_type(@surveys)
+    @instrument.set_instrument_breakoff
   end
 
   def saq_instrument

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,7 +22,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     if params[:contact_link_id]
       @contact_link = ContactLink.find(params[:contact_link_id])
-      set_defaults_for_event
+      set_suggested_values_for_event
     end
     @close = params[:close]
     set_disposition_group
@@ -103,21 +103,14 @@ class EventsController < ApplicationController
 
   private
 
-    def set_defaults_for_event
-      if @event.event_disposition.blank? || @event.event_disposition < 0
-        @event.event_disposition = @contact_link.contact.contact_disposition
-      end
+    def set_suggested_values_for_event
+      @event.set_suggested_event_disposition(@contact_link)
 
-      if (@event.event_disposition_category.blank? || @event.event_disposition_category_code < 0) &&
-          @contact_link.try(:contact)
-        @event.set_event_disposition_category(@contact_link.contact)
-      end
+      @event.set_suggested_event_disposition_category(@contact_link)
 
-      @event.event_repeat_key = @event.determine_repeat_key
+      @event.set_suggested_event_repeat_key
 
-      if @contact_link.instrument && response_set = @contact_link.instrument.response_set
-        @event.set_event_breakoff(response_set)
-      end
+      @event.set_suggested_event_breakoff(@contact_link)
     end
 
     def redirect_path

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -314,7 +314,7 @@ class Instrument < ActiveRecord::Base
         break
       end
     end
-    self.instrument_breakoff = NcsCode.for_attribute_name_and_local_code(:instrument_breakoff_code, local_code)
+    self.instrument_breakoff_code = local_code
   end
 
   ##

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -306,11 +306,15 @@ class Instrument < ActiveRecord::Base
     !instrument_end_date.blank? && !instrument_end_time.blank? && instrument_status.to_s == "Complete"
   end
 
-  def set_instrument_breakoff(response_set)
-    if response_set
-      local_code = response_set.has_responses_in_each_section_with_questions? ? 2 : 1
-      self.instrument_breakoff = NcsCode.for_attribute_name_and_local_code(:instrument_breakoff_code, local_code)
+  def set_instrument_breakoff
+    local_code = NcsCode::NO
+    response_sets.each do |rs|
+      if !rs.has_responses_in_each_section_with_questions?
+        local_code = NcsCode::YES
+        break
+      end
     end
+    self.instrument_breakoff = NcsCode.for_attribute_name_and_local_code(:instrument_breakoff_code, local_code)
   end
 
   ##
@@ -415,16 +419,6 @@ class Instrument < ActiveRecord::Base
     response_sets.last
   end
 
-  # FIXME: This is temporary until we fix all places that call Instrument.response_set
-  def response_set
-    response_sets.first
-  end
-
-  # FIXME: This is temporary until we fix all places that call Instrument.response_set=
-  def response_set=(rs)
-    response_sets[0] = rs
-  end
-
   def enumerable_to_warehouse?
     return false unless event_id
 
@@ -433,6 +427,17 @@ class Instrument < ActiveRecord::Base
       FROM events e
       WHERE e.id=#{event_id} AND e.event_disposition IS NOT NULL
     QUERY
+  end
+
+  def set_instrument_repeat_key(person)
+    lowest = response_sets.min_by { |r_set|  person.instrument_repeat_key(r_set.survey) }
+    self.instrument_repeat_key = person.instrument_repeat_key(lowest.survey)
+  end
+
+  def set_instrument_type(surveys)
+    if instrument_type.blank? || instrument_type_code <= 0
+      self.instrument_type_code = surveys.first.instrument_type
+    end
   end
 
   private

--- a/app/views/contact_links/edit.html.haml
+++ b/app/views/contact_links/edit.html.haml
@@ -6,7 +6,7 @@
 %p
   - if @surveys.first
     = blank_safe(@person.to_s)
-    - if @response_sets.first.complete?
+    - if @response_sets.all?(&:complete?)
       has completed
     - else
       has taken

--- a/app/views/contact_links/edit.html.haml
+++ b/app/views/contact_links/edit.html.haml
@@ -4,9 +4,9 @@
   Remember to record the Contact and Event Dispositions.
 
 %p
-  - if @survey
+  - if @surveys.first
     = blank_safe(@person.to_s)
-    - if @response_set.complete?
+    - if @response_sets.first.complete?
       has completed
     - else
       has taken

--- a/app/views/contact_links/edit_instrument.html.haml
+++ b/app/views/contact_links/edit_instrument.html.haml
@@ -1,12 +1,12 @@
 - title "Finalize Instrument"
 %p
-  - if @survey
+  - if @surveys.first
     = @person
-    - if @response_set.complete?
+    - if @response_sets.first.complete?
       has completed
     - else
       has taken
-    = @survey.description
+    = @surveys.first.description
 
 .page_section
   = form_for(@contact_link, :url => finalize_instrument_contact_link_path(@contact_link), :html => {:autocomplete => "off"}) do |f|

--- a/app/views/contact_links/edit_instrument.html.haml
+++ b/app/views/contact_links/edit_instrument.html.haml
@@ -2,7 +2,7 @@
 %p
   - if @surveys.first
     = @person
-    - if @response_sets.first.complete?
+    - if @response_sets.all?(&:complete?)
       has completed
     - else
       has taken

--- a/features/step_definitions/merge_steps.rb
+++ b/features/step_definitions/merge_steps.rb
@@ -102,24 +102,6 @@ Given /^the surveys$/ do |table|
   end
 end
 
-Given /^the responses$/ do |table|
-  rs = @instrument.response_set
-
-  table.hashes.each do |h|
-    q = Question.where(:reference_identifier => h['qref']).first
-    raise "Unknown qref #{h['qref']}" unless q
-
-    a = q.answers.where(:reference_identifier => h['aref']).first
-    raise "Unknown aref #{h['aref']}" unless a
-
-    rs.responses.create!(
-      :question => q,
-      :answer => a,
-      :string_value => h['string_value']
-    )
-  end
-end
-
 # FIXME: This is a pretty terrible hack, but Cases' current UI provides no way
 # of differentating between response sets.
 Given /^there are no response sets for "([^"]*)"$/ do |survey_title|

--- a/spec/controllers/contact_links_controller_spec.rb
+++ b/spec/controllers/contact_links_controller_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe ContactLinksController do
@@ -17,15 +16,15 @@ describe ContactLinksController do
       login(user_login)
     end
 
-    describe "GET index" do 
-      
+    describe "GET index" do
+
       # id sort for paginate
-      it "defaults to sorting contact links by id" do 
+      it "defaults to sorting contact links by id" do
         get :index
         assigns(:q).sorts[0].name.should == "id"
       end
-      
-      it "performs user selected sort first; id second" do 
+
+      it "performs user selected sort first; id second" do
         get :index, :q => { :s => "person_last_name asc" }
         assigns(:q).sorts[0].name.should == "person_last_name"
         assigns(:q).sorts[1].name.should == "id"

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
 require 'spec_helper'
 
 describe EventsController do
@@ -23,14 +22,14 @@ describe EventsController do
       EventsController.any_instance.stub(:mark_activity_occurred).and_return(true)
     end
 
-    describe "GET index" do 
+    describe "GET index" do
       # id sort for paginate
-      it "defaults to sorting events by id" do 
+      it "defaults to sorting events by id" do
         get :index
         assigns(:q).sorts[0].name.should == "id"
       end
-      
-      it "performs user selected sort first; id second" do 
+
+      it "performs user selected sort first; id second" do
         get :index, :q => { :s => "event_type_code asc" }
         assigns(:q).sorts[0].name.should == "event_type_code"
         assigns(:q).sorts[1].name.should == "id"

--- a/spec/models/field/model_resolution_spec.rb
+++ b/spec/models/field/model_resolution_spec.rb
@@ -147,7 +147,7 @@ module Field
             end
 
             it 'has a response set' do
-              instrument.response_set.should_not be_nil
+              instrument.response_sets.first.should_not be_nil
             end
 
             it 'is linked to the event' do


### PR DESCRIPTION
### Summary

An instrument can have many response sets, yet there was code in `Instrument` for a `response_set` method that returned the first response set. I needed to find all the instances this method was being used, evaluate and change the behavior to handle multiple response sets or reference a single instance from the collection. Along the way, I pulled out some of the business logic from the controllers to the models.
##### Changes
- `ContactLinksController#setup_instrument_variables` populates instruments with reasonable defaults. Pull most of the logic out into the models. Refactored to accept multiple response sets. Refactored instances for the views
- `EventsController` Pull out the default setting logic into the model. Refactored the models to accept multiple response sets
- `Instrument` Deleted `#response_set` and `#response_set=`.  
- `Views` Adapted to multiple response sets.
- Solid chunks of testing.
