### PR TITLE
Add form validation for contact_date for create/update contact. Closes #3644.

### DIFF
--- a/app/assets/javascripts/form_validation.js
+++ b/app/assets/javascripts/form_validation.js
@@ -87,6 +87,10 @@ $(document).ready(function() {
       'contact[contact_distance]': {
         maxlength: 6,
         number: true
+      },
+      'contact[contact_date_date]': {
+        minlength: 10,
+        maxlength: 10
       }
     }
   });
@@ -95,6 +99,10 @@ $(document).ready(function() {
       'contact[contact_distance]': {
         maxlength: 6,
         number: true
+      },
+      'contact[contact_date_date]': {
+        minlength: 10,
+        maxlength: 10
       }
     }
   });

--- a/app/views/contacts/_form_fields.html.haml
+++ b/app/views/contacts/_form_fields.html.haml
@@ -9,7 +9,7 @@
     = label_tag "When did this contact happen?"
     %br
     = f.label :contact_date_date, "Date"
-    = f.text_field :contact_date_date, :class => "datepicker"
+    = f.text_field :contact_date_date, :class => "required datepicker"
 
   %p
     = f.label :contact_start_time, "Start Time"


### PR DESCRIPTION
Add form validation for contact_date for create/update contact. This will prevent user to add/update contact without the date. 
