### PR TITLE
Adding provider address and unit to provider resource

### DIFF
--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -1,8 +1,8 @@
 class ProviderSerializer < ActiveModel::Serializer
   attribute :name_practice, :key => :name
   attribute :provider_id, :key => :location
-  attributes :practice_num, :recruited
-
+  attributes :practice_num, :recruited, :address_one, :unit
+  
   def practice_num
     object.pbs_list.try(:practice_num)
   end
@@ -10,5 +10,13 @@ class ProviderSerializer < ActiveModel::Serializer
   def recruited
     # Providers schema expects a boolean.
     !!object.recruited?
+  end
+
+  def address_one
+    object.address.try(:address_one)
+  end
+
+  def unit
+    object.address.try(:unit)
   end
 end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -42,4 +42,14 @@ describe ProviderSerializer do
     provider.stub!(:recruited? => false)
     json['provider']['recruited'].should be_false
   end
+
+  it "writes address.address_one to address_one" do
+    provider.build_address(:address_one => '31 Foo St')
+    json['provider']['address_one'].should == '31 Foo St'
+  end
+
+  it "writes address.unit to unit" do
+    provider.build_address(:unit => '9')
+    json['provider']['unit'].should == '9'
+  end
 end


### PR DESCRIPTION
The provider resource will now provide address and unit for a provider.

See https://code.bioinformatics.northwestern.edu/issues/issues/show/3653
