### PR TITLE
add event times to scheduled events page #3176

### DIFF
--- a/app/assets/stylesheets/partials/_welcome.scss
+++ b/app/assets/stylesheets/partials/_welcome.scss
@@ -42,6 +42,11 @@
       display: inline-block;
     }
 
+    span.activity_time {
+      text-align: right;
+      width: 5em;
+    }
+
     span.participant_link {
       width: 15em;
     }

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -134,11 +134,12 @@ class WelcomeController < ApplicationController
       events = []
       if rows = scheduled_activities['rows']
         rows.each do |row|
+          activity_time = row['activity_time'] if row && row['activity_time']
           if row && row['subject']
             person = Person.find_by_person_id(row['subject']['person_id'])
             if person
               event_label = Event.parse_label(row['labels'].first)
-              events << ScheduledEvent.new(row['scheduled_date'], person, event_label.titleize) if event_label
+              events << ScheduledEvent.new(row['scheduled_date'], activity_time, person, event_label.titleize) if event_label
             end
           end
         end
@@ -181,6 +182,6 @@ class WelcomeController < ApplicationController
       end
     end
 
-    ScheduledEvent = Struct.new(:date, :person, :event_type)
+    ScheduledEvent = Struct.new(:date, :activity_time, :person, :event_type)
 
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -16,4 +16,14 @@ module WelcomeHelper
     result
   end
 
+  def place_activities_with_blank_times_at_the_bottom_of_list(activities)
+    activities.sort{ |a1, a2|( a1.send(:activity_time) && a2.send(:activity_time) ) ?
+                               a1.send(:activity_time) <=> a2.send(:activity_time) :
+                             ( a1.send(:activity_time) ? -1 : 1 ) }
+  end
+
+  def convert_24_hour_time_to_am_pm_time(time)
+    Time.strptime(time, '%H:%M').strftime('%l:%M %p')
+  end
+
 end

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -18,8 +18,10 @@
           .events_for_date
             %b
               = date
-            - @events[date].each do |e|
+            - place_activities_with_blank_times_at_the_bottom_of_list(@events[date]).each do |e|
               .event_participant
+                %span.activity_time
+                  = convert_24_hour_time_to_am_pm_time(e.activity_time) if e.activity_time
                 %span.participant_link
                   - path = e.person.participant? ? participant_path(e.person.participant) : person_path(e.person)
                   = link_to e.person.to_s, path, :class => "show_link icon_link"

--- a/spec/helpers/welcome_helper_spec.rb
+++ b/spec/helpers/welcome_helper_spec.rb
@@ -5,6 +5,42 @@ require 'spec_helper'
 
 describe ApplicationHelper do
 
+  describe "#place_activities_with_blank_times_at_the_bottom_of_list" do
+    ScheduledEvent = Struct.new(:date, :activity_time, :person, :event_type)
+
+    before do
+      @early_activity  = ScheduledEvent.new(nil, '09:33', nil, nil)
+      @middle_activity = ScheduledEvent.new(nil, '14:33', nil, nil)
+      @later_activity  = ScheduledEvent.new(nil, '21:33', nil, nil)
+      @blank_time_activity1   = ScheduledEvent.new(nil, nil, nil, nil)
+      @blank_time_activity2   = ScheduledEvent.new(nil, nil, nil, nil)
+      @unsorted_activities = [@later_activity, @blank_time_activity1, @early_activity, @blank_time_activity1, @middle_activity]
+    end
+
+    it "places blank time events to the end of the list" do
+      sorted = helper.place_activities_with_blank_times_at_the_bottom_of_list(@unsorted_activities)
+      sorted.index(@blank_time_activity2).should be > 2
+      sorted.index(@blank_time_activity1).should be > 2
+    end
+
+    it "places events with times in ascending chronological order" do
+      sorted = helper.place_activities_with_blank_times_at_the_bottom_of_list(@unsorted_activities)
+      sorted.index(@early_activity).should  == 0
+      sorted.index(@middle_activity).should == 1
+      sorted.index(@later_activity).should  == 2
+    end
+
+  end
+
+  describe "#convert_24_hour_time_to_am_pm_time" do
+    it "converts 24 hour style time to AM/PM style time" do
+      helper.convert_24_hour_time_to_am_pm_time("17:45").should == " 5:45 PM"
+      helper.convert_24_hour_time_to_am_pm_time("07:17").should == " 7:17 AM"
+      helper.convert_24_hour_time_to_am_pm_time("22:01").should == "10:01 PM"
+      helper.convert_24_hour_time_to_am_pm_time("11:32").should == "11:32 AM"
+    end
+  end
+
   it "is included in the helper object" do
     included_modules = (class << helper; self; end).send :included_modules
     included_modules.should include(WelcomeHelper)


### PR DESCRIPTION
### Summary

Added the time for event activities to the scheduled events page, alongside the participant. 
##### Actions
-  Added `activity_time` as one of the factors that gets parsed out of the `scheduled_activities_report` and made available to the view
- Added two helper methods, one to sort the activities by their activity_time for display, and another to convert the string 24-hour format time to AM/PM format time.
- Implemented the helper methods in the scheduled activities tab of the `welcome#index view`.
- Minor tweak to the CSS for time display
