### PR TITLE
Ineligible women batch entry feature #3211

### DIFF
--- a/app/models/person_provider_link.rb
+++ b/app/models/person_provider_link.rb
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130129202515
+# Schema version: 20130329150304
 #
 # Table name: person_provider_links
 #
-#  created_at                   :datetime
-#  date_first_visit             :string(255)
-#  date_first_visit_date        :date
-#  id                           :integer          not null, primary key
-#  is_active_code               :integer          not null
-#  person_id                    :integer
-#  person_provider_id           :string(36)       not null
-#  pre_screening_status_code    :integer          not null
-#  provider_id                  :integer
-#  provider_intro_outcome_code  :integer          not null
-#  provider_intro_outcome_other :string(255)
-#  psu_code                     :integer          not null
-#  sampled_person_code          :integer          not null
-#  transaction_type             :string(36)
-#  updated_at                   :datetime
+#  created_at                     :datetime
+#  date_first_visit               :string(255)
+#  date_first_visit_date          :date
+#  id                             :integer          not null, primary key
+#  ineligibility_batch_identifier :string(36)
+#  is_active_code                 :integer          not null
+#  person_id                      :integer
+#  person_provider_id             :string(36)       not null
+#  pre_screening_status_code      :integer          not null
+#  provider_id                    :integer
+#  provider_intro_outcome_code    :integer          not null
+#  provider_intro_outcome_other   :string(255)
+#  psu_code                       :integer          not null
+#  sampled_person_code            :integer          not null
+#  transaction_type               :string(36)
+#  updated_at                     :datetime
 #
 
 class PersonProviderLink < ActiveRecord::Base

--- a/app/views/providers/_form.html.haml
+++ b/app/views/providers/_form.html.haml
@@ -1,0 +1,81 @@
+.page_section
+  = form_tag(create_batch_provider_people_path(@provider.id), :id => 'batch_ineligible_form') do
+    = label :people, :number, "Number of People"
+    = text_field :people, :number, :required => true, :class => "required", :style => "width: 25px;"
+    = fields_for :person do |builder|
+      = builder.fields_for :person_provider_links_attributes, {:index => 0} do |ppl|
+        = ppl.hidden_field :provider_id, :value=>@provider.id
+        = render "shared/ncs_code_select",
+          { :f => ppl, :code => :pre_screening_status_code, :label_text => "Pre-Screening Status", :html_attrs => { :class => "required pre_screening_status_selector", :required => true } }
+
+        = render "shared/ncs_code_select",
+          { :f => ppl, :code => :sampled_person_code, :label_text => "Sampled Person?", :html_attrs => { :class => "required sampled_person_code_selector", :required => true } }
+
+        %p
+        = ppl.label :date_first_visit, "Date of First Visit"
+        %br
+        = ppl.text_field :date_first_visit, :class => "datepicker required", :required => true
+
+        = render "shared/ncs_code_select",
+          { :f => ppl, :code => :provider_intro_outcome_code, :label_text => "Outcome of Provider Introduction",  :other => :provider_intro_outcome_other, :html_attrs => { :class => "required provider_intro_outcome_code", :required => true } }
+
+      %div.persons_ineligibility
+        %b
+          Sampled Persons Ineligibility
+        %br
+        = builder.fields_for :sampled_persons_ineligibilities_attributes, {:index => 0} do |inelig|
+          = inelig.hidden_field :provider_id, :value=>@provider.id
+          = render "shared/ncs_code_select",
+            { :f => inelig, :code => :age_eligible_code, :label_text => "Is sampled woman age eligible?", :html_attrs => { :class => "required ineligible" } }
+
+          = render "shared/ncs_code_select",
+            { :f => inelig, :code => :county_of_residence_code, :label_text => "Does sampled woman reside in sample PSU/county?", :html_attrs => { :class => "required ineligible" } }
+
+          = render "shared/ncs_code_select",
+            { :f => inelig, :code => :pregnancy_eligible_code, :label_text => "Is sampled woman pregnant?", :html_attrs => { :class => "required ineligible" } }
+
+          = render "shared/ncs_code_select",
+            { :f => inelig, :code => :first_prenatal_visit_code, :label_text => "Is this the first prenatal visit for the sampled woman?", :html_attrs => { :class => "required ineligible" } }
+
+          = render "shared/ncs_code_select",
+            { :f => inelig, :code => :ineligible_by_code, :label_text => "Who determined sampled woman is ineligible?", :html_attrs => { :class => "required ineligible" } }
+
+    = submit_tag "Submit", :disable_with => 'Submitting...'
+
+:javascript
+  $(function() {
+    function show_hide_persons_ineligibility() {
+      if($('.pre_screening_status_selector').val() === '2') {
+        $('.persons_ineligibility').show();
+        $('.ineligible').prop('required', 'required');
+      }
+      else {
+        $('.persons_ineligibility').hide();
+        $('.ineligible').removeProp('required');
+      }
+    }
+    function show_hide_intro_otherpersons_ineligibility() {
+      if($('.provider_intro_outcome_code').val() === '-5') {
+        $('.other_field').show();
+      }
+      else {
+        $('.other_field').hide();
+      }
+    }
+    show_hide_persons_ineligibility();
+    $('.pre_screening_status_selector').change(show_hide_persons_ineligibility);
+    show_hide_intro_otherpersons_ineligibility();
+    $('.provider_intro_outcome_code').change(show_hide_intro_otherpersons_ineligibility);
+    $('#batch_ineligible_form').validate({
+      rules: {
+        'person[person_provider_links_attributes][0][date_first_visit]': {
+          minlength: 10,
+          maxlength: 10
+        },
+        'people[number]': {
+        number: true,
+        range: [1, 500]
+        }
+      }
+    });
+  });

--- a/app/views/providers/batch_ineligible.html.haml
+++ b/app/views/providers/batch_ineligible.html.haml
@@ -1,0 +1,4 @@
+- txt = @provider.nil? ? "ERROR: provider missing" : "Batch entry of non-sampled and pre-screened out women for #{@provider}"
+- page_title txt
+
+= render "form"

--- a/app/views/providers/show.html.haml
+++ b/app/views/providers/show.html.haml
@@ -4,19 +4,22 @@
   = "#{@provider.name_practice}"
 
 .page_section
-  - if @provider.people.empty?
+  - if @patients.empty?
     %b
       Patients at this Location
     #no_records
       No patients exist for provider.
   - else
+    .records_header
+      .page_entries_info
+        = raw page_entries_info @patients
     %table.records
       %tr
         %th
           Patients at this Location
         %th
 
-      - @provider.people.each do |per|
+      - @patients.each do |per|
         %tr{ :class => cycle('even_record', 'odd_record') }
           %td
             = link_to blank_safe(per.full_name), edit_provider_person_path(@provider, per),
@@ -24,6 +27,72 @@
           %td
             - if permit?(Role::FIELD_STAFF, Role::PHONE_STAFF)
               = pbs_eligibility_screener_link(per)
-
+    = will_paginate @patients, :param_name => 'patients_page'
   .links
     = link_to 'Add New Patient', new_provider_person_path(@provider), :class => "add_link icon_link"
+  %hr
+  %b
+    Batch patients at this Location
+  - if @ineligible_patients.empty?
+    #no_records
+      No batch patients exist for provider.
+  - else
+    .records_header
+      .page_entries_info
+        = raw page_entries_info @ineligible_patients
+    %table.records
+      %tr
+        %th
+          First Visit Date
+        %th
+          Patient Count
+        %th
+          Pre-Screening Status
+        %th
+          Sampled Person?
+        %th
+          Outcome of Introduction
+        %th
+          Age Eligible?
+        %th
+          In sample PSU/county?
+        %th
+          Pregnant?
+        %th
+          First Visit?
+        %th
+          Determined Ineligible By
+        %th
+          Delete Batch
+
+      - @ineligible_patients.each do |per|
+        %tr{ :class => cycle('even_record', 'odd_record') }
+          %td
+            = per.date_first_visit_date
+          %td
+            = per.count
+          %td
+            = lookup_text_for_ncs_attrib('pre_screening_status_code', per.pre_screening_status_code)
+          %td
+            = lookup_text_for_ncs_attrib('sampled_person_code', per.sampled_person_code)
+          %td
+            = lookup_text_for_ncs_attrib('provider_intro_outcome_code', per.provider_intro_outcome_code)
+          %td
+            = lookup_text_for_ncs_attrib('age_eligible_code', per.age_eligible_code)
+          %td
+            = lookup_text_for_ncs_attrib('county_of_residence_code', per.county_of_residence_code)
+          %td
+            = lookup_text_for_ncs_attrib('pregnancy_eligible_code', per.pregnancy_eligible_code)
+          %td
+            = lookup_text_for_ncs_attrib('first_prenatal_visit_code', per.first_prenatal_visit_code)
+          %td
+            = lookup_text_for_ncs_attrib('ineligible_by_code', per.ineligible_by_code)
+          %td
+            = link_to '',
+              delete_batch_provider_people_path(@provider.id, :ineligibility_batch_identifier => per.ineligibility_batch_identifier),
+              :confirm => "Are you sure you want to delete total of #{per.count} patients in this batch?",
+              :method => :delete,
+              :class => "delete_link icon_link"
+    = will_paginate @ineligible_patients, :param_name => 'inpatients_page'
+  .links
+    = link_to 'Enter non-sampled and pre-screened out women', batch_ineligible_provider_path(@provider), :class => "add_link icon_link"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,7 @@ NcsNavigatorCore::Application.routes.draw do
       post :create_staff
       get :edit_staff
       put :update_staff
-
+      get :batch_ineligible
       get :contact_log
       get :post_recruitment_contact
       get :recruited
@@ -113,7 +113,12 @@ NcsNavigatorCore::Application.routes.draw do
       put :process_refused
     end
     resources :non_interview_providers, :except => [:destroy]
-    resources :people, :except => [:index, :destroy, :show]
+    resources :people, :except => [:index, :destroy, :show] do
+      collection do
+        delete :delete_batch
+        post :create_batch
+      end
+    end
   end
   resources :pbs_lists, :except => [:new, :create] do
     member do

--- a/db/migrate/20130326184001_add_ineligibility_batch_identifier_to_person_provider_link.rb
+++ b/db/migrate/20130326184001_add_ineligibility_batch_identifier_to_person_provider_link.rb
@@ -1,0 +1,9 @@
+class AddIneligibilityBatchIdentifierToPersonProviderLink < ActiveRecord::Migration
+  def up
+    add_column :person_provider_links, :ineligibility_batch_identifier, :string, :limit => 36
+  end
+
+  def down
+    remove_column :person_provider_links, :ineligibility_batch_identifier
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -820,20 +820,21 @@ ActiveRecord::Schema.define(:version => 20130403145616) do
   end
 
   create_table "person_provider_links", :force => true do |t|
-    t.integer  "psu_code",                                   :null => false
-    t.string   "person_provider_id",           :limit => 36, :null => false
+    t.integer  "psu_code",                                     :null => false
+    t.string   "person_provider_id",             :limit => 36, :null => false
     t.integer  "provider_id"
     t.integer  "person_id"
-    t.integer  "is_active_code",                             :null => false
-    t.integer  "provider_intro_outcome_code",                :null => false
+    t.integer  "is_active_code",                               :null => false
+    t.integer  "provider_intro_outcome_code",                  :null => false
     t.string   "provider_intro_outcome_other"
-    t.string   "transaction_type",             :limit => 36
+    t.string   "transaction_type",               :limit => 36
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "sampled_person_code",                        :null => false
-    t.integer  "pre_screening_status_code",                  :null => false
+    t.integer  "sampled_person_code",                          :null => false
+    t.integer  "pre_screening_status_code",                    :null => false
     t.string   "date_first_visit"
     t.date     "date_first_visit_date"
+    t.string   "ineligibility_batch_identifier", :limit => 36
   end
 
   create_table "person_races", :force => true do |t|

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -29,7 +29,7 @@ describe ProvidersController do
         assigns(:q).sorts[0].name.should == "name_practice"
         assigns(:q).sorts[1].name.should == "id"
       end
-      
+
       it "performs user selected sort first; id second" do 
         get :index, :q => { :s => "name_practice desc" }
         assigns(:q).sorts[0].name.should == "name_practice"

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -35,6 +35,7 @@ FactoryGirl.define do
     ppl.provider_intro_outcome_code     1
     ppl.sampled_person_code             1
     ppl.pre_screening_status_code       1
+    ppl.ineligibility_batch_identifier  nil
   end
 
   factory :personnel_provider_link do |ppl|

--- a/spec/models/person_provider_link_spec.rb
+++ b/spec/models/person_provider_link_spec.rb
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130129202515
+# Schema version: 20130326184001
 #
 # Table name: person_provider_links
 #
-#  created_at                   :datetime
-#  date_first_visit             :string(255)
-#  date_first_visit_date        :date
-#  id                           :integer          not null, primary key
-#  is_active_code               :integer          not null
-#  person_id                    :integer
-#  person_provider_id           :string(36)       not null
-#  pre_screening_status_code    :integer          not null
-#  provider_id                  :integer
-#  provider_intro_outcome_code  :integer          not null
-#  provider_intro_outcome_other :string(255)
-#  psu_code                     :integer          not null
-#  sampled_person_code          :integer          not null
-#  transaction_type             :string(36)
-#  updated_at                   :datetime
+#  created_at                     :datetime
+#  date_first_visit               :string(255)
+#  date_first_visit_date          :date
+#  id                             :integer          not null, primary key
+#  ineligibility_batch_identifier :string(36)
+#  is_active_code                 :integer          not null
+#  person_id                      :integer
+#  person_provider_id             :string(36)       not null
+#  pre_screening_status_code      :integer          not null
+#  provider_id                    :integer
+#  provider_intro_outcome_code    :integer          not null
+#  provider_intro_outcome_other   :string(255)
+#  psu_code                       :integer          not null
+#  sampled_person_code            :integer          not null
+#  transaction_type               :string(36)
+#  updated_at                     :datetime
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Two tables now display in /providers/#. Top one shows 'normal' people
associated with the provider. Bottom one shows people created by the
batch-entry form. Form for entry of ineligible women is accessible via
/providers/#/batch_ineligible uri. `batch_ineligible` in `PersonProviderLink`
keeps track of which people are in the same group of batch-ineligible
women.
