### PR TITLE
Support MDES-versioned code lists (#3616)

### DIFF
--- a/app/models/ncs_code.rb
+++ b/app/models/ncs_code.rb
@@ -22,316 +22,6 @@ class NcsCode < ActiveRecord::Base
   OTHER = -5
   UNKNOWN = -6
 
-  ATTRIBUTE_MAPPING = {
-
-    ### person
-    :psu_code                       => "PSU_CL1",
-    :prefix_code                    => "NAME_PREFIX_CL1",
-    :suffix_code                    => "NAME_SUFFIX_CL1",
-    :sex_code                       => "GENDER_CL1",
-    :age_range_code                 => "AGE_RANGE_CL1",
-    :deceased_code                  => "CONFIRM_TYPE_CL2",
-    :ethnic_group_code              => "ETHNICITY_CL1",
-    :language_code                  => "LANGUAGE_CL2",
-    :marital_status_code            => "MARITAL_STATUS_CL1",
-    :preferred_contact_method_code  => "CONTACT_TYPE_CL1",
-    :planned_move_code              => "CONFIRM_TYPE_CL1",
-    :move_info_code                 => "MOVING_PLAN_CL1",
-    :when_move_code                 => "CONFIRM_TYPE_CL4",
-    :p_tracing_code                 => "CONFIRM_TYPE_CL2",
-    :p_info_source_code             => "INFORMATION_SOURCE_CL4",
-
-    ### person_race
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :race_code => "RACE_CL1",
-
-    ### participant
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :p_type_code              => "PARTICIPANT_TYPE_CL1",
-    :status_info_source_code  => "INFORMATION_SOURCE_CL4",
-    :status_info_mode_code    => "CONTACT_TYPE_CL1",
-    :enroll_status_code       => "CONFIRM_TYPE_CL2",
-    :pid_entry_code           => "STUDY_ENTRY_METHOD_CL1",
-    :pid_age_eligibility_code => "AGE_ELIGIBLE_CL2",
-
-    ### participant_person_link
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :relationship_code => "PERSON_PARTCPNT_RELTNSHP_CL1",
-    :is_active_code    => "CONFIRM_TYPE_CL2",
-
-    ### listing_unit
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :list_source_code  => "LISTING_SOURCE_CL1",
-
-    ### dwelling_unit
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :duplicate_du_code  => "CONFIRM_TYPE_CL2",
-    :missed_du_code     => "CONFIRM_TYPE_CL2",
-    :du_type_code       => "RESIDENCE_TYPE_CL2",
-    :du_ineligible_code => "CONFIRM_TYPE_CL3",
-    :du_access_code     => "CONFIRM_TYPE_CL2",
-
-    ### household_unit
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :hh_status_code      => "CONFIRM_TYPE_CL2",
-    :hh_eligibility_code => "HOUSEHOLD_ELIGIBILITY_CL2",
-    :hh_structure_code   => "RESIDENCE_TYPE_CL2",
-
-    ### dwelling_household_link
-    # :psu_code               => "PSU_CL1",             # already referenced
-    # :is_active_code         => "CONFIRM_TYPE_CL2",    # already referenced
-    :du_rank_code   => "COMMUNICATION_RANK_CL1",
-
-    ### household_person_link
-    # :psu_code               => "PSU_CL1",             # already referenced
-    # :is_active_code         => "CONFIRM_TYPE_CL2",
-    :hh_rank_code   => "COMMUNICATION_RANK_CL1",
-
-    ### address
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :address_rank_code        => 'COMMUNICATION_RANK_CL1',
-    :address_info_source_code => 'INFORMATION_SOURCE_CL1',
-    :address_info_mode_code   => 'CONTACT_TYPE_CL1',
-    :address_type_code        => 'ADDRESS_CATEGORY_CL1',
-    :address_description_code => 'RESIDENCE_TYPE_CL1',
-    :state_code               => 'STATE_CL1',
-
-    ### telephone
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :phone_info_source_code        => 'INFORMATION_SOURCE_CL2',
-    :phone_type_code               => 'PHONE_TYPE_CL1',
-    :phone_rank_code               => 'COMMUNICATION_RANK_CL1',
-    :phone_landline_code           => 'CONFIRM_TYPE_CL2',
-    :phone_share_code              => 'CONFIRM_TYPE_CL2',
-    :cell_permission_code          => 'CONFIRM_TYPE_CL2',
-    :text_permission_code          => 'CONFIRM_TYPE_CL2',
-
-    ### email
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :email_info_source_code        => 'INFORMATION_SOURCE_CL2',
-    :email_type_code               => 'EMAIL_TYPE_CL1',
-    :email_rank_code               => 'COMMUNICATION_RANK_CL1',
-    :email_share_code              => 'CONFIRM_TYPE_CL2',
-    :email_active_code             => 'CONFIRM_TYPE_CL2',
-
-    ### instrument
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :instrument_type_code          => 'INSTRUMENT_TYPE_CL1',
-    :instrument_breakoff_code      => 'CONFIRM_TYPE_CL2',
-    :instrument_status_code        => 'INSTRUMENT_STATUS_CL1',
-    :instrument_mode_code          => 'INSTRUMENT_ADMIN_MODE_CL1',
-    :instrument_method_code        => 'INSTRUMENT_ADMIN_METHOD_CL1',
-    :supervisor_review_code        => 'CONFIRM_TYPE_CL2',
-    :data_problem_code             => 'CONFIRM_TYPE_CL2',
-
-    ### event
-    # :psu_code                   => "PSU_CL1",             # already referenced
-    :event_type_code                   => 'EVENT_TYPE_CL1',
-    :event_disposition_category_code   => 'EVENT_DSPSTN_CAT_CL1',
-    :event_breakoff_code               => 'CONFIRM_TYPE_CL2',
-    :event_incentive_type_code         => 'INCENTIVE_TYPE_CL1',
-
-    ### contact_link
-    # :psu_code               => "PSU_CL1",             # already referenced
-
-    ### contact
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :contact_type_code             => 'CONTACT_TYPE_CL1',
-    :contact_language_code         => 'LANGUAGE_CL2',
-    :contact_interpret_code        => 'TRANSLATION_METHOD_CL3',
-    :contact_location_code         => 'CONTACT_LOCATION_CL1',
-    :contact_private_code          => 'CONFIRM_TYPE_CL2',
-    :who_contacted_code            => 'CONTACTED_PERSON_CL1',
-
-    ### ppg_details
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :ppg_pid_status_code           => 'PARTICIPANT_STATUS_CL1',
-    :ppg_first_code                => 'PPG_STATUS_CL2',
-
-    ### ppg_status_history
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :ppg_status_code               => 'PPG_STATUS_CL1',
-    :ppg_info_source_code          => 'INFORMATION_SOURCE_CL3',
-    :ppg_info_mode_code            => 'CONTACT_TYPE_CL1',
-
-    ### participant_consent
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :consent_type_code              => 'CONSENT_TYPE_CL1',
-    :consent_form_type_code         => 'CONSENT_TYPE_CL3',
-    :consent_given_code             => 'CONFIRM_TYPE_CL2',
-    :consent_withdraw_code          => 'CONFIRM_TYPE_CL2',
-    :consent_withdraw_type_code     => 'CONSENT_WITHDRAW_REASON_CL1',
-    :consent_withdraw_reason_code   => 'CONSENT_WITHDRAW_REASON_CL2',
-    :consent_language_code          => 'LANGUAGE_CL2',
-    :who_consented_code             => 'AGE_STATUS_CL1',
-    :who_wthdrw_consent_code        => 'AGE_STATUS_CL3',
-    :consent_translate_code         => 'TRANSLATION_METHOD_CL1',
-    :reconsideration_script_use_code => 'CONFIRM_TYPE_CL21',
-    :consent_reconsent_code         => 'CONFIRM_TYPE_CL2',
-    :consent_reconsent_reason_code  => 'CONSENT_RECONSENT_REASON_CL1',
-
-    ### participant_visit_consent
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :vis_consent_type_code      => 'VISIT_TYPE_CL1',
-    :vis_consent_response_code  => 'CONFIRM_TYPE_CL2',
-    :vis_language_code          => 'LANGUAGE_CL2',
-    :vis_who_consented_code     => 'AGE_STATUS_CL1',
-    :vis_translate_code         => 'TRANSLATION_METHOD_CL1',
-
-    ### participant_authorization_form
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :auth_form_type_code        => 'AUTH_FORM_TYPE_CL1',
-    :auth_status_code           =>'AUTH_STATUS_CL1',
-
-    ### participant_consent_sample
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :sample_consent_type_code   => 'CONSENT_TYPE_CL2',
-    :sample_consent_given_code  => 'CONFIRM_TYPE_CL2',
-
-    ### participant_visit_record
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :rvis_language_code        => 'LANGUAGE_CL2',
-    :rvis_who_consented_code   => 'AGE_STATUS_CL1',
-    :rvis_translate_code       => 'TRANSLATION_METHOD_CL1',
-    :rvis_sections_code        => 'CONFIRM_TYPE_CL21',
-    :rvis_during_interv_code   => 'CONFIRM_TYPE_CL21',
-    :rvis_during_bio_code      => 'CONFIRM_TYPE_CL21',
-    :rvis_bio_cord_code        => 'CONFIRM_TYPE_CL21',
-    :rvis_during_env_code      => 'CONFIRM_TYPE_CL21',
-    :rvis_during_thanks_code   => 'CONFIRM_TYPE_CL21',
-    :rvis_after_saq_code       => 'CONFIRM_TYPE_CL21',
-    :rvis_reconsideration_code => 'CONFIRM_TYPE_CL21',
-
-    ### non_interview_report
-    # :psu_code               => "PSU_CL1",             # already referenced
-    :nir_vacancy_information_code   => 'DU_VACANCY_INFO_SOURCE_CL1',
-    :nir_no_access_code             => 'NO_ACCESS_DESCR_CL1',
-    :nir_access_attempt_code        => 'ACCESS_ATTEMPT_CL1',
-    :nir_type_person_code           => 'NIR_REASON_PERSON_CL1',
-    :cog_inform_relation_code       => 'NIR_INFORM_RELATION_CL1',
-    :permanent_disability_code      => 'CONFIRM_TYPE_CL10',
-    :deceased_inform_relation_code  => 'NIR_INFORM_RELATION_CL1',
-    :state_of_death_code            => 'STATE_CL3',
-    :who_refused_code               => 'NIR_INFORM_RELATION_CL2',
-    :nir_who_refused_code           => 'NIR_INFORM_RELATION_CL2', # not to be confused with non_interview_report_provider
-    :refuser_strength_code          => 'REFUSAL_INTENSITY_CL1',
-    :refusal_action_code            => 'REFUSAL_ACTION_CL1',
-    :permanent_long_term_code       => 'CONFIRM_TYPE_CL10',
-    :reason_unavailable_code        => 'UNAVAILABLE_REASON_CL1',
-    :moved_unit_code                => 'TIME_UNIT_PAST_CL1',
-    :moved_inform_relation_code     => 'MOVED_INFORM_RELATION_CL1',
-
-    ### no_access_nir
-    # :nir_no_access                => 'NO_ACCESS_DESCR_CL1' # already referenced
-
-    ### dwelling_unit_type_nir
-    :nir_dwelling_unit_type_code    => 'DU_NIR_REASON_CL1',
-
-    ### vacant_nir
-    :nir_vacant_code                => 'DU_VACANCY_INDICATOR_CL1',
-
-    ### refusal nir
-    :refusal_reason_code            => 'REFUSAL_REASON_CL1',
-
-    ### spec_shipping
-    :shipment_temperature_code       => 'SHIPMENT_TEMPERATURE_CL1',
-    :shipment_receipt_confirmed_code => 'CONFIRM_TYPE_CL2',
-    :shipment_issues_code            => 'SHIPMENT_ISSUES_CL1',
-
-    ### sample_shipping
-    :shipment_coolant_code          => 'SHIPMENT_TEMPERATURE_CL2',
-    :shipper_destination_code       => 'SHIPPER_DESTINATION_CL1',
-    :sample_shipped_by_code         => 'SAMPLES_SHIPPED_BY_CL1',
-
-    ### spec_pickup_form
-    :spec_pickup_comment_code       => 'SPECIMEN_STATUS_CL5',
-
-    ### spec_receipt
-    :receipt_comment_code         => 'SPECIMEN_STATUS_CL3',
-    :monitor_status_code          => 'TRIGGER_STATUS_CL1',
-    :upper_trigger_code           => 'TRIGGER_STATUS_CL1',
-    :upper_trigger_level_code     => 'TRIGGER_STATUS_CL2',
-    :lower_trigger_cold_code      => 'TRIGGER_STATUS_CL1',
-    :lower_trigger_ambient_code   => 'TRIGGER_STATUS_CL1',
-    :centrifuge_comment_code      => 'SPECIMEN_STATUS_CL4',
-
-    ### specimen_storage
-    :master_storage_unit_code     => 'STORAGE_AREA_CL1',
-
-    ### sample_receipt_store
-    :sample_condition_code        => 'SPECIMEN_STATUS_CL7',
-    :cooler_temp_condition_code   => 'COOLER_TEMP_CL1',
-    :storage_compartment_area_code => 'STORAGE_AREA_CL2',
-    :temp_event_occurred_code     => 'CONFIRM_TYPE_CL20',
-    :temp_event_action_code       => 'SPECIMEN_STATUS_CL6',
-
-    ### sample_receipt_confirmation
-    :shipment_receipt_confirmed_code    =>     'CONFIRM_TYPE_CL21',
-    :shipment_condition_code            =>     'SHIPMENT_CONDITION_CL1',
-    :sample_condition_code              =>     'SPECIMEN_STATUS_CL7',
-
-    ### institution
-    # :psu_code                         => 'PSU_CL1',
-    :institute_type_code                => 'ORGANIZATION_TYPE_CL1',
-    :institute_relation_code            => 'PERSON_ORGNZTN_FUNCTION_CL1',
-    :institute_owner_code               => 'ORGANIZATION_OWNERSHIP_CL1',
-    :institute_unit_code                => 'ORGANIZATION_SIZE_UNIT_CL1',
-    :institute_info_source_code         => 'INFORMATION_SOURCE_CL2',
-
-    ### provider
-    # :psu_code                         => 'PSU_CL1',
-    :provider_type_code               => 'PROVIDER_TYPE_CL1',
-    :provider_ncs_role_code           => 'PROVIDER_STUDY_ROLE_CL1',
-    :practice_info_code               => 'PRACTICE_CHARACTERISTIC_CL1',
-    :practice_patient_load_code       => 'PRACTICE_LOAD_RANGE_CL1',
-    :practice_size_code               => 'PRACTICE_SIZE_RANGE_CL1',
-    :public_practice_code             => 'CONFIRM_TYPE_CL2',
-    :provider_info_source_code        => 'INFORMATION_SOURCE_CL2',
-    :list_subsampling_code            => 'CONFIRM_TYPE_CL2',
-
-    ### pbs_provider_role
-    :provider_role_pbs_code           => 'PROVIDER_STUDY_ROLE_CL2',
-
-    ### pbs_list
-    # :psu_code                         => 'PSU_CL1',
-    :in_out_frame_code                => 'INOUT_FRAME_CL1',                 # MDES 3.0
-    :in_sample_code                   => 'ORIGINAL_SUBSTITUTE_SAMPLE_CL1',  # MDES 3.0
-    :in_out_psu_code                  => 'INOUT_PSU_CL1',                   # MDES 3.0
-    :cert_flag_code                   => 'CERT_UNIT_CL1',                   # MDES 3.0
-    :frame_completion_req_code        => 'CONFIRM_TYPE_CL21',
-    :pr_recruitment_status_code       => 'RECRUIT_STATUS_CL1',              # MDES 3.0
-
-    ### provider_logistics
-    # :psu_code                       => 'PSU_CL1',
-    :provider_logistics_code          => 'PROVIDER_LOGISTICS_CL1',
-
-    ### non-interview provider
-    :nir_type_provider_code =>         'NON_INTERVIEW_CL1',
-    :nir_closed_info_code =>           'INFORMATION_SOURCE_CL8',
-    :perm_closure_code =>              'CONFIRM_TYPE_CL10',
-    :who_refused_code =>               'REFUSAL_PROVIDER_CL1',
-    :refuser_strength_code =>          'REFUSAL_INTENSITY_CL2',
-    :ref_action_provider_code =>       'REFUSAL_ACTION_CL1',
-    :who_confirm_noprenatal_code =>    'REFUSAL_PROVIDER_CL1',
-    :nir_moved_info_code =>            'INFORMATION_SOURCE_CL8',
-    :perm_moved_code =>                'CONFIRM_TYPE_CL10',
-
-    ### person_provider_link
-    # :psu,                     'PSU_CL1'
-    :is_active_code                 => 'CONFIRM_TYPE_CL2',
-    :provider_intro_outcome_code    => 'STUDY_INTRODCTN_OUTCOME_CL1',
-    :sampled_person_code            => 'CONFIRM_TYPE_CL2',
-    :pre_screening_status_code      => 'SCREENING_STATUS_CL1',
-
-    ### sampled_person_ineligibility
-    :age_eligible_code              => 'CONFIRM_TYPE_CL3',
-    :county_of_residence_code       => 'CONFIRM_TYPE_CL3',
-    :pregnancy_eligible_code        => 'CONFIRM_TYPE_CL3',
-    :first_prenatal_visit_code      => 'CONFIRM_TYPE_CL3',
-    :ineligible_by_code             => 'INELIG_SOURCE_CL1'
-
-  }.with_indifferent_access
-
   ##
   # Given a list of attributes, returns all NCS codes for those attributes.
   # You can use either symbols or strings for the attributes.  Attributes that
@@ -385,8 +75,65 @@ class NcsCode < ActiveRecord::Base
     keep_default_order ? 1 : 0
   end
 
-  def self.attribute_lookup(attribute_name)
-     ATTRIBUTE_MAPPING[attribute_name]
+  ##
+  # Return the code list for the given NcsCodedAttribute attribute name.
+  #
+  # E.g., `NcsCode.attribute_lookup('psu_code') # => 'PSU_CL1'`.
+  #
+  # Note: this method uses a dynamically-built index which is created the first
+  # time it is accessed in a process. If you are dynamically creating models,
+  # you'll want to create them all before calling this method, or you'll need
+  # to purge the index (see {.clear_attribute_lookup_index}).
+  #
+  # @param [#to_s] attribute_name the attribute for which the list is
+  #   desired.
+  # @param [Hash] options values to influence the lookup.
+  # @option options [String,nil] :mdes_version (application version) the MDES
+  #   version for which to return the list.
+  # @option options [#to_s,nil] :model_class in the rare case where the same
+  #   attribute appears in multiple models with different code lists, specifying
+  #   the model allows you specify which attribute you mean.
+  def self.attribute_lookup(attribute_name, options={})
+    mdes_version = options[:mdes_version] || NcsNavigatorCore.mdes_version.number
+    model = options[:model_class].try(:to_s)
+
+    matches = attribute_lookup_index(mdes_version)[attribute_name.to_s]
+    if matches.nil?
+      nil
+    elsif matches.size == 1
+      matches.keys.first
+    else
+      list_name, _ = matches.find { |list_name, models| models.include?(model) }
+      if list_name
+        list_name
+      elsif model
+        fail "#{model}##{attribute_name} is not a coded attribute (it may not be an attribute at all)"
+      else
+        fail "#{attribute_name} maps to #{matches.size} code lists in different models. Please use :model_class => 'Foo' to disambiguate."
+      end
+    end
+  end
+
+  class << self
+    def attribute_lookup_index(mdes_version)
+      @attribute_lookup_index ||= {}
+      @attribute_lookup_index[mdes_version] ||= build_attribute_lookup_index(mdes_version)
+    end
+    private :attribute_lookup_index
+
+    def build_attribute_lookup_index(mdes_version)
+      all_coded_attributes = NcsNavigator::Core::Mdes::MdesRecord.models.
+        collect { |rec| rec.ncs_coded_attributes.values }.flatten
+      all_coded_attributes.each_with_object({}) do |nca, index|
+        attribute_entry = (index[nca.foreign_key_name.to_s] ||= {})
+        (attribute_entry[nca.list_name(mdes_version)] ||= []) << nca.model_class.to_s
+      end
+    end
+    private :build_attribute_lookup_index
+
+    def clear_attribute_lookup_index
+      @attribute_lookup_index = nil
+    end
   end
 
   def self.for_attribute_name_and_local_code(attribute_name, local_code)

--- a/app/models/ncs_code.rb
+++ b/app/models/ncs_code.rb
@@ -48,8 +48,17 @@ class NcsCode < ActiveRecord::Base
     maximum(:updated_at)
   end
 
-  def self.ncs_code_lookup(attribute_name, show_missing_in_error = false)
-    list_name = attribute_lookup(attribute_name)
+  def self.ncs_code_lookup(attribute_name, options={})
+    show_missing_in_error =
+      case options
+      when true
+        options = {}
+        true
+      else
+        options[:include_missing_in_error]
+      end
+
+    list_name = attribute_lookup(attribute_name, options)
     codes = for_list_name(list_name)
 
     unless show_missing_in_error
@@ -136,8 +145,9 @@ class NcsCode < ActiveRecord::Base
     end
   end
 
-  def self.for_attribute_name_and_local_code(attribute_name, local_code)
-    for_list_name_and_local_code(attribute_lookup(attribute_name), local_code)
+  def self.for_attribute_name_and_local_code(attribute_name, local_code, attribute_lookup_options={})
+    for_list_name_and_local_code(
+      attribute_lookup(attribute_name, attribute_lookup_options), local_code)
   end
 
   def self.for_list_name(list_name)

--- a/app/models/participant_consent_sample.rb
+++ b/app/models/participant_consent_sample.rb
@@ -28,7 +28,8 @@ class ParticipantConsentSample < ActiveRecord::Base
 
   ncs_coded_attribute :psu,                  'PSU_CL1'
   ncs_coded_attribute :sample_consent_type,  'CONSENT_TYPE_CL2'
-  ncs_coded_attribute :sample_consent_given, 'CONFIRM_TYPE_CL2'
+  ncs_coded_attribute :sample_consent_given,
+    :list_name => { 'CONFIRM_TYPE_CL2' => '2.0', 'CONFIRM_TYPE_CL21' => '> 2.0' }
 
   ENVIRONMENTAL = 1
   BIOSPECIMEN   = 2

--- a/app/models/telephone.rb
+++ b/app/models/telephone.rb
@@ -53,8 +53,10 @@ class Telephone < ActiveRecord::Base
   ncs_coded_attribute :phone_rank,        'COMMUNICATION_RANK_CL1'
   ncs_coded_attribute :phone_landline,    'CONFIRM_TYPE_CL2'
   ncs_coded_attribute :phone_share,       'CONFIRM_TYPE_CL2'
-  ncs_coded_attribute :cell_permission,   'CONFIRM_TYPE_CL2'
-  ncs_coded_attribute :text_permission,   'CONFIRM_TYPE_CL2'
+  ncs_coded_attribute :cell_permission,
+    :list_name => { 'CONFIRM_TYPE_CL2' => '2.0', 'CONFIRM_TYPE_CL21' => '> 2.0' }
+  ncs_coded_attribute :text_permission,
+    :list_name => { 'CONFIRM_TYPE_CL2' => '2.0', 'CONFIRM_TYPE_CL10' => '> 2.0' }
 
   validates :phone_ext,        :length => { :maximum => 5 },  :allow_blank => true
   validates :phone_nbr,        :length => { :maximum => 10 }, :allow_blank => true, :numericality => true

--- a/app/views/non_interview_providers/_form_fields.html.haml
+++ b/app/views/non_interview_providers/_form_fields.html.haml
@@ -21,9 +21,9 @@
   - cls = "nir_section nir_type_provider_2"
   - cls += " hide" if obj.nir_type_provider_code != 2
   %div{ :class => cls }
-    = render "shared/ncs_code_select", { :f => f, :code => :who_refused_code, :label_text => "Person in the provider's office who refused participation", :other => :who_refused_other }
+    = render "shared/ncs_code_select", { :f => f, :code => :who_refused_code, :model_class => 'NonInterviewProvider', :label_text => "Person in the provider's office who refused participation", :other => :who_refused_other }
 
-    = render "shared/ncs_code_select", { :f => f, :code => :refuser_strength_code, :label_text => "Strength/Intensity of Refusal" }
+    = render "shared/ncs_code_select", { :f => f, :code => :refuser_strength_code, :model_class => 'NonInterviewProvider', :label_text => "Strength/Intensity of Refusal" }
 
     = render "shared/ncs_code_select", { :f => f, :code => :ref_action_provider_code, :label_text => "Recommended next steps for case" }
 

--- a/app/views/non_interview_reports/_form_fields.html.haml
+++ b/app/views/non_interview_reports/_form_fields.html.haml
@@ -86,9 +86,9 @@
     %b
       Refusal
 
-    = render "shared/ncs_code_select", { :f => f, :code => :who_refused_code, :unambiguous_code => :nir_who_refused_code, :label_text => "Relationship of informant to participant", :other => :who_refused_other }
+    = render "shared/ncs_code_select", { :f => f, :code => :who_refused_code, :model_class => 'NonInterviewReport', :label_text => "Relationship of informant to participant", :other => :who_refused_other }
 
-    = render "shared/ncs_code_select", { :f => f, :code => :refuser_strength_code, :label_text => "Strength/Intensity of Refusal" }
+    = render "shared/ncs_code_select", { :f => f, :code => :refuser_strength_code, :model_class => 'NonInterviewReport', :label_text => "Strength/Intensity of Refusal" }
 
     = render "shared/ncs_code_select", { :f => f, :code => :refusal_action_code, :label_text => "Recommended next steps for case" }
 

--- a/app/views/shared/_ncs_code_select.html.haml
+++ b/app/views/shared/_ncs_code_select.html.haml
@@ -4,7 +4,7 @@
 - help_text ||= nil
 - notify_marker ||= nil
 - html_attrs ||= { :class => "required" }
-- unambiguous_code ||= nil
+- model_class ||= nil
 
 - html_attrs[:disabled] = "disabled" if code.to_s == "psu_code"
 %p
@@ -18,8 +18,7 @@
     = render help_text
   - f.object.send("#{code}=", default_value) if default_value
   %p{ :class => 'ncs_select' }
-    - c = unambiguous_code ? unambiguous_code : code
-    - ncs_code = NcsCode.ncs_code_lookup(c)
+    - ncs_code = NcsCode.ncs_code_lookup(code, :model_class => model_class)
     = f.select(code, ncs_code, { :include_blank => "-- Select #{label_text} --" }, html_attrs)
     - if other
       %p.other_field

--- a/config/initializers/eager_load_models.rb
+++ b/config/initializers/eager_load_models.rb
@@ -1,0 +1,8 @@
+# Models need to all be loaded for NcsCode.attribute_lookup to work. They are
+# eagerly loaded by Rails in staging/production/test, but not development.
+unless Rails.configuration.cache_classes
+  Rails.logger.debug "Eager-loading models for development"
+  Dir[(Rails.root + 'app/models/**/*.rb').to_s].each do |model_file|
+    require_dependency model_file
+  end
+end

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -4,6 +4,8 @@ module NcsNavigator::Core
   module Mdes
     ##
     # All the MDES versions supported by this version of Cases.
+    # This should be kept in order so that sanity checks for Mdes::Version#<=>
+    # are useful.
     SUPPORTED_VERSIONS = %w(2.0 2.1 2.2 3.0 3.1 3.2).freeze
 
     autoload :CodeListCache,  'ncs_navigator/core/mdes/code_list_cache'

--- a/lib/ncs_navigator/core/mdes.rb
+++ b/lib/ncs_navigator/core/mdes.rb
@@ -2,6 +2,10 @@ require 'ncs_navigator/core'
 
 module NcsNavigator::Core
   module Mdes
+    ##
+    # All the MDES versions supported by this version of Cases.
+    SUPPORTED_VERSIONS = %w(2.0 2.1 2.2 3.0 3.1 3.2).freeze
+
     autoload :CodeListCache,  'ncs_navigator/core/mdes/code_list_cache'
     autoload :CodeListLoader, 'ncs_navigator/core/mdes/code_list_loader'
 

--- a/lib/ncs_navigator/core/mdes/mdes_record.rb
+++ b/lib/ncs_navigator/core/mdes/mdes_record.rb
@@ -16,6 +16,8 @@ module NcsNavigator::Core::Mdes
       before_save :format_dates
 
       include NcsNavigator::Core::HasPublicId
+
+      MdesRecord.models << self
     end
 
     module ClassMethods
@@ -223,6 +225,10 @@ module NcsNavigator::Core::Mdes
       end
       private :get_value
 
+    end
+
+    def self.models
+      @models ||= []
     end
 
   end

--- a/lib/ncs_navigator/core/mdes/mdes_record.rb
+++ b/lib/ncs_navigator/core/mdes/mdes_record.rb
@@ -44,9 +44,13 @@ module NcsNavigator::Core::Mdes
         end
       end
 
-      def ncs_coded_attribute(attribute_name, list_name)
+      def ncs_coded_attribute(attribute_name, options)
+        if String === options
+          options = { :list_name => options }
+        end
+
         ncs_coded_attributes[attribute_name.to_sym] =
-          NcsNavigator::Core::Mdes::NcsCodedAttribute.new(self, attribute_name, list_name)
+          NcsNavigator::Core::Mdes::NcsCodedAttribute.new(self, attribute_name, options)
       end
 
       def ncs_coded_attributes

--- a/lib/ncs_navigator/core/mdes/version.rb
+++ b/lib/ncs_navigator/core/mdes/version.rb
@@ -2,6 +2,8 @@ module NcsNavigator::Core::Mdes
   ##
   # The current MDES version for this particular Cases deployment.
   class Version
+    include Comparable
+
     ##
     # Set the MDES version for a new deployment.
     #
@@ -70,6 +72,24 @@ module NcsNavigator::Core::Mdes
 
     def specification=(spec)
       @specification = spec
+    end
+
+    ##
+    # Compares to another value. An instance of this class is comparable to:
+    #
+    # * Other instances. {#number} is compared lexicographically (good till 10.0).
+    # * `String`s. This instance's {#number} is compared to the string lexicographically.
+    #
+    # @return [-1, 0, 1, nil] per the contract defined in `Comparable`.
+    def <=>(other)
+      case other
+      when self.class
+        number <=> other.number
+      when String
+        number <=> other
+      else
+        nil
+      end
     end
   end
 end

--- a/lib/ncs_navigator/core/mdes/version.rb
+++ b/lib/ncs_navigator/core/mdes/version.rb
@@ -91,5 +91,25 @@ module NcsNavigator::Core::Mdes
         nil
       end
     end
+
+    ##
+    # Indicates whether this version matches the given comparison operation and
+    # version string. Supported operations are:
+    #
+    # * `>`
+    # * `>=`
+    # * `=`
+    # * `<=`
+    # * `<`
+    #
+    # @param [String] version_operation a string of the form [operator] ' ' [version].
+    #   Ex: `">= 2.2"`.
+    def matches?(version_operation)
+      pattern_match = version_operation.scan(/\A([<>]?=?)\s*(\d+\.\d+)\z/).first
+      fail "Unsupported comparison operation or version name in #{version_operation.inspect}" unless pattern_match
+      operator, other_version = pattern_match
+      operator = '==' if operator.empty? || operator == '='
+      send(operator, other_version)
+    end
   end
 end

--- a/lib/tasks/mdes.rake
+++ b/lib/tasks/mdes.rake
@@ -19,7 +19,7 @@ namespace :mdes do
     # n.b.: this touches your development database
     desc 'Generate the code list YAML and pg_dump files for every supported MDES version'
     task :all => :base do
-      versions = %w(2.0 2.1 2.2 3.0 3.1 3.2)
+      versions = NcsNavigator::Core::Mdes::SUPPORTED_VERSIONS.dup
 
       # move current version to end so that it is the one left in the database.
       current_version = NcsNavigator::Core::Mdes::Version.new.number

--- a/spec/lib/ncs_navigator/core/mdes/mdes_record_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/mdes_record_spec.rb
@@ -10,7 +10,7 @@ module NcsNavigator::Core::Mdes
     acts_as_mdes_record
 
     ncs_coded_attribute :psu, 'PSU_CL1'
-    ncs_coded_attribute :event_type, 'EVENT_TYPE_CL1'
+    ncs_coded_attribute :event_type, :list_name => 'EVENT_TYPE_CL1'
   end
 
   class Bar < ActiveRecord::Base
@@ -177,6 +177,14 @@ module NcsNavigator::Core::Mdes
     describe 'a coded attribute' do
       it 'exposes the list name' do
         Foo.ncs_coded_attributes[:psu].list_name.should == 'PSU_CL1'
+      end
+
+      it 'can be configured with a flat list name' do
+        Foo.ncs_coded_attributes[:psu].list_name.should == 'PSU_CL1'
+      end
+
+      it 'can be configured with the list name in an options hash' do
+        Foo.ncs_coded_attributes[:event_type].list_name.should == 'EVENT_TYPE_CL1'
       end
     end
 

--- a/spec/lib/ncs_navigator/core/mdes/mdes_record_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/mdes_record_spec.rb
@@ -67,6 +67,12 @@ module NcsNavigator::Core::Mdes
       let(:o2) { Foo.create! }
     end
 
+    describe '.models' do
+      it 'includes all the models' do
+        MdesRecord.models.should include(Baz)
+      end
+    end
+
     describe '.public_id' do
       it 'defaults to :uuid' do
         Foo.public_id_field.should == :uuid

--- a/spec/lib/ncs_navigator/core/mdes/version_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_spec.rb
@@ -94,5 +94,59 @@ module NcsNavigator::Core::Mdes
         Version.new.number.should == '2.1'
       end
     end
+
+    describe '#<=>' do
+      let(:version) { Version.new('3.1') }
+
+      shared_context 'Mdes::Version comparisons' do
+        it 'is -1 when compared to a greater value' do
+          (version <=> greater_value).should == -1
+        end
+
+        it 'is 0 when compared to an equivalent value' do
+          (version <=> same_value).should == 0
+        end
+
+        it 'is +1 when compared to a lesser value' do
+          (version <=> lesser_value).should == 1
+        end
+      end
+
+      describe 'with another Mdes::Version' do
+        let(:greater_value) { Version.new('3.5') }
+        let(:same_value)    { Version.new('3.1') }
+        let(:lesser_value)  { Version.new('2.2') }
+
+        include_context 'Mdes::Version comparisons'
+      end
+
+      describe 'with a string' do
+        let(:greater_value) { '4.8' }
+        let(:same_value)    { '3.1' }
+        let(:lesser_value)  { '1.1' }
+
+        include_context 'Mdes::Version comparisons'
+      end
+
+      it 'is not comparable to a float' do
+        (version <=> 3.1).should be_nil
+      end
+
+      it 'is not comparable to an integer' do
+        (version <=> 3).should be_nil
+      end
+
+      it 'is not comparable to nil' do
+        (version <=> nil).should be_nil
+      end
+
+      it 'reproduces the ordering for all known MDES versions' do
+        scrambled_versions = SUPPORTED_VERSIONS.
+          sort_by { rand }.collect { |n| Version.new(n) }
+
+        scrambled_versions.sort.collect(&:number).should ==
+          SUPPORTED_VERSIONS
+      end
+    end
   end
 end

--- a/spec/lib/ncs_navigator/core/mdes/version_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_spec.rb
@@ -148,5 +148,105 @@ module NcsNavigator::Core::Mdes
           SUPPORTED_VERSIONS
       end
     end
+
+    describe '#matches?' do
+      def v(number)
+        Version.new(number)
+      end
+
+      describe 'with a single version' do
+        it 'matches the same version' do
+          v('2.2').matches?('2.2').should be_true
+        end
+
+        it 'does not match a lesser version' do
+          v('2.2').matches?('2.1').should be_false
+        end
+
+        it 'does not match a greater version' do
+          v('2.2').matches?('3.1').should be_false
+        end
+      end
+
+      describe 'with =' do
+        it 'matches the same version' do
+          v('2.2').matches?('= 2.2').should be_true
+        end
+
+        it 'does not match a lesser version' do
+          v('2.2').matches?('= 2.1').should be_false
+        end
+
+        it 'does not match a greater version' do
+          v('2.2').matches?('= 2.4').should be_false
+        end
+      end
+
+      describe 'with <' do
+        it 'does not match the same version' do
+          v('2.2').matches?('< 2.2').should be_false
+        end
+
+        it 'does not match a lesser version' do
+          v('2.2').matches?('< 2.0').should be_false
+        end
+
+        it 'matches a greater version' do
+          v('2.2').matches?('< 2.4').should be_true
+        end
+      end
+
+      describe 'with <=' do
+        it 'matches the same version' do
+          v('2.2').matches?('<= 2.2').should be_true
+        end
+
+        it 'does not match a lesser version' do
+          v('2.2').matches?('<= 2.1').should be_false
+        end
+
+        it 'matches a greater version' do
+          v('2.2').matches?('<= 3.0').should be_true
+        end
+      end
+
+      describe 'with >' do
+        it 'does not match the same version' do
+          v('2.2').matches?('> 2.2').should be_false
+        end
+
+        it 'matches a lesser version' do
+          v('2.2').matches?('> 2.0').should be_true
+        end
+
+        it 'does not match a greater version' do
+          v('2.2').matches?('> 2.3').should be_false
+        end
+      end
+
+      describe 'with >=' do
+        it 'matches the same version' do
+          v('2.2').matches?('>= 2.2').should be_true
+        end
+
+        it 'matches a lesser version' do
+          v('2.2').matches?('>= 2.1').should be_true
+        end
+
+        it 'does not match a greater version' do
+          v('2.2').matches?('>= 3.8').should be_false
+        end
+      end
+
+      it 'throws an exception with some other comparator op' do
+        expect { v('2.0').matches?('<< 3.4') }.
+          to raise_error('Unsupported comparison operation or version name in "<< 3.4"')
+      end
+
+      it 'throws an exception without a version' do
+        expect { v('2.0').matches?('<=') }.
+          to raise_error('Unsupported comparison operation or version name in "<="')
+      end
+    end
   end
 end

--- a/spec/models/mdes_record_use_spec.rb
+++ b/spec/models/mdes_record_use_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Every MdesRecord model in Cases' do
+  describe 'each coded attribute' do
+    NcsNavigator::Core::Mdes::SUPPORTED_VERSIONS.each do |mdes_version|
+      it "has exactly one code list specified for MDES version #{mdes_version}" do
+        errors = NcsNavigator::Core::Mdes::MdesRecord.models.
+          collect { |model_class| model_class.ncs_coded_attributes.values }.flatten.
+          collect { |nca|
+            begin
+              nca.list_name(mdes_version)
+              nil
+            rescue RuntimeError => e
+              e.to_s
+            end
+            }.compact
+
+        errors.should == []
+      end
+    end
+  end
+end

--- a/spec/models/ncs_code_spec.rb
+++ b/spec/models/ncs_code_spec.rb
@@ -160,5 +160,29 @@ describe NcsCode do
         should include(['Missing in Error', -4])
     end
   end
+
+  describe '.attribute_lookup' do
+    it 'returns a code list name for a single known attribute symbol' do
+      NcsCode.attribute_lookup('centrifuge_comment_code').should == 'SPECIMEN_STATUS_CL4'
+    end
+
+    it 'returns a code list name for a single known attribute string' do
+      NcsCode.attribute_lookup(:centrifuge_comment_code).should == 'SPECIMEN_STATUS_CL4'
+    end
+
+    it 'returns nil for an unknown attribute' do
+      NcsCode.attribute_lookup(:foobar).should be_nil
+    end
+
+    it 'is MDES version aware'
+
+    describe 'for an attribute which appears in multiple models' do
+      it 'returns the sole code list when all the attributes use the same code list'
+
+      it 'fails when there is more than one code list possibility and no model is specified'
+
+      it 'returns the code list for the specified model when specified'
+    end
+  end
 end
 

--- a/spec/models/ncs_code_spec.rb
+++ b/spec/models/ncs_code_spec.rb
@@ -174,14 +174,42 @@ describe NcsCode do
       NcsCode.attribute_lookup(:foobar).should be_nil
     end
 
-    it 'is MDES version aware'
+    it 'is MDES version aware' do
+      [
+        NcsCode.attribute_lookup('text_permission_code', :mdes_version => '2.0'),
+        NcsCode.attribute_lookup('text_permission_code', :mdes_version => '2.1')
+      ].should == %w(CONFIRM_TYPE_CL2 CONFIRM_TYPE_CL10)
+    end
 
     describe 'for an attribute which appears in multiple models' do
-      it 'returns the sole code list when all the attributes use the same code list'
+      it 'returns the sole code list when all the attributes use the same code list' do
+        NcsCode.attribute_lookup('psu_code').should == 'PSU_CL1'
+      end
 
-      it 'fails when there is more than one code list possibility and no model is specified'
+      it 'fails when there is more than one code list possibility and no model is specified' do
+        expect { NcsCode.attribute_lookup('refuser_strength_code') }.
+          to raise_error("refuser_strength_code maps to 2 code lists in different models. Please use :model_class => 'Foo' to disambiguate.")
+      end
 
-      it 'returns the code list for the specified model when specified'
+      it 'returns the code list for the specified model when specified as a class' do
+        NcsCode.attribute_lookup('refuser_strength_code', :model_class => NonInterviewProvider).
+          should == 'REFUSAL_INTENSITY_CL2'
+      end
+
+      it 'returns the code list for the specified model when specified as a name' do
+        NcsCode.attribute_lookup('refuser_strength_code', :model_class => 'NonInterviewReport').
+          should == 'REFUSAL_INTENSITY_CL1'
+      end
+
+      it 'returns the code list for the specified model when specified as a symbol' do
+        NcsCode.attribute_lookup('refuser_strength_code', :model_class => :NonInterviewReport).
+          should == 'REFUSAL_INTENSITY_CL1'
+      end
+
+      it 'fails when the specified model does not have that attribute' do
+        expect { NcsCode.attribute_lookup('refuser_strength_code', :model_class => 'Contact') }.
+          to raise_error('Contact#refuser_strength_code is not a coded attribute (it may not be an attribute at all)')
+      end
     end
   end
 end

--- a/spec/models/ncs_code_spec.rb
+++ b/spec/models/ncs_code_spec.rb
@@ -140,6 +140,23 @@ describe NcsCode do
     end
   end
 
+  describe '.for_attribute_name_and_local_code' do
+    let(:actual) { NcsCode.for_attribute_name_and_local_code(:p_tracing_code, 2) }
+
+    it 'uses the code list looked up from the attribute name' do
+      actual.list_name.should == NcsCode.attribute_lookup(:p_tracing_code)
+    end
+
+    it 'gives the NcsCode for the specified value' do
+      actual.local_code.should == 2
+    end
+
+    it 'passes along options to attribute_lookup' do
+      expect { NcsCode.for_attribute_name_and_local_code(:refuser_strength_code, 1, :model_class => 'NonInterviewProvider') }.
+        to_not raise_error
+    end
+  end
+
   describe '.ncs_code_lookup' do
     let(:actual) { NcsCode.ncs_code_lookup(:p_tracing_code) }
 
@@ -155,9 +172,24 @@ describe NcsCode do
         should_not include(-4)
     end
 
-    it 'will include Missing in Error by request' do
+    it 'will include Missing in Error by request with boolean' do
       NcsCode.ncs_code_lookup(:p_tracing_code, true).
         should include(['Missing in Error', -4])
+    end
+
+    it 'omits Missing in Error with an explicit option' do
+      NcsCode.ncs_code_lookup(:p_tracing_code, :include_missing_in_error => false).collect { |p| p.last }.
+        should_not include(-4)
+    end
+
+    it 'will include Missing in Error by request with an option' do
+      NcsCode.ncs_code_lookup(:p_tracing_code, :include_missing_in_error => true).
+        should include(['Missing in Error', -4])
+    end
+
+    it 'passes options to attribute_lookup' do
+      expect { NcsCode.ncs_code_lookup('refuser_strength_code', :model_class => 'NonInterviewReport') }.
+        to_not raise_error
     end
   end
 


### PR DESCRIPTION
This series of commits addresses [Cases-3616](https://code.bioinformatics.northwestern.edu/issues/issues/show/3616) by:
- Making `NcsNavigator::Core::Mdes::Version` comparable
- Defining and implementing a mechanism for associating the same model attribute with different code lists in different MDES versions
- Using this mechanism for the operational code lists that changed between MDES 2.0 and 2.1
- Making `NcsCode.attribute_lookup` MDES-version-aware. This is handled by making it dynamic, based on `ncs_coded_attribute` declarations, rather than static. This in turn also enables detecting (by the software) and correcting (by the developer) ambiguities arising out of the same attribute being used with different code lists in different models.

The ambiguities in the NIR/NIP part of the consent process are corrected in this branch. There are other ambiguities in the sample/specimen collection area which are not corrected because they have deeper causes (see [Cases-3764](https://code.bioinformatics.northwestern.edu/issues/issues/show/3764)).

[Cases-3743](https://code.bioinformatics.northwestern.edu/issues/issues/show/3743) came up while working on this issue (and [Cases-3633](https://code.bioinformatics.northwestern.edu/issues/issues/show/3633)) and will be handled separately.
