### PR TITLE
adapting reset button for grid questions #3792

### DIFF
--- a/app/assets/javascripts/radio_reset_button.js
+++ b/app/assets/javascripts/radio_reset_button.js
@@ -2,13 +2,11 @@ $(document).ready(function() {
   $('.surveyor_radio').parent().parent().append('<a class="reset-button">Reset</a>');
 
   $('.reset-button').click(function () {
-      $('input[type="radio"]:checked','#'+$(this).data('question-id')).each(function () {
-          $(this).prop('checked', false);
-      }).trigger('change');
+      $('#'+$(this).data('question-id') + ' input[type="radio"]:checked').prop('checked', false).trigger('change');
   });
 
-  $('fieldset').each(function () {
-      var qid = $(this).attr('id');
-      $('.reset-button', $(this)).attr('data-question-id', qid);
+  $(".reset-button").each(function() {
+    $(this).data('question-id', $(this).parent().attr('id'));
   });
+
 });


### PR DESCRIPTION
### Summary

There was a faulty assumption that the question ID, which narrows the scope of the reset button's action, could always be found on the ascending fieldset. That's true for the vast majority of questions, but not grid questions. So changed the reference point to be relative to the reset button itself, namely its parent. 
