### PR TITLE
Migrations and OperationalImporter updates #3615

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
+# Schema version: 20130408184301
 #
 # Table name: participants
 #
-#  being_followed            :boolean          default(FALSE)
+#  being_followed            :boolean          default(TRUE)
 #  being_processed           :boolean          default(FALSE)
 #  created_at                :datetime
 #  enroll_date               :date

--- a/db/migrate/20130408184301_change_default_value_for_participants_being_followed_to_true.rb
+++ b/db/migrate/20130408184301_change_default_value_for_participants_being_followed_to_true.rb
@@ -1,0 +1,9 @@
+class ChangeDefaultValueForParticipantsBeingFollowedToTrue < ActiveRecord::Migration
+  def up
+    change_column_default(:participants, :being_followed, true)
+  end
+
+  def down
+    change_column_default(:participants, :being_followed, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130403145616) do
+ActiveRecord::Schema.define(:version => 20130408184301) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false
@@ -729,7 +729,7 @@ ActiveRecord::Schema.define(:version => 20130403145616) do
     t.string   "low_intensity_state"
     t.string   "high_intensity_state"
     t.text     "enrollment_status_comment"
-    t.boolean  "being_followed",                          :default => false
+    t.boolean  "being_followed",                          :default => true
     t.integer  "lock_version",                            :default => 0
   end
 

--- a/lib/ncs_navigator/core/warehouse/operational_importer.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer.rb
@@ -393,19 +393,11 @@ module NcsNavigator::Core::Warehouse
 
     def set_participant_being_followed
       if @followed_p_ids
-        set_participant_being_followed_by_ids(@followed_p_ids)
+        Participant.update_all(['being_followed = ?', false],
+                               ['p_id NOT IN (?)', @followed_p_ids])
       else
         set_participant_being_followed_using_heuristic
       end
-    end
-
-    def set_participant_being_followed_by_ids(p_ids)
-      ActiveRecord::Base.connection.
-        execute(<<-SQL)
-          UPDATE participants p
-          SET being_followed=true
-          WHERE p.p_id IN ('#{p_ids.join("', '")}')
-        SQL
     end
 
     def set_participant_being_followed_using_heuristic

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
+# Schema version: 20130408184301
 #
 # Table name: participants
 #
-#  being_followed            :boolean          default(FALSE)
+#  being_followed            :boolean          default(TRUE)
 #  being_processed           :boolean          default(FALSE)
 #  created_at                :datetime
 #  enroll_date               :date


### PR DESCRIPTION
This makes `being_followed` attribute on `Participant` true by default.  Only a minor adjustment in the `OperationalImporter` was needed to `set_participant_being_followed_by_ids` and no change to `set_participant_being_followed_using_heuristic` is necessary; the 'old' logic should still hold when trying to heuristically determine which participant is being followed.
