### PR TITLE
Fix postnatal prepopulators #3029

### DIFF
--- a/app/models/response_set_prepopulation.rb
+++ b/app/models/response_set_prepopulation.rb
@@ -22,6 +22,7 @@ module ResponseSetPrepopulation
     ParticipantVerification,
     PbsParticipantVerification,
     PbsEligibilityScreener,
+    Postnatal,
     PregnancyScreener,
     PregnancyVisit,
     TracingModule,


### PR DESCRIPTION
A tiny fix that makes `Postnatal` prepopulator available via `ResponseSetPrepopulation#populators_for`.  I started to changed the specs for all the prepopulators to use `ResponseSet#prepopulate` instead of `PrepopName.new(@response_set_pt).run` but I'm not sure if it's worth the effort?
