### PR TITLE
Adjudicating eligibility of person during Field sync

### DIFF
--- a/app/context/eligibility_adjudicator.rb
+++ b/app/context/eligibility_adjudicator.rb
@@ -1,52 +1,81 @@
-class EligibilityAdjudicator
-
-  def initialize(person)
-    @person = person
-    @participant = person.participant
+module EligibilityAdjudicator
+  def self.included(base)
+    base.extend(ClassMethods)
   end
 
-  def self.adjudicate_eligibility(person)
-    me = EligibilityAdjudicator.new(person)
-    me.make_ineligible if person.participant.try(:ineligible?)
-  end
-
-  def make_ineligible
-    ActiveRecord::Base.transaction do
-      creates_ineligibility_record(@person)
-      remove_ppg_details(@participant)
-      delete_participant_person_links(@participant)
-      disassociates_participant_from_all_events(@participant)
-      disassociates_participant_from_response_sets(@participant)
-      remove_participant(@participant)
+  module ClassMethods
+    # Elibilility can be adjudicated for one or more participants and then ineligible
+    # participants are disqualified from the study. See usage below:
+    # 
+    # Participant.adjudicate_eligibility_and_disqualify_ineligible(
+    # => participant1, participant2, participant3)
+    #
+    # @param [*Participant]
+    # @return [Hash] Participants grouped by eligibility. 
+    # => ex. {:eligible => [participant1, participant3], :ineligible => [participant2]}
+    def adjudicate_eligibility_and_disqualify_ineligible(*participants)
+      adjudicate_eligibility(*participants).tap do |adj|
+        disqualify(*adj[:ineligible])
+      end
     end
-  end
 
-  private
+    def adjudicate_eligibility(*participants)
+      ineligible, eligible = participants.partition{ |p| p.ineligible? }
+      {:ineligible => ineligible, :eligible => eligible}
+    end
 
-  def creates_ineligibility_record(person)
-    SampledPersonsIneligibility.create_from_person!(person)
-  end
+    # DANGER: Only use if you want to remove participant(s) from the study. See usage below:
+    # 
+    # Participant.disqualify(participant1, participant2, participant3)
+    def disqualify(*participants)
+      found = Participant.where(:id => participants).
+        includes(:events,
+          :ppg_status_histories,
+          :ppg_details,
+          :response_sets,
+          :low_intensity_state_transition_audits,
+          :high_intensity_state_transition_audits,
+          :participant_person_links => :person)
 
-  def remove_ppg_details(participant)
-    PpgStatusHistory.where(:participant_id => participant).destroy_all
-    PpgDetail.where(:participant_id => participant).destroy_all
-  end
+      ActiveRecord::Base.transaction do
+        found.each do |p|
+          creates_ineligibility_record(p.person)
+          remove_ppg_details(p)
+          delete_participant_person_links(p)
+          disassociates_participant_from_all_events(p)
+          disassociates_participant_from_response_sets(p)
+          remove_participant(p)
+        end
+      end
+    end
 
-  def delete_participant_person_links(participant)
-    ParticipantPersonLink.where(:participant_id => participant).destroy_all
-  end
+    private
 
-  def disassociates_participant_from_all_events(participant)
-    participant.events.update_all(:participant_id => nil)
-  end
+    def creates_ineligibility_record(person)
+      SampledPersonsIneligibility.create_from_person!(person)
+    end
 
-  def disassociates_participant_from_response_sets(participant)
-    ResponseSet.where(:participant_id => participant.id).each { |rs| rs.update_attribute(:participant_id, nil) }
-  end
+    def remove_ppg_details(participant)
+      participant.ppg_status_histories.destroy_all
+      participant.ppg_details.destroy_all
+    end
 
-  def remove_participant(participant)
-    participant.low_intensity_state_transition_audits.destroy_all
-    participant.high_intensity_state_transition_audits.destroy_all
-    participant.destroy
+    def delete_participant_person_links(participant)
+      participant.participant_person_links.destroy_all
+    end
+
+    def disassociates_participant_from_all_events(participant)
+      participant.events.update_all(:participant_id => nil)
+    end
+
+    def disassociates_participant_from_response_sets(participant)
+      participant.response_sets.each { |rs| rs.update_attribute(:participant_id, nil) }
+    end
+
+    def remove_participant(participant)
+      participant.low_intensity_state_transition_audits.destroy_all
+      participant.high_intensity_state_transition_audits.destroy_all
+      participant.destroy
+    end
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -57,7 +57,7 @@ class EventsController < ApplicationController
         elsif participant = @event.participant
           if participant.ineligible?
             if @event.screener_event? && person = @event.participant.try(:person)
-              EligibilityAdjudicator.adjudicate_eligibility(person)
+              person.adjudicate_eligibility
             end
           else
             resp = participant.advance(psc)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -56,8 +56,8 @@ class EventsController < ApplicationController
           # do not set participant
         elsif participant = @event.participant
           if participant.ineligible?
-            if @event.screener_event? && person = @event.participant.try(:person)
-              person.adjudicate_eligibility
+            if @event.screener_event?
+              Participant.adjudicate_eligibility_and_disqualify_ineligible(participant)
             end
           else
             resp = participant.advance(psc)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -58,6 +58,7 @@ class EventsController < ApplicationController
           if participant.ineligible?
             if @event.screener_event?
               Participant.adjudicate_eligibility_and_disqualify_ineligible(participant)
+              @event.reload
             end
           else
             resp = participant.advance(psc)

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -1,0 +1,14 @@
+module Field
+  module ProtocolEligibility
+
+    def determine_eligibility
+      psc = login_to_psc
+
+      current_participants.each(&:reload)
+
+      ineligible_participants, self.eligible_participants = current_participants.partition{ |p| p.ineligible? }
+      
+      ineligible_participants.map(&:person).compact.each(&:adjudicate_eligibility)
+    end
+  end
+end

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -1,6 +1,5 @@
 module Field
   module ProtocolEligibility
-
     def determine_eligibility
       psc = login_to_psc
 

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -5,13 +5,10 @@ module Field
       psc = login_to_psc
 
       current_participants.each(&:reload)
-
-      ps = Participant.where(:id => current_participants.map(&:id)).includes(:participant_person_links => :person)
-      ineligible, eligible = ps.partition(&:ineligible?)
       
-      ineligible.map(&:person).each(&:adjudicate_eligibility)
-
-      self.ineligible_participants = ineligible
+      adj = EligibilityAdjudicator.adjudicate_eligibility_and_disqualify_ineligible(current_participants)
+      
+      self.eligible_participants = adj[:eligible]
     end
   end
 end

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -6,9 +6,12 @@ module Field
 
       current_participants.each(&:reload)
 
-      ineligible_participants, self.eligible_participants = current_participants.partition{ |p| p.ineligible? }
+      ps = Participant.where(:id => current_participants.map(&:id)).includes(:participant_person_links => :person)
+      ineligible, eligible = ps.partition(&:ineligible?)
       
-      ineligible_participants.map(&:person).compact.each(&:adjudicate_eligibility)
+      ineligible.map(&:person).each(&:adjudicate_eligibility)
+
+      self.ineligible_participants = ineligible
     end
   end
 end

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -5,7 +5,7 @@ module Field
 
       current_participants.each(&:reload)
       
-      adj = EligibilityAdjudicator.adjudicate_eligibility_and_disqualify_ineligible(current_participants)
+      adj = Participant.adjudicate_eligibility_and_disqualify_ineligible(*current_participants)
       
       self.eligible_participants = adj[:eligible]
     end

--- a/app/models/field/protocol_eligibility.rb
+++ b/app/models/field/protocol_eligibility.rb
@@ -1,10 +1,21 @@
 module Field
+  ##
+  # Wrapper around Participant::adjudicate_participants_and_disqualify_ineligible, which
+  # determines the eligibility of participants and disqualifies ineligible participants.
+  #
+  # Expects its host object to respond to:
+  #
+  # * {#login_to_psc} with a {PatientStudyCalendar} instance
+  # * {#eligible_participants} with a list of {Participant} objects
   module ProtocolEligibility
     def determine_eligibility
       psc = login_to_psc
 
+      # Ensure we have up-to-date data; we're entering this method out of a
+      # lot of manipulations.
       current_participants.each(&:reload)
       
+      # Adjudicate
       adj = Participant.adjudicate_eligibility_and_disqualify_ineligible(*current_participants)
       
       self.eligible_participants = adj[:eligible]

--- a/app/models/field/scheduling.rb
+++ b/app/models/field/scheduling.rb
@@ -14,10 +14,10 @@ module Field
 
       # Ensure we have up-to-date data; we're entering this method out of a
       # lot of manipulations.
-      current_participants.each(&:reload)
+      eligible_participants.each(&:reload)
 
       # Advance.
-      current_participants.each { |p| p.advance(psc) }
+      eligible_participants.each { |p| p.advance(psc) }
     end
   end
 end

--- a/app/models/field/scheduling.rb
+++ b/app/models/field/scheduling.rb
@@ -5,7 +5,7 @@ module Field
   # Expects its host object to respond to:
   #
   # * {#login_to_psc} with a {PatientStudyCalendar} instance
-  # * {#current_participants} with a list of {Participant} objects
+  # * {#eligible_participants} with a list of {Participant} objects
   module Scheduling
     include PscSync
 

--- a/app/models/field/superposition.rb
+++ b/app/models/field/superposition.rb
@@ -81,6 +81,7 @@ module Field
     include Field::Merge
     include Field::PscSync
     include Field::Scheduling
+    include Field::ProtocolEligibility
 
     attr_accessor :contacts
     attr_accessor :events
@@ -90,6 +91,7 @@ module Field
     attr_accessor :question_response_sets
     attr_accessor :response_sets
     attr_accessor :responses
+    attr_accessor :eligible_participants
 
     ##
     # The staff ID of the user building the superposition.
@@ -110,7 +112,8 @@ module Field
       self.question_response_sets = {}
       self.response_sets = {}
       self.responses = {}
-
+      self.eligible_participants = []
+      
       self.logger = Rails.logger
     end
 

--- a/app/models/merge.rb
+++ b/app/models/merge.rb
@@ -169,6 +169,9 @@ class Merge < ActiveRecord::Base
             superposition.prepare_for_sync(self)
             superposition.sync_with_psc
 
+            # .. then determine eligibility
+            superposition.determine_eligibility
+
             # ...and schedule new events.
             superposition.advance_participant_schedules
             update_attribute(:synced_at, Time.now)

--- a/app/models/merge.rb
+++ b/app/models/merge.rb
@@ -164,7 +164,7 @@ class Merge < ActiveRecord::Base
             superposition.prepare_for_sync(self)
             superposition.sync_with_psc
 
-            # ...then determine eligibility
+            # then determine eligibility...
             superposition.determine_eligibility
 
             # ...and schedule new events.

--- a/app/models/merge.rb
+++ b/app/models/merge.rb
@@ -169,7 +169,7 @@ class Merge < ActiveRecord::Base
             superposition.prepare_for_sync(self)
             superposition.sync_with_psc
 
-            # .. then determine eligibility
+            # ...then determine eligibility
             superposition.determine_eligibility
 
             # ...and schedule new events.

--- a/app/models/merge.rb
+++ b/app/models/merge.rb
@@ -159,11 +159,6 @@ class Merge < ActiveRecord::Base
           self.conflict_report = superposition.conflicts
           save(:validate => false)
 
-          # TODO: cf. #3734
-          # check if the participant is eligible and/or
-          # send person to EligibilityAdjudicator
-          # Is this the correct place to do this?
-
           if self.class.sync_with_psc?
             # Sync current state...
             superposition.prepare_for_sync(self)

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -38,6 +38,7 @@
 # pregnancy screener, pregnancy questionnaire, etc. Once born, NCS-eligible babies are assigned Participant IDs.
 # Every Participant is also a Person. People do not become Participants until they are determined eligible for a pregnancy screener.
 class Participant < ActiveRecord::Base
+  include EligibilityAdjudicator
   class << self; attr_accessor :importer_mode_on; end
 
   include NcsNavigator::Core::Mdes::MdesRecord

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -475,10 +475,6 @@ class Person < ActiveRecord::Base
     1
   end
 
-  def adjudicate_eligibility
-    EligibilityAdjudicator.adjudicate_eligibility(self)
-  end
-
   private
 
     def dob

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -475,6 +475,10 @@ class Person < ActiveRecord::Base
     1
   end
 
+  def adjudicate_eligibility
+    EligibilityAdjudicator.adjudicate_eligibility(self)
+  end
+
   private
 
     def dob

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -141,6 +141,7 @@ describe EventsController do
             {'event_end_date' => '2001-01-01', 'event_end_time' => '12:00', 'event_repeat_key' => '99'}
           updated_event = Event.find(@event.id)
           updated_event.participant.should be_nil
+          response.should redirect_to(events_path)
         end
       end
 


### PR DESCRIPTION
This will mark a person as ineligible when during a Field sync and prevents scheduling further events.

I tested this works locally, but haven't written any automated tests because there's not currently an easy way to mock out the interaction with PSC. I can look into doing this, but I have a feeling it's not trivial.
