### PR TITLE
due_dates ignores empty string dates #3814

### DIFF
--- a/app/models/ppg_detail.rb
+++ b/app/models/ppg_detail.rb
@@ -58,7 +58,10 @@ class PpgDetail < ActiveRecord::Base
   # Return the most recently updated due date that is a valid date
   # @return [String]
   def due_date
-    [due_date_3, due_date_2, orig_due_date].compact.detect { |d| Date.valid_date?(*d.split('-').map(&:to_i)) }
+    [due_date_3,
+     due_date_2,
+     orig_due_date].reject(&:blank?)
+                   .detect { |d| Date.valid_date?(*d.split('-').map(&:to_i)) }
   end
 
   ##

--- a/spec/models/ppg_detail_spec.rb
+++ b/spec/models/ppg_detail_spec.rb
@@ -79,6 +79,12 @@ describe PpgDetail do
       ppg = Factory(:ppg_detail, :orig_due_date => '2012-02-09', :due_date_2 => '9666-96-96', :due_date_3 => '9666-96-96')
       ppg.due_date.should == '2012-02-09'
     end
+
+    it "ignores empty strings" do
+      ppg = Factory(:ppg_detail, :orig_due_date => '2012-02-09', :due_date_2 => '', :due_date_3 => '9666-96-96')
+      ppg.due_date.should == '2012-02-09'
+    end
+
   end
 
   it { should belong_to(:participant) }


### PR DESCRIPTION
### Summary

Removes empty string "dates" from consideration, as opposed to 
blowing up.
