### PR TITLE
Feature 3790 psc registration processor

### DIFF
--- a/lib/ncs_navigator/core.rb
+++ b/lib/ncs_navigator/core.rb
@@ -13,6 +13,7 @@ module NcsNavigator
     autoload :Mustache,                   'ncs_navigator/core/mustache'
     autoload :Pbs,                        'ncs_navigator/core/pbs'
     autoload :Psc,                        'ncs_navigator/core/psc'
+    autoload :PscRegistrationProcessor,   'ncs_navigator/core/psc_registration_processor'
     autoload :RecordOfContactImporter,    'ncs_navigator/core/record_of_contact_importer'
     autoload :RedisConfiguration,         'ncs_navigator/core/redis_configuration'
     autoload :SidekiqConfiguration,       'ncs_navigator/core/sidekiq_configuration'

--- a/lib/ncs_navigator/core/psc_registration_processor.rb
+++ b/lib/ncs_navigator/core/psc_registration_processor.rb
@@ -16,8 +16,8 @@ class NcsNavigator::Core::PscRegistrationProcessor
       process_participant(row[:p_id])
     end
 
-    wh_config.shell.say_line("Preparing records for PSC sync...")
-    NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(@psc, @wh_config, keygen).import
+    @wh_config.shell.say_line("Preparing records for PSC sync...")
+    NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(@psc, @wh_config, keygen).import('psc_registration')
   end
 
   def keygen
@@ -31,7 +31,7 @@ class NcsNavigator::Core::PscRegistrationProcessor
       @sync_loader.cache_participant(participant)
       participant.events.each do |e|
         @sync_loader.cache_event(e, e.participant)
-        event.contact_links.each do |cl|
+        e.contact_links.each do |cl|
           @sync_loader.cache_contact_link(cl, cl.contact, cl.event, cl.participant)
         end
       end

--- a/lib/ncs_navigator/core/psc_registration_processor.rb
+++ b/lib/ncs_navigator/core/psc_registration_processor.rb
@@ -1,35 +1,33 @@
 class NcsNavigator::Core::PscRegistrationProcessor
   def initialize(pid_io, psc, wh_config)
-    @pid_io = pid_io
+    @csv ||= Rails.application.csv_impl.read(pid_io, :headers => true, :header_converters => :symbol)
     @psc = psc
     @wh_config = wh_config
     @sync_loader = Psc::SyncLoader.new(keygen)
   end
 
-  def csv
-    @csv ||= Rails.application.csv_impl.read(@pid_io, :headers => true, :header_converters => :symbol)
-  end
-
   def register_to_psc
-    csv.each do |row|
-      next if row.header_row?
-      process_participant(row[:p_id])
-    end
-
     @wh_config.shell.say_line("Preparing records for PSC sync...")
+    p_ids = []
+    @csv.each do |row|
+      next if row.header_row?
+      p_ids << row[:p_id]
+    end
+    process_participants(p_ids)
     NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(@psc, @wh_config, keygen).import('psc_registration')
   end
 
   def keygen
     @keygen ||= lambda do |*c|
-      ['psc_registration', c].flatten.join(':')
+      ["psc_registration:#{Date.today}", c].flatten.join(":")
     end
   end
 
-  def process_participant(p_id)
-    if participant = find_participant(p_id)
-      @sync_loader.cache_participant(participant)
-      participant.events.each do |e|
+  def process_participants(p_ids)
+    participants = Participant.where(:p_id => p_ids)
+    participants.each do |p|
+      @sync_loader.cache_participant(p)
+      p.events.each do |e|
         @sync_loader.cache_event(e, e.participant)
         e.contact_links.each do |cl|
           @sync_loader.cache_contact_link(cl, cl.contact, cl.event, cl.participant)
@@ -37,14 +35,5 @@ class NcsNavigator::Core::PscRegistrationProcessor
       end
     end
   end
-  private :process_participant
-
-  def find_participant(p_id)
-    participant = Participant.where(:p_id => p_id).first
-    unless participant
-      return nil
-    end
-    participant
-  end
-  private :find_participant
+  private :process_participants
 end

--- a/lib/ncs_navigator/core/psc_registration_processor.rb
+++ b/lib/ncs_navigator/core/psc_registration_processor.rb
@@ -1,0 +1,50 @@
+class NcsNavigator::Core::PscRegistrationProcessor
+  def initialize(pid_io, psc, wh_config)
+    @pid_io = pid_io
+    @psc = psc
+    @wh_config = wh_config
+    @sync_loader = Psc::SyncLoader.new(keygen)
+  end
+
+  def csv
+    @csv ||= Rails.application.csv_impl.read(@pid_io, :headers => true, :header_converters => :symbol)
+  end
+
+  def register_to_psc
+    csv.each do |row|
+      next if row.header_row?
+      process_participant(row[:p_id])
+    end
+
+    wh_config.shell.say_line("Preparing records for PSC sync...")
+    NcsNavigator::Core::Warehouse::OperationalImporterPscSync.new(@psc, @wh_config, keygen).import
+  end
+
+  def keygen
+    @keygen ||= lambda do |*c|
+      ['psc_registration', c].flatten.join(':')
+    end
+  end
+
+  def process_participant(p_id)
+    if participant = find_participant(p_id)
+      @sync_loader.cache_participant(participant)
+      participant.events.each do |e|
+        @sync_loader.cache_event(e, e.participant)
+        event.contact_links.each do |cl|
+          @sync_loader.cache_contact_link(cl, cl.contact, cl.event, cl.participant)
+        end
+      end
+    end
+  end
+  private :process_participant
+
+  def find_participant(p_id)
+    participant = Participant.where(:p_id => p_id).first
+    unless participant
+      return nil
+    end
+    participant
+  end
+  private :find_participant
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -237,6 +237,22 @@ namespace :import do
     end
   end
 
+  desc 'Register Participants to the PSC'
+  task :register_to_psc, [:participant_csv] => [:psc_setup, :warehouse_setup, :environment, :set_whodunnit] do |t, args|
+    fail 'Please specify the path to the participant csv' unless args[:participant_csv]
+
+    require 'ncs_navigator/core'
+    options = {}
+    options[:psc] = psc
+    options[:wh_config] = import_wh_config
+
+    processor = NcsNavigator::Core::PscRegistrationProcessor.new(
+      File.open(args[:participant_csv]),
+      options
+    )
+    processor.register_to_psc
+  end
+
   desc 'Looks for participants with "extra" events'
   task :find_extra_events => :environment do
     Participant.includes(:events).each do |p|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -242,13 +242,10 @@ namespace :import do
     fail 'Please specify the path to the participant csv' unless args[:participant_csv]
 
     require 'ncs_navigator/core'
-    options = {}
-    options[:psc] = psc
-    options[:wh_config] = import_wh_config
-
     processor = NcsNavigator::Core::PscRegistrationProcessor.new(
       File.open(args[:participant_csv]),
-      options
+      psc,
+      import_wh_config
     )
     processor.register_to_psc
   end


### PR DESCRIPTION
Add psc registration module which will take list of participant ids and will sync with PSC. This will be useful when import didn't register some participants for some reason.( e.g participant had all events with retired event type or particular segment is not available in PSC template)
