### PR TITLE
A class and task that clones a case (#3826)

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -38,9 +38,8 @@
 # pregnancy screener, pregnancy questionnaire, etc. Once born, NCS-eligible babies are assigned Participant IDs.
 # Every Participant is also a Person. People do not become Participants until they are determined eligible for a pregnancy screener.
 class Participant < ActiveRecord::Base
-  class << self; attr_accessor :importer_mode_on; end
-
   include NcsNavigator::Core::Mdes::MdesRecord
+  include NcsNavigator::Core::ImportAware
 
   acts_as_mdes_record :public_id_field => :p_id,
     :public_id_generator => NcsNavigator::Core::Mdes::HumanReadablePublicIdGenerator.new
@@ -101,10 +100,6 @@ class Participant < ActiveRecord::Base
   delegate :age, :first_name, :last_name, :person_dob, :gender, :upcoming_events, :contact_links, :instruments, :start_instrument, :started_survey, :instrument_for, :to => :person
 
   after_create :set_initial_state_for_recruitment_strategy
-
-  def after_initialize
-    self.class.importer_mode_on = false;
-  end
 
   ##
   # Only Hi/Lo strategy uses the low_intensity_state machine.
@@ -979,13 +974,13 @@ class Participant < ActiveRecord::Base
   ##
   # Change the Participant status from Pregnant to Other Probability after having given birth
   def update_ppg_status_after_birth
-    post_transition_ppg_status_update(4) unless self.class.importer_mode_on
+    post_transition_ppg_status_update(4) unless in_importer_mode?
   end
 
   ##
   # Change the Participant status to PPG 3 after child loss
   def update_ppg_status_after_child_loss
-    post_transition_ppg_status_update(3) unless self.class.importer_mode_on
+    post_transition_ppg_status_update(3) unless in_importer_mode?
   end
 
   def last_contact
@@ -1211,12 +1206,6 @@ class Participant < ActiveRecord::Base
     else
       fail "Unhandled event type for participant state #{event.event_type.local_code.inspect}"
     end
-  end
-
-  def self.importer_mode
-    self.importer_mode_on = true
-    yield
-    self.importer_mode_on = false
   end
 
   comma do

--- a/app/models/ppg_detail.rb
+++ b/app/models/ppg_detail.rb
@@ -33,6 +33,7 @@
 # PPG Details record.
 # There is a one-to-many relationship between Participant and PPG Details.
 class PpgDetail < ActiveRecord::Base
+  include NcsNavigator::Core::ImportAware
   include NcsNavigator::Core::Mdes::MdesRecord
   acts_as_mdes_record :public_id_field => :ppg_details_id
 
@@ -42,7 +43,8 @@ class PpgDetail < ActiveRecord::Base
   ncs_coded_attribute :ppg_pid_status, 'PARTICIPANT_STATUS_CL1'
   ncs_coded_attribute :ppg_first,      'PPG_STATUS_CL2'
 
-  after_create :create_associated_ppg_status_history
+  after_create :create_associated_ppg_status_history,
+    :unless => lambda { self.in_importer_mode? }
 
   ##
   # When creating a new record, this attribute may be used to specify
@@ -73,12 +75,6 @@ class PpgDetail < ActiveRecord::Base
     else
       self.update_attribute(attribute, due_date)
     end
-  end
-
-  def self.importer_mode
-    PpgDetail.skip_callback(:create, :after, :create_associated_ppg_status_history)
-    yield
-    PpgDetail.set_callback(:create, :after, :create_associated_ppg_status_history)
   end
 
   private

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -24,6 +24,7 @@ class ResponseSet < ActiveRecord::Base
   include NcsNavigator::Core::Surveyor::HasPublicId
   include ResponseSetPrepopulation
   include Surveyor::Models::ResponseSetMethods
+  include NcsNavigator::Core::ImportAware
 
   belongs_to :person, :foreign_key => :user_id, :class_name => 'Person', :primary_key => :id
   belongs_to :participant, :inverse_of => :response_sets
@@ -33,7 +34,7 @@ class ResponseSet < ActiveRecord::Base
   belongs_to :participant_consent, :inverse_of => :response_set
   belongs_to :non_interview_report, :inverse_of => :response_set
 
-  after_save :extract_operational_data
+  after_save :extract_operational_data, :unless => lambda { self.in_importer_mode? }
 
   attr_accessible :participant_id
 

--- a/lib/ncs_navigator/core.rb
+++ b/lib/ncs_navigator/core.rb
@@ -4,6 +4,7 @@ module NcsNavigator
   module Core
     autoload :VERSION,                  'ncs_navigator/core/version'
 
+    autoload :CaseCloner,                 'ncs_navigator/core/case_cloner'
     autoload :Configuration,              'ncs_navigator/core/configuration'
     autoload :Field,                      'ncs_navigator/core/field'
     autoload :FollowedParticipantChecker, 'ncs_navigator/core/followed_participant_checker'

--- a/lib/ncs_navigator/core.rb
+++ b/lib/ncs_navigator/core.rb
@@ -9,6 +9,7 @@ module NcsNavigator
     autoload :Field,                      'ncs_navigator/core/field'
     autoload :FollowedParticipantChecker, 'ncs_navigator/core/followed_participant_checker'
     autoload :HasPublicId,                'ncs_navigator/core/has_public_id'
+    autoload :ImportAware,                'ncs_navigator/core/import_aware'
     autoload :Mdes,                       'ncs_navigator/core/mdes'
     autoload :MdesInstrumentSurvey,       'ncs_navigator/core/mdes_instrument_survey'
     autoload :Mustache,                   'ncs_navigator/core/mustache'

--- a/lib/ncs_navigator/core/case_cloner.rb
+++ b/lib/ncs_navigator/core/case_cloner.rb
@@ -87,12 +87,12 @@ module NcsNavigator::Core
     end
 
     def find_source_participants
-      participant_ids = ActiveRecord::Base.connection.select_all(<<-SQL).collect(&:values).flatten.uniq
-        SELECT other.participant_id
+      participant_ids = Participant.find_by_sql([<<-SQL, @root_p_id]).collect(&:id)
+        SELECT DISTINCT other.participant_id AS id
         FROM participants root
           INNER JOIN participant_person_links root_persons ON root.id = root_persons.participant_id
           INNER JOIN participant_person_links other ON root_persons.person_id = other.person_id
-        WHERE root.p_id = '#{@root_p_id}'
+        WHERE root.p_id = ?
       SQL
 
       Participant.where(:id => participant_ids).includes(INCLUDES).all

--- a/lib/ncs_navigator/core/case_cloner.rb
+++ b/lib/ncs_navigator/core/case_cloner.rb
@@ -21,6 +21,8 @@ module NcsNavigator::Core
       Instrument
       ResponseSet
       Response
+      DwellingUnit
+      DwellingHouseholdLink
       HouseholdUnit
       HouseholdPersonLink
       PersonProviderLink
@@ -31,6 +33,18 @@ module NcsNavigator::Core
       PpgDetail
       PpgStatusHistory
       SampledPersonsIneligibility
+      Sample
+      SpecimenReceiptConfirmation
+      Specimen
+      ShipSpecimen
+      SpecimenPickup
+      NonInterviewReport
+      DwellingUnitTypeNonInterviewReport
+      NoAccessNonInterviewReport
+      RefusalNonInterviewReport
+      VacantNonInterviewReport
+      LegacyInstrumentDataRecord
+      LegacyInstrumentDataValue
     )
 
     UNIVERSAL_NON_COPIED_ATTRIBUTES = %w(id updated_at created_at lock_version access_code)

--- a/lib/ncs_navigator/core/case_cloner.rb
+++ b/lib/ncs_navigator/core/case_cloner.rb
@@ -1,0 +1,203 @@
+require 'ncs_navigator/core'
+
+module NcsNavigator::Core
+  class CaseCloner
+    ##
+    # The cloner works by walking record associations recursively, starting
+    # from Participant. For each association it encounters, it will clone
+    # and recurse over the record on the other end IFF its type is in this list.
+    MODELS_TO_CLONE = %w(
+      Participant
+      ParticipantLowIntensityStateTransition
+      ParticipantHighIntensityStateTransition
+      ParticipantPersonLink
+      ParticipantConsent
+      ParticipantConsentSample
+      Person
+      PersonRace
+      ContactLink
+      Contact
+      Event
+      Instrument
+      ResponseSet
+      Response
+      HouseholdUnit
+      HouseholdPersonLink
+      PersonProviderLink
+      InstitutionPersonLink
+      Telephone
+      Address
+      Email
+      PpgDetail
+      PpgStatusHistory
+      SampledPersonsIneligibility
+    )
+
+    UNIVERSAL_NON_COPIED_ATTRIBUTES = %w(id updated_at created_at lock_version access_code)
+
+    INCLUDES = {
+      :participant_person_links => {
+        :person => {
+          :addresses => [],
+          :emails => [],
+          :telephones => [],
+          :contact_links => { :event => [], :contact => [], :instrument => { :response_sets => [:responses] }},
+          :races => [],
+          :household_person_links => :household_unit,
+          :participant_person_links => :participant,
+          :institution_person_links => [],
+          :person_provider_links => [],
+          :sampled_persons_ineligibilities => []
+        }
+      },
+      :ppg_details => [],
+      :ppg_status_histories => [],
+      :low_intensity_state_transition_audits => [],
+      :high_intensity_state_transition_audits => [],
+      :participant_consents => [:participant_consent_samples],
+      :participant_consent_samples => [],
+      :events => { :contact_links => { :contact => [], :instrument => { :response_sets => :responses } } },
+      :response_sets => [:responses]
+    }
+
+    def initialize(p_id)
+      @root_p_id = p_id or fail "Please specify a p_id"
+    end
+
+    ##
+    # @return [Array<Participant>] the specified participant to clone, plus
+    #   all participants related to it (via ParticipantPersonLinks) one level
+    #   deep.
+    def source_participants
+      @source_participants ||= find_source_participants
+    end
+
+    def find_source_participants
+      participant_ids = ActiveRecord::Base.connection.select_all(<<-SQL).collect(&:values).flatten.uniq
+        SELECT other.participant_id
+        FROM participants root
+          INNER JOIN participant_person_links root_persons ON root.id = root_persons.participant_id
+          INNER JOIN participant_person_links other ON root_persons.person_id = other.person_id
+        WHERE root.p_id = '#{@root_p_id}'
+      SQL
+
+      Participant.where(:id => participant_ids).includes(INCLUDES).all
+    end
+    private :find_source_participants
+
+    ##
+    # Clone just the records in Cases for the given participant
+    #
+    # @return [Hash<Participant, Participant>] a mapping from each source
+    #   participant to its corresponding clone.
+    def clone_cases_side
+      Participant.transaction do
+        source_participants.each_with_object({}) { |p, result| result[p] = clone_record(p) }
+      end
+    end
+
+    private
+
+    def cloned_record_cache
+      @cloned_records ||= {}
+    end
+
+    def record_key(record)
+      [record.class.name, '#', record.id].join
+    end
+
+    def clone_record(record, log_depth=0)
+      return unless record
+      unless MODELS_TO_CLONE.include?(record.class.name)
+        log_at log_depth, "#{record.class} is not a model to be cloned; using source value"
+        return record
+      end
+
+      key = record_key(record)
+      log_at log_depth, "Cloning #{key}"
+      if cloned_record_cache[key]
+        cloned_record_cache[key].tap do |clone|
+          msg =
+            if clone.persisted?
+              "* returning already-created clone #{record_key(clone)}"
+            else
+              "* returning in-progress clone"
+            end
+
+          log_at log_depth, msg
+        end
+      else
+        clone = record.class.new
+        # pre-cache the new record to avoid circular recursion
+        cloned_record_cache[key] = clone
+
+        copy_scalar_values(record, clone, log_depth)
+        clone_single_value_association(:belongs_to, record, clone, log_depth)
+
+        log_at log_depth, "- saving new #{clone.class}"
+        clone.save!
+
+        clone_has_many(record, clone, log_depth)
+        clone_single_value_association(:has_one, record, clone, log_depth)
+
+        log_at log_depth, "+ created new clone #{record_key(clone)}"
+        clone
+      end
+    end
+
+    def copy_scalar_values(record, clone, log_depth)
+      skips = UNIVERSAL_NON_COPIED_ATTRIBUTES +
+        record.class.reflect_on_all_associations(:belongs_to).collect(&:primary_key_name) +
+        [public_id_field_or_nil(record)].compact
+      scalar_attributes = record.attributes.reject { |name, value| skips.include?(name) || value.nil? }
+      log_at log_depth, "- copying scalar attribute#{'s' unless scalar_attributes.keys.size == 1} #{scalar_attributes.keys.inspect}"
+      scalar_attributes.each do |name, value|
+        clone.send("#{name}=", value)
+      end
+    end
+
+    def public_id_field_or_nil(record)
+      if record.class.respond_to?(:public_id_field)
+        record.class.public_id_field.to_s
+      end
+    end
+
+    def clone_has_many(record, clone, log_depth)
+      associations = record.class.reflect_on_all_associations(:has_many).
+        # no point in traversing :through associations; they'll be handled the long way
+        reject { |assoc| assoc.options[:through] }.
+        # don't change versions in clone
+        reject { |assoc| assoc.name == :versions }.
+        each do |assoc|
+        log_at log_depth, "- recursing for has_many #{assoc.name.inspect}"
+
+        source_collection = record.send(assoc.name)
+        clone.send(assoc.name).tap do |clone_assoc_proxy|
+          source_collection.each do |source_value|
+            clone_assoc_proxy << clone_record(source_value, log_depth + 1)
+          end
+        end
+
+        log_at log_depth, "- done with #{assoc.name.inspect}"
+      end
+    end
+
+    def clone_single_value_association(macro, record, clone, log_depth)
+      associations = record.class.reflect_on_all_associations(macro).
+        # exclude Surveyor's weird, invented "User" association
+        reject { |assoc| assoc.active_record == ResponseSet && assoc.name == :user }
+      associations.each do |assoc|
+        log_at log_depth, "- recursing for #{assoc.macro} #{assoc.name.inspect}"
+
+        source_value = record.send(assoc.name)
+        clone.send("#{assoc.name}=", clone_record(source_value, log_depth + 1))
+
+        log_at log_depth, "- done with #{assoc.name.inspect}"
+      end
+    end
+
+    def log_at(log_depth, message)
+      Rails.logger.debug ['    ' * log_depth, message].join
+    end
+  end
+end

--- a/lib/ncs_navigator/core/import_aware.rb
+++ b/lib/ncs_navigator/core/import_aware.rb
@@ -1,0 +1,29 @@
+require 'ncs_navigator/core'
+require 'active_support/concern'
+
+module NcsNavigator::Core
+  module ImportAware
+    extend ActiveSupport::Concern
+
+    def in_importer_mode?
+      self.class.in_importer_mode?
+    end
+
+    module ClassMethods
+      attr_accessor :importer_mode_on
+
+      ##
+      # Sets the importer mode to true for the duration of the provided block.
+      def importer_mode
+        fail "This method is intended for use with a block" unless block_given?
+        original = importer_mode_on
+        self.importer_mode_on = true
+        result = yield
+        self.importer_mode_on = original
+        result
+      end
+
+      alias :in_importer_mode? :importer_mode_on
+    end
+  end
+end

--- a/lib/ncs_navigator/core/import_aware.rb
+++ b/lib/ncs_navigator/core/import_aware.rb
@@ -17,10 +17,12 @@ module NcsNavigator::Core
       def importer_mode
         fail "This method is intended for use with a block" unless block_given?
         original = importer_mode_on
-        self.importer_mode_on = true
-        result = yield
-        self.importer_mode_on = original
-        result
+        begin
+          self.importer_mode_on = true
+          yield
+        ensure
+          self.importer_mode_on = original
+        end
       end
 
       alias :in_importer_mode? :importer_mode_on

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -32,4 +32,26 @@ namespace :setup do
       puts 'All surveys are syntactically valid ruby.'
     end
   end
+
+  task :set_whodunnit do
+    PaperTrail.whodunnit = ['rake', ARGV].flatten.join(' ')
+  end
+
+  desc 'Clones a single case'
+  task :clone_case, [:p_id, :n] => ['import:psc_setup', :environment, :set_whodunnit] do |t, args|
+    psc_user = task('import:psc_setup').user
+    p_id = args[:p_id] or fail "Please specify a p_id: rake #{t.name}[12-1234]"
+    n = args[:n].try(:to_i) || 1
+    digits = (Math.log(n, 10) + 1).to_i
+
+    1.upto(n) do |i|
+      $stderr.print "(%#{digits}d/%d) Cloning #{p_id} and any related participants..." % [i, n]
+      result = NcsNavigator::Core::CaseCloner.new(p_id).clone(psc_user)
+      $stderr.puts "done."
+
+      result.each do |source, clone|
+        $stderr.puts "  #{source.p_id} cloned as #{clone.p_id}"
+      end
+    end
+  end
 end

--- a/spec/factories/participant.rb
+++ b/spec/factories/participant.rb
@@ -30,6 +30,15 @@ FactoryGirl.define do
       low_intensity_state     "moved_to_high_intensity_arm"
     end
 
+    trait :with_self do
+      after_create do |p, _|
+        # Participant#person= can only be used after both the person and
+        # participant have been persisted.
+        p.person = FactoryGirl.create(:person)
+        p.save! # but it also doesn't automatically persist the link
+      end
+    end
+
     ## Pregnancy Probability Groups
 
     trait :in_ppg1 do

--- a/spec/lib/ncs_navigator/core/case_cloner_spec.rb
+++ b/spec/lib/ncs_navigator/core/case_cloner_spec.rb
@@ -141,10 +141,16 @@ module NcsNavigator::Core
       end
 
       describe 'for related data' do
-        let!(:threem_contact) { Factory(:contact) }
         let!(:threem_event) { Factory(:event, :participant => mother, :event_type_code => 23) }
-        let!(:threem_contact_link) {
-          Factory(:contact_link, :person => mother.person, :event => threem_event, :instrument => threem_interview)
+
+        let!(:threem_contact_1) { Factory(:contact) }
+        let!(:threem_contact_link_1) {
+          Factory(:contact_link, :contact => threem_contact_1, :person => mother.person, :event => threem_event, :instrument => threem_interview)
+        }
+
+        let!(:threem_contact_2) { Factory(:contact) }
+        let!(:threem_contact_link_2) {
+          Factory(:contact_link, :contact => threem_contact_2, :person => mother.person, :event => threem_event, :instrument => threem_interview)
         }
 
         let!(:threem_interview) { Factory(:instrument) }
@@ -192,6 +198,13 @@ module NcsNavigator::Core
           )
         }
 
+        let!(:child1_consent_event) { Factory(:event, :event_type_code => 10, :participant => child1) }
+        let!(:mother_consent_event) { Factory(:event, :event_type_code => 10, :participant => mother) }
+
+        let!(:child1_consent_cl) { Factory(:contact_link, :event => child1_consent_event, :contact => consent_contact) }
+        let!(:mother_consent_cl) { Factory(:contact_link, :event => mother_consent_event, :contact => consent_contact) }
+        let!(:child1_consent_during_threem) { Factory(:contact_link, :event => child1_consent_event, :contact => threem_contact_1) }
+
         let!(:consent_contact) {
           Factory(:contact)
         }
@@ -236,15 +249,15 @@ module NcsNavigator::Core
           'person.addresses.first',
           'person.emails.first',
           'person.telephones.first',
-          'person.contact_links.first',
-          'person.contact_links.first.event',
-          'person.contact_links.first.contact',
-          'person.contact_links.first.instrument',
-          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first",
-          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Child'}.first",
-          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
-          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
-          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.person",
+          'person.contact_links.order(:contact_id).first',
+          'person.contact_links.order(:contact_id).first.event',
+          'person.contact_links.order(:contact_id).first.contact',
+          'person.contact_links.order(:contact_id).first.instrument',
+          "person.contact_links.order(:contact_id).first.instrument.#{response_sets_for_survey '3M Mother'}.first",
+          "person.contact_links.order(:contact_id).first.instrument.#{response_sets_for_survey '3M Child'}.first",
+          "person.contact_links.order(:contact_id).first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
+          "person.contact_links.order(:contact_id).first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
+          "person.contact_links.order(:contact_id).first.instrument.#{response_sets_for_survey '3M Mother'}.first.person",
           'person.races.first',
           'person.household_person_links.first',
           'person.household_person_links.first.household_unit',
@@ -260,12 +273,12 @@ module NcsNavigator::Core
           'participant_consents.first.participant_consent_samples.first',
           'participant_consent_samples.first',
           'events.last',
-          'events.where(:event_type_code => 23).first.contact_links.last',
-          'events.where(:event_type_code => 23).first.contact_links.last.contact',
-          'events.where(:event_type_code => 23).first.contact_links.last.instrument',
-          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first",
-          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
-          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
+          'events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last',
+          'events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last.contact',
+          'events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last.instrument',
+          "events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last.instrument.#{response_sets_for_survey '3M Mother'}.first",
+          "events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
+          "events.where(:event_type_code => 23).first.contact_links.order(:contact_id).last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
           'response_sets.first',
           'response_sets.first.responses.first'
         ].each do |exp|

--- a/spec/lib/ncs_navigator/core/case_cloner_spec.rb
+++ b/spec/lib/ncs_navigator/core/case_cloner_spec.rb
@@ -1,0 +1,307 @@
+require 'spec_helper'
+
+module NcsNavigator::Core
+  describe CaseCloner do
+    let(:cloner) { CaseCloner.new(mother.p_id) }
+
+    let!(:earlier_person) { Factory(:person) }
+
+    let!(:mother) { FactoryGirl.create(:participant, :with_self, :p_type_code => 3) }
+    let!(:child1) { FactoryGirl.create(:participant, :with_self, :p_type_code => 6) }
+    let!(:child2) { FactoryGirl.create(:participant, :with_self, :p_type_code => 6) }
+
+    def link_mother_child(mother, child)
+      Factory(:participant_person_link,
+        :participant => mother, :person => child.person, :relationship_code => 8)
+      Factory(:participant_person_link,
+        :participant => child, :person => mother.person, :relationship_code => 2)
+    end
+
+    before do
+      link_mother_child(mother, child1)
+      link_mother_child(mother, child2)
+    end
+
+    describe '#source_participants' do
+      let(:actual) { cloner.source_participants }
+
+      it 'includes the referenced participant' do
+        actual.should include(mother)
+      end
+
+      it 'includes all associated children' do
+        actual.should include(child1)
+        actual.should include(child2)
+      end
+
+      it 'includes each participant exactly once' do
+        actual.size.should == 3
+      end
+    end
+
+    describe '#clone_cases_side' do
+      let(:clone_result) { cloner.clone_cases_side }
+      let(:mother_clone) { clone_result[mother] }
+
+      it 'returns a mapping from the source participants to the cloned participants' do
+        clone_result.should respond_to(:[])
+        clone_result.keys.map(&:class).uniq.should == [Participant]
+        clone_result.values.map(&:class).uniq.should == [Participant]
+      end
+
+      it 'persists the cloned records' do
+        clone_result.each { |_, result| Participant.where(:id => result.id).count.should == 1 }
+      end
+
+      shared_examples 'clone verification' do
+        it 'has a different internal ID in the clone' do
+          in_clone.id.should_not == in_source.id
+        end
+
+        it 'has an internal ID in the clone' do
+          in_clone.id.should_not be_nil
+        end
+
+        it 'is the same type in the clone' do
+          in_clone.class.should == in_source.class
+        end
+
+        it 'has a different public ID in the clone (if applicable)' do
+          pending "no public ID for #{in_source.class}" unless in_source.respond_to?(:public_id)
+
+          in_clone.public_id.should_not == in_source.public_id
+        end
+
+        it 'has some public ID in the clone (if applicable)' do
+          pending "no public ID for #{in_source.class}" unless in_source.respond_to?(:public_id)
+
+          in_clone.public_id.should_not be_nil
+        end
+
+        it 'has a different access code in the clone (if applicable)' do
+          pending "no access_code for #{in_source.class}" unless in_source.respond_to?(:access_code)
+
+          in_clone.access_code.should_not == in_source.access_code
+        end
+
+        it 'has a some access code in the clone (if applicable)' do
+          pending "no access_code for #{in_source.class}" unless in_source.respond_to?(:access_code)
+
+          in_clone.access_code.should_not be_nil
+        end
+
+        def some_attribute(instance)
+          instance.attributes.
+            select { |name, value| value && [/id\z/, /\A(created|updated)_at\z/, /access_code/, /lock_version/].none? { |re| re =~ name } }.
+            sort_by { |name, _| name =~ /_code\z/ ? 1 : 0 }.
+            first or pending "No scalar attributes for #{instance.class}"
+        end
+
+        it 'copies scalar attributes to the clone' do
+          attribute, source_value = some_attribute(in_source)
+          source_value.should == in_clone.send(attribute)
+        end
+
+        it 'does not copy created_at to the clone' do
+          in_source # prompt to create
+          sleep 1
+          in_clone.created_at.should_not == in_source.created_at
+        end
+
+        it 'does not copy updated_at to the clone' do
+          in_source # prompt to create
+          sleep 1
+          in_clone.updated_at.should_not == in_source.updated_at
+        end
+
+        it 'does not copy versions to the clone' do
+          in_clone.versions.should == []
+        end
+      end
+
+      describe 'for mother participant' do
+        let(:in_source) { mother }
+        let(:in_clone) { mother_clone }
+
+        include_examples 'clone verification'
+      end
+
+      describe 'for child1 participant' do
+        let(:in_source) { child1 }
+        let(:in_clone) { clone_result[child1] }
+
+        include_examples 'clone verification'
+      end
+
+      describe 'for child1 participant' do
+        let(:in_source) { child2 }
+        let(:in_clone) { clone_result[child2] }
+
+        include_examples 'clone verification'
+      end
+
+      describe 'for related data' do
+        let!(:threem_contact) { Factory(:contact) }
+        let!(:threem_event) { Factory(:event, :participant => mother, :event_type_code => 23) }
+        let!(:threem_contact_link) {
+          Factory(:contact_link, :person => mother.person, :event => threem_event, :instrument => threem_interview)
+        }
+
+        let!(:threem_interview) { Factory(:instrument) }
+
+        let!(:threem_survey_mother) {
+          load_survey_string(<<-SURV)
+            survey '3M Mother' do
+              section '1' do
+                q_alpha 'How are things?'
+                a_1 'Okay'
+                a_2 'Fine'
+              end
+            end
+          SURV
+        }
+
+        let!(:threem_survey_child) {
+          load_survey_string(<<-SURV)
+            survey '3M Child' do
+              section '1' do
+                q_beta 'And how is the baby?'
+                a_1 'Cute'
+                a_2 'Not cute'
+              end
+            end
+          SURV
+        }
+
+        let!(:threem_mother_rs) {
+          Factory(:response_set,
+            :instrument => threem_interview, :survey => threem_survey_mother,
+            :participant => mother, :person => mother.person
+          )
+        }
+        let!(:threem_child1_rs)  {
+          Factory(:response_set,
+            :instrument => threem_interview, :survey => threem_survey_child,
+            :participant => child1, :person => mother.person
+          )
+        }
+        let!(:threem_child2_rs)  {
+          Factory(:response_set,
+            :instrument => threem_interview, :survey => threem_survey_child,
+            :participant => child2, :person => mother.person
+          )
+        }
+
+        let!(:consent_contact) {
+          Factory(:contact)
+        }
+
+        let!(:consent) {
+          Factory(:participant_consent, :participant => mother,
+            :consent_form_type_code => 1, :contact => consent_contact)
+        }
+
+        let!(:sample_consent) {
+          Factory(:participant_consent_sample, :participant => mother, :participant_consent => consent)
+        }
+
+        before do
+          Factory(:address, :person => mother.person)
+          Factory(:email, :person => mother.person)
+          Factory(:telephone, :person => mother.person)
+          Factory(:person_race, :person => mother.person)
+          Factory(:household_person_link, :person => mother.person)
+          Factory(:institution_person_link, :person => mother.person)
+          Factory(:person_provider_link, :person => mother.person)
+          Factory(:sampled_persons_ineligibility, :person => mother.person)
+          Factory(:ppg_detail, :participant => mother)
+          Factory(:ppg_status_history, :participant => mother)
+
+          mother_q = threem_survey_mother.questions.first
+          threem_mother_rs.responses.create!(:question => mother_q, :answer => mother_q.answers.first, :unit => 'cm')
+          child_q = threem_survey_child.questions.first
+          threem_child1_rs.responses.create!(:question => child_q, :answer => child_q.answers.first, :unit => 'cm')
+          threem_child2_rs.responses.create!(:question => child_q, :answer => child_q.answers.last, :unit => 'cm')
+        end
+
+        def self.response_sets_for_survey(survey_title)
+          "response_sets.joins(:survey).where('surveys.title = ?', #{survey_title.inspect})"
+        end
+
+        [
+          'self_link',
+          'participant_person_links.where("relationship_code != 1").first',
+          'participant_person_links.where("relationship_code != 1").first.person',
+          'person',
+          'person.addresses.first',
+          'person.emails.first',
+          'person.telephones.first',
+          'person.contact_links.first',
+          'person.contact_links.first.event',
+          'person.contact_links.first.contact',
+          'person.contact_links.first.instrument',
+          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first",
+          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Child'}.first",
+          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
+          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
+          "person.contact_links.first.instrument.#{response_sets_for_survey '3M Mother'}.first.person",
+          'person.races.first',
+          'person.household_person_links.first',
+          'person.household_person_links.first.household_unit',
+          'person.participant_person_links.where("relationship_code != 1").first.participant',
+          'person.participant_person_links.where("relationship_code =  1").first.participant',
+          'person.institution_person_links.first',
+          'person.person_provider_links.first',
+          'person.sampled_persons_ineligibilities.first',
+          'ppg_details.first',
+          'ppg_status_histories.last',
+          'participant_consents.first',
+          'participant_consents.first.contact',
+          'participant_consents.first.participant_consent_samples.first',
+          'participant_consent_samples.first',
+          'events.last',
+          'events.where(:event_type_code => 23).first.contact_links.last',
+          'events.where(:event_type_code => 23).first.contact_links.last.contact',
+          'events.where(:event_type_code => 23).first.contact_links.last.instrument',
+          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first",
+          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.first",
+          "events.where(:event_type_code => 23).first.contact_links.last.instrument.#{response_sets_for_survey '3M Mother'}.first.responses.last",
+          'response_sets.first',
+          'response_sets.first.responses.first'
+        ].each do |exp|
+          describe exp do
+            let(:in_source) { mother.instance_eval(exp) }
+            let(:in_clone)  { mother_clone.instance_eval(exp) }
+
+            include_examples 'clone verification'
+          end
+        end
+
+        %w(
+          person.institution_person_links.first.institution
+          person.person_provider_links.first.provider
+          response_sets.first.survey
+          response_sets.first.responses.first.question
+          response_sets.first.responses.first.answer
+        ).each do |exp|
+          describe exp do
+            let(:in_source) { mother.instance_eval(exp) }
+            let(:in_clone)  { mother_clone.instance_eval(exp) }
+
+            it 'is the same object' do
+              in_clone.id.should == in_source.id
+            end
+          end
+        end
+
+        it 'reuses the same cloned object when there are multiple referencing paths' do
+          participant_rs = mother_clone.response_sets.where(:survey_id => threem_survey_mother).first
+          instrument_rs = mother_clone.events.where(:event_type_code => 23).first.
+            contact_links.first.instrument.response_sets.where(:survey_id => threem_survey_mother).first
+
+          participant_rs.id.should == instrument_rs.id
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/ncs_navigator/core/import_aware_spec.rb
+++ b/spec/lib/ncs_navigator/core/import_aware_spec.rb
@@ -20,6 +20,16 @@ module NcsNavigator::Core
             host_class.importer_mode_on.should == outer_mode
           end
 
+          it 'preserves the original mode after an exception' do
+            begin
+              host_class.importer_mode do
+                fail 'Refused'
+              end
+            rescue; end
+
+            host_class.importer_mode_on.should == outer_mode
+          end
+
           it 'sets the mode to true for the duration of the block' do
             host_class.importer_mode do
               host_class.should be_in_importer_mode

--- a/spec/lib/ncs_navigator/core/import_aware_spec.rb
+++ b/spec/lib/ncs_navigator/core/import_aware_spec.rb
@@ -10,7 +10,7 @@ module NcsNavigator::Core
 
     describe '.importer_mode' do
       [nil, true, false].each do |outer_mode|
-        describe "when the starting mode is #{outer_mode}" do
+        describe "when the starting mode is #{outer_mode.inspect}" do
           before do
             host_class.importer_mode_on = outer_mode
           end
@@ -35,7 +35,7 @@ module NcsNavigator::Core
 
     describe '#in_importer_mode?' do
       [nil, true, false].each do |mode|
-        describe "when the mode is #{mode}" do
+        describe "when the mode is #{mode.inspect}" do
           before do
             host_class.importer_mode_on = mode
           end

--- a/spec/lib/ncs_navigator/core/import_aware_spec.rb
+++ b/spec/lib/ncs_navigator/core/import_aware_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module NcsNavigator::Core
+  describe ImportAware do
+    let(:host_class) {
+      Class.new do
+        include ImportAware
+      end
+    }
+
+    describe '.importer_mode' do
+      [nil, true, false].each do |outer_mode|
+        describe "when the starting mode is #{outer_mode}" do
+          before do
+            host_class.importer_mode_on = outer_mode
+          end
+
+          it 'preserves the original mode after the block' do
+            host_class.importer_mode { }
+            host_class.importer_mode_on.should == outer_mode
+          end
+
+          it 'sets the mode to true for the duration of the block' do
+            host_class.importer_mode do
+              host_class.should be_in_importer_mode
+            end
+          end
+
+          it 'returns the return value of the block' do
+            host_class.importer_mode { 'foo' }.should == 'foo'
+          end
+        end
+      end
+    end
+
+    describe '#in_importer_mode?' do
+      [nil, true, false].each do |mode|
+        describe "when the mode is #{mode}" do
+          before do
+            host_class.importer_mode_on = mode
+          end
+
+          it 'reflects the class-level setting' do
+            host_class.new.in_importer_mode?.should == mode
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -22,7 +22,6 @@ require 'spec_helper'
 require File.expand_path('../../shared/models/a_publicly_identified_record', __FILE__)
 
 describe ResponseSet do
-
   it { should belong_to(:person) }
   it { should belong_to(:instrument) }
   it { should belong_to(:participant) }
@@ -310,4 +309,27 @@ describe ResponseSet do
 
   end
 
+  describe 'operational data extraction' do
+    # RMS20130415: I'm adding a spec for the existing behavior.
+    # Not an endorsement of using callbacks for complex logic.
+    it 'happens on save when complete' do
+      rs = FactoryGirl.build(:response_set, :completed_at => Date.new(2012, 1, 8))
+      OperationalDataExtractor::Base.should_receive(:process).with(rs)
+      rs.save!
+    end
+
+    it 'does not happen on save when not complete' do
+      rs = FactoryGirl.build(:response_set, :completed_at => nil)
+      OperationalDataExtractor::Base.should_not_receive(:process)
+      rs.save!
+    end
+
+    it 'does not happen when complete but in importer mode' do
+      ResponseSet.importer_mode do
+        rs = FactoryGirl.build(:response_set, :completed_at => Date.new(2012, 1, 8))
+        OperationalDataExtractor::Base.should_not_receive(:process).with(rs)
+        rs.save!
+      end
+    end
+  end
 end


### PR DESCRIPTION
Provides `setup:clone_case`, a rake task which produces one or more clones of a participant and all its related persons, participants, and other case-specific records. It also syncs any primary participants to PSC. This task is intended for use in setting up training or QA data.

This branch also includes a fix for [Cases-3848](https://code.bioinformatics.northwestern.edu/issues/issues/show/3848) because it involves a refactoring of `Participant` to share its "importer mode" code with `ResponseSet`.
