### PR TITLE
Change 3810 - Allow imported events with invalid disposition / category combinations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130226172617
+# Schema version: 20130415192041
 #
 # Table name: events
 #
@@ -21,6 +21,7 @@
 #  event_type_code                    :integer          not null
 #  event_type_other                   :string(255)
 #  id                                 :integer          not null, primary key
+#  imported_invalid                   :boolean          default(FALSE), not null
 #  lock_version                       :integer          default(0)
 #  participant_id                     :integer
 #  psc_ideal_date                     :date
@@ -58,7 +59,7 @@ class Event < ActiveRecord::Base
   validates_format_of :event_start_time, :with => mdes_time_pattern, :allow_blank => true
   validates_format_of :event_end_time,   :with => mdes_time_pattern, :allow_blank => true
 
-  validate :disposition_code_is_in_disposition_category
+  validate :disposition_code_is_in_disposition_category, :unless => :imported_invalid
 
   before_validation :strip_time_whitespace
   before_create :set_start_time

--- a/db/migrate/20130415192041_add_imported_invalid_to_events.rb
+++ b/db/migrate/20130415192041_add_imported_invalid_to_events.rb
@@ -1,0 +1,5 @@
+class AddImportedInvalidToEvents < ActiveRecord::Migration
+  def change
+  	add_column :events, :imported_invalid, :boolean, :null => false, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130403145616) do
+ActiveRecord::Schema.define(:version => 20130415192041) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false
@@ -248,20 +248,20 @@ ActiveRecord::Schema.define(:version => 20130403145616) do
   add_index "event_type_order", ["event_type_code"], :name => "index_event_type_order_on_event_type_code", :unique => true
 
   create_table "events", :force => true do |t|
-    t.integer  "psu_code",                                                                                       :null => false
-    t.string   "event_id",                           :limit => 36,                                               :null => false
+    t.integer  "psu_code",                                                                                           :null => false
+    t.string   "event_id",                           :limit => 36,                                                   :null => false
     t.integer  "participant_id"
-    t.integer  "event_type_code",                                                                                :null => false
+    t.integer  "event_type_code",                                                                                    :null => false
     t.string   "event_type_other"
     t.integer  "event_repeat_key"
     t.integer  "event_disposition"
-    t.integer  "event_disposition_category_code",                                                                :null => false
+    t.integer  "event_disposition_category_code",                                                                    :null => false
     t.date     "event_start_date"
     t.string   "event_start_time"
     t.date     "event_end_date"
     t.string   "event_end_time"
-    t.integer  "event_breakoff_code",                                                                            :null => false
-    t.integer  "event_incentive_type_code",                                                                      :null => false
+    t.integer  "event_breakoff_code",                                                                                :null => false
+    t.integer  "event_incentive_type_code",                                                                          :null => false
     t.decimal  "event_incentive_cash",                             :precision => 12, :scale => 2
     t.string   "event_incentive_noncash"
     t.text     "event_comment"
@@ -271,6 +271,7 @@ ActiveRecord::Schema.define(:version => 20130403145616) do
     t.string   "scheduled_study_segment_identifier"
     t.integer  "lock_version",                                                                    :default => 0
     t.date     "psc_ideal_date"
+    t.boolean  "imported_invalid",                                                                :default => false, :null => false
   end
 
   create_table "fieldworks", :force => true do |t|

--- a/lib/ncs_navigator/core/warehouse/operational_importer.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer.rb
@@ -519,6 +519,9 @@ module NcsNavigator::Core::Warehouse
     def save_core_record(core_record)
       ident = "#{core_record.class}##{core_record.id}##{core_record.public_id}"
       if core_record.new_record?
+        if core_record.has_attribute?("imported_invalid")
+          core_record.imported_invalid = true unless core_record.valid?
+        end
         log.debug("Creating #{ident}: #{core_record.inspect}.")
         @progress.increment_creates
       elsif core_record.changed?

--- a/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
@@ -141,7 +141,7 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
@@ -141,7 +141,7 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -141,7 +141,7 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -175,7 +175,7 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -174,7 +174,7 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -175,7 +175,7 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         :event_incentive_noncash => :event_incent_noncash
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version)
+        psc_ideal_date lock_version imported_invalid)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/spec/lib/ncs_navigator/core/warehouse/operational_importer_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/operational_importer_spec.rb
@@ -937,6 +937,23 @@ module NcsNavigator::Core::Warehouse
                 Event.find_by_event_id('g_e1').event_disposition.should == 45
               end
             end
+
+            describe 'with invalid category/code combination' do
+              let!(:g_e2) {
+                create_warehouse_record_with_defaults(wh_config.model(:Event),
+                  :event_id => 'g_e2',
+                  :participant => ginger_p,
+                  :event_disp => 560,
+                  :event_disp_cat => '4',
+                  :event_type => code_for_event_type('Pregnancy Screener'),
+                  :event_start_date => '2010-11-07')
+              }
+
+              it 'imports and saves event record' do
+                do_import
+                Event.find_by_event_id('g_e2').event_disposition.should == 60
+              end
+            end
           end
         end
       end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130226172617
+# Schema version: 20130415192041
 #
 # Table name: events
 #
@@ -21,6 +21,7 @@
 #  event_type_code                    :integer          not null
 #  event_type_other                   :string(255)
 #  id                                 :integer          not null, primary key
+#  imported_invalid                   :boolean          default(FALSE), not null
 #  lock_version                       :integer          default(0)
 #  participant_id                     :integer
 #  psc_ideal_date                     :date
@@ -976,6 +977,11 @@ describe Event do
         invalid.save!
       end.to raise_error(ActiveRecord::RecordInvalid,
         "Validation failed: Event disposition does not exist in the disposition category.")
+    end
+
+    it "skips the validation for invalid event_disposition combination if imported_invalid is set to 'true'" do
+      invalid.imported_invalid = true
+      invalid.should be_valid
     end
 
   end


### PR DESCRIPTION
This commit adds imported_invalid to event models. Skip the validation if imported_invalid is set to true. Importing the events, if event is not valid due to invalid combination of disposition category set the imported_invalid flag to true.
