### PR TITLE
Bug: 3870 & 2154. Add/Update checks for enumerating events records. Drop the event checks from contact link and instrument records.

### DIFF
--- a/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
@@ -131,8 +131,9 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
@@ -147,9 +147,6 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -221,10 +218,7 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
@@ -131,8 +131,9 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
@@ -147,9 +147,6 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -224,10 +221,7 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -147,9 +147,6 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -221,10 +218,7 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -131,8 +131,9 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -181,9 +181,6 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -207,10 +204,7 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -165,8 +165,9 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -164,8 +164,9 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -180,9 +180,6 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -206,10 +203,7 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -181,9 +181,6 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
 
     produce_one_for_one(:instruments, :Instrument,
       :public_ids => %w(events),
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      },
       :column_map => {
         :instrument_start_date => :ins_date_start,
         :instrument_start_time => :ins_start_time,
@@ -207,10 +204,7 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         :events,
         :contacts,
         :instruments
-      ],
-      :where => %q{
-        EXISTS(SELECT 'x' FROM events e WHERE e.id=t.event_id AND e.event_disposition IS NOT NULL)
-      }
+      ]
     )
 
     produce_one_for_one(:addresses, :Address,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -165,8 +165,9 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
             END) normalized_event_disposition}
       ],
       :where => %q{
-        t.event_disposition IS NOT NULL AND
-        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id)
+        t.event_disposition IS NOT NULL OR
+        EXISTS(SELECT 'x' FROM contact_links cl WHERE cl.event_id=t.id) OR
+        EXISTS(SELECT 'x' FROM instruments ins WHERE ins.event_id=t.id)
       },
       :column_map => {
         :normalized_event_disposition => :event_disp,

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
@@ -540,18 +540,12 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -736,7 +730,7 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -762,12 +756,6 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
@@ -582,14 +582,6 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -604,16 +596,74 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
@@ -540,18 +540,12 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -736,7 +730,7 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -762,12 +756,6 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
@@ -582,14 +582,6 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -604,16 +596,74 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
@@ -540,18 +540,12 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -736,7 +730,7 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -762,12 +756,6 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
@@ -582,14 +582,6 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -604,16 +596,74 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
@@ -538,18 +538,12 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -734,7 +728,7 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -760,12 +754,6 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
@@ -580,14 +580,6 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -602,16 +594,74 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
@@ -538,18 +538,12 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -734,7 +728,7 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -760,12 +754,6 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
@@ -580,14 +580,6 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -602,16 +594,74 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
@@ -538,18 +538,12 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
       let(:warehouse_model) { wh_config.model(:Instrument) }
       let(:core_model) { Instrument }
 
-      let!(:instrument) { Factory(:instrument, :event => Factory(:mdes_min_event)) }
+      let!(:instrument) { Factory(:instrument) }
 
       include_examples 'one to one'
 
       it 'uses the public ID for event' do
         results.first.event_id.should == Event.first.event_id
-      end
-
-      it 'emits nothing when the associated event has no disposition' do
-        Event.first.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
 
       describe 'with manually mapped variables' do
@@ -734,7 +728,7 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
       let(:warehouse_model) { wh_config.model(:LinkContact) }
       let(:core_model) { ContactLink }
 
-      let!(:contact_link) { Factory(:contact_link, :event => Factory(:mdes_min_event)) }
+      let!(:contact_link) { Factory(:contact_link) }
 
       include_examples 'one to one'
 
@@ -760,12 +754,6 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
 
       it 'uses the public ID for provider' do
         results.first.provider_id.should == Provider.first.provider_id
-      end
-
-      it 'emits nothing if the associated event has no disposition' do
-        contact_link.event.tap { |e| e.event_disposition = nil }.save!
-
-        results.should == []
       end
     end
 

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
@@ -580,14 +580,6 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
 
       include_examples 'one to one'
 
-      before do
-        # This rigamarole is because you apparently can't stop
-        # FactoryGirl from initializing associations, even if you
-        # provide an override.
-        ContactLink.create!(
-          :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
-      end
-
       describe 'with manually mapped variables' do
         include_context 'mapping test'
 
@@ -602,16 +594,74 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         results.first.participant_id.should == Participant.first.p_id
       end
 
-      it 'emits nothing when there are no associated contact links' do
-        ContactLink.destroy_all
-        results.should == []
+      describe 'with no disposition' do
+        before do
+          event.event_disposition = nil
+          event.save!
+        end
+
+        it 'emits event when there is associated contact link' do
+          # This rigamarole is because you apparently can't stop
+          # FactoryGirl from initializing associations, even if you
+          # provide an override.
+          ContactLink.create!(
+            :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+          results.size.should == 1
+        end
+
+        it 'emits event when there is associated instrument' do
+          Factory(:instrument, :event => event)
+          results.size.should == 1
+        end
+
+        it 'emits nothing when there is no associated contact link and no associated instrument' do
+          results.should == []
+        end
       end
 
-      it 'emits nothing when there is no disposition' do
-        event.event_disposition = nil
-        event.save!
+      describe 'with no associated contact link' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
 
-        results.should == []
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated instrument' do
+            Factory(:instrument, :event => event)
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated instrument' do
+            results.should == []
+          end
+        end
+      end
+
+      describe 'with no associated instrument' do
+        it 'emits event when there is disposition' do
+          results.size.should == 1
+        end
+
+        describe 'and with no disposition' do
+          before do
+            event.event_disposition = nil
+            event.save!
+          end
+
+          it 'emits event when there is associated contact link' do
+            ContactLink.create!(
+              :psu_code => 20000030, :event => event, :contact => Factory(:contact), :staff_id => 'dc')
+            results.size.should == 1
+          end
+
+          it 'emits nothing when there is no associated contact link' do
+            results.should == []
+          end
+        end
       end
 
       describe '#event_disp' do


### PR DESCRIPTION
This commit includes adding/updating to existing checks for events records. Now all the events who have disposition or have reference in the contact links or instruments records will be enumerate. It also removes the event checks with disposition when enumerating contact links or instruments.

Since both bug fixes tide together, apply in same branch. 
