### PR TITLE
3880 contacts on wrong events

### DIFF
--- a/app/helpers/contact_links_helper.rb
+++ b/app/helpers/contact_links_helper.rb
@@ -20,11 +20,12 @@ module ContactLinksHelper
   end
 
   def show_continue_action(person, contact_link, event, participant)
-    person && contact_link && continuable?(event) && participant.in_study?
+    person && contact_link && continuable?(event, contact_link.contact) && participant.in_study?
   end
 
-  def continuable?(event)
-    event.continuable?
+  def continuable?(event, contact)
+    can_continue = event.consent_event? ? event.standalone_consent_event?(contact) : !event.closed?
+    event.continuable? && can_continue
   end
 
   ##

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -437,6 +437,27 @@ class Event < ActiveRecord::Base
   end
 
   ##
+  # True if this is a consent event and a standalone event
+  # @see Event#consent_event?
+  # @see Event#standalone_event?
+  # @param[Contact]
+  # @return[Boolean]
+  def standalone_consent_event?(contact)
+    consent_event? && stand_alone_event?(contact)
+  end
+
+  ##
+  # A stand-alone Event is an event
+  # that is not associated with another event during same contact
+  # @param[Contact]
+  # @return[Boolean]
+  def stand_alone_event?(contact)
+    ContactLink.select("distinct event_id").where("contact_id in (?)",
+      ContactLink.select(:contact_id).where(:event_id => self.id).all.map(&:contact_id)
+    ).count == 1
+  end
+
+  ##
   # Returns true for all post-natal events (includes Birth)
   # @return [Boolean]
   def postnatal?
@@ -673,10 +694,12 @@ class Event < ActiveRecord::Base
      responded = SurveySection.scoped.joins('INNER JOIN response_sets ON response_sets.survey_id = survey_sections.survey_id
                                                    INNER JOIN responses ON responses.response_set_id = response_sets.id
                                                    INNER JOIN questions ON responses.question_id = questions.id
-                                                   AND questions.survey_section_id = survey_sections.id').select('survey_sections.id').merge(target).uniq
+                                                   AND questions.survey_section_id = survey_sections.id')
+                              .select("survey_sections.id, survey_sections.display_order")
+                              .merge(target).uniq
 
      referenced = SurveySection.scoped.joins(:questions, :survey => :response_sets)
-                              .select('survey_sections.id')
+                              .select("survey_sections.id, survey_sections.display_order")
                               .merge(target).where("questions.display_type IS NULL OR questions.display_type != 'label'").uniq
 
     self.event_breakoff_code = (referenced - responded).empty? ? NcsCode::NO : NcsCode::YES
@@ -904,7 +927,10 @@ class Event < ActiveRecord::Base
     self.participant.events.where(:event_type_code => self.event_type_code).count - 1
   end
 
+  ##
+  #
   def set_suggested_event_breakoff(contact_link)
+    return if closed? || event_breakoff_code.to_i > 0
     if contact_link.instrument && contact_link.instrument.response_sets.exists?
       set_event_breakoff(contact_link.instrument.response_sets)
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -240,19 +240,19 @@ class Event < ActiveRecord::Base
   }
 
   def self.method_missing(method_name, *args)
-    method_name = method_name.to_s
-    if method_name =~ /_code/
-      return NAMED_EVENT_CODES[method_name.sub("_code", "")]
+    m = method_name.to_s
+    if m =~ /_code/
+      return NAMED_EVENT_CODES[m.sub("_code", "")]
     end
 
     super
   end
 
   def method_missing(method_name, *args)
-    method_name = method_name.to_s
-    if method_name =~ /\?/
-      super unless NAMED_EVENT_CODES[method_name.sub("\?", "")]
-      return NAMED_EVENT_CODES[method_name.sub("\?", "")] == self.event_type_code
+    m = method_name.to_s
+    if m =~ /\?/
+      super unless NAMED_EVENT_CODES[m.sub("\?", "")]
+      return NAMED_EVENT_CODES[m.sub("\?", "")] == self.event_type_code
     end
 
     super

--- a/app/views/contact_links/decision_page.html.haml
+++ b/app/views/contact_links/decision_page.html.haml
@@ -1,7 +1,7 @@
 - page_title "Event Activities"
 
 %h3
-  = @person
+  = link_to @person.to_s, person_path(@person), :class => "header_link"
 
 .page_section
   %h3

--- a/app/views/contacts/edit.html.haml
+++ b/app/views/contacts/edit.html.haml
@@ -1,7 +1,7 @@
 - page_title "Edit Contact"
 
 %h3
-  = @person
+  = link_to @person.to_s, person_path(@person), :class => "header_link"
   = "::"
   = @event.event_type.display_text
 

--- a/spec/helpers/contact_links_helper_spec.rb
+++ b/spec/helpers/contact_links_helper_spec.rb
@@ -62,5 +62,27 @@ describe ContactLinksHelper do
       end
     end
 
+    context "with an Informed Consent event" do
+      let(:et) { NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', Event.informed_consent_code) }
+
+      before do
+        participant.stub!(:in_study? => true)
+      end
+
+      it "is true" do
+        helper.show_continue_action(person, contact_link, event, participant).should be_true
+      end
+
+      context "associated with another event during the same contact" do
+        it "is false" do
+          other_event = Factory(:event)
+          other_contact_link = Factory(:contact_link, :event => other_event, :contact => contact)
+          helper.show_continue_action(person, contact_link, event, participant).should be_false
+        end
+
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
A stop gap measure to limit users associating contacts with the wrong events.
