### PR TITLE
Task 3628: 2.2 to 3.1 migration

### DIFF
--- a/app/models/specimen_receipt.rb
+++ b/app/models/specimen_receipt.rb
@@ -33,25 +33,26 @@
 class SpecimenReceipt < ActiveRecord::Base
   include NcsNavigator::Core::Mdes::MdesRecord
   acts_as_mdes_record :public_id_field => :specimen_id
-  
+
   belongs_to :specimen_processing_shipping_center
   belongs_to :specimen_equipment
   belongs_to :specimen
-  
+
   belongs_to :specimen_storage_container
-  
+
   ncs_coded_attribute :psu,                   'PSU_CL1'
-  ncs_coded_attribute :receipt_comment,       'SPECIMEN_STATUS_CL3'
+  ncs_coded_attribute :receipt_comment,
+    :list_name => { 'SPECIMEN_STATUS_CL3' => '<= 3.0', 'SPECIMEN_STATUS_CL10' => '>= 3.1' }
   ncs_coded_attribute :monitor_status,        'TRIGGER_STATUS_CL1'
   ncs_coded_attribute :upper_trigger,         'TRIGGER_STATUS_CL1'
   ncs_coded_attribute :upper_trigger_level,   'TRIGGER_STATUS_CL2'
   ncs_coded_attribute :lower_trigger_cold,    'TRIGGER_STATUS_CL1'
   ncs_coded_attribute :lower_trigger_ambient, 'TRIGGER_STATUS_CL1'
   ncs_coded_attribute :centrifuge_comment,    'SPECIMEN_STATUS_CL4'
-  
+
   validates_presence_of :staff_id
   validates_presence_of :specimen_processing_shipping_center_id
   # validates_presence_of :specimen_storage_container_id
-  validates_presence_of :receipt_datetime  
+  validates_presence_of :receipt_datetime
 end
 

--- a/lib/ncs_navigator/core/mdes/version_migrations.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations.rb
@@ -3,7 +3,8 @@ require 'ncs_navigator/core'
 module NcsNavigator::Core::Mdes
   module VersionMigrations
     autoload :Basic,               'ncs_navigator/core/mdes/version_migrations/basic'
-    autoload :ThreeZeroToThreeTwo, 'ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two'
     autoload :TwoZeroToTwoOne,     'ncs_navigator/core/mdes/version_migrations/two_zero_to_two_one'
+    autoload :TwoTwoToThreeOne,    'ncs_navigator/core/mdes/version_migrations/two_two_to_three_one'
+    autoload :ThreeZeroToThreeTwo, 'ncs_navigator/core/mdes/version_migrations/three_zero_to_three_two'
   end
 end

--- a/lib/ncs_navigator/core/mdes/version_migrations/two_two_to_three_one.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrations/two_two_to_three_one.rb
@@ -1,0 +1,9 @@
+require 'ncs_navigator/core'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  class TwoTwoToThreeOne < Basic
+    def initialize(options={})
+      super('2.2', '3.1', options)
+    end
+  end
+end

--- a/lib/ncs_navigator/core/mdes/version_migrator.rb
+++ b/lib/ncs_navigator/core/mdes/version_migrator.rb
@@ -20,8 +20,9 @@ module NcsNavigator::Core::Mdes
     # @return [Array<#run,#to#from>]
     def self.default_migrations(options={})
       [
-        VersionMigrations::ThreeZeroToThreeTwo.new(options),
         VersionMigrations::TwoZeroToTwoOne.new(options)
+        VersionMigrations::TwoTwoToThreeOne.new(options)
+        VersionMigrations::ThreeZeroToThreeTwo.new(options),
       ]
     end
 

--- a/spec/lib/ncs_navigator/core/mdes/version_migrations/two_two_to_three_one_spec.rb
+++ b/spec/lib/ncs_navigator/core/mdes/version_migrations/two_two_to_three_one_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module NcsNavigator::Core::Mdes::VersionMigrations
+  # clean_with_truncation because CodeListLoader#load_from_pg_dump hangs
+  # when there's an open transaction that's touched ncs_codes.
+  describe TwoTwoToThreeOne, :clean_with_truncation do
+    include SurveyCompletion
+
+    let(:migration) {
+      TwoTwoToThreeOne.new
+    }
+
+    it 'goes from 2.2' do
+      migration.from.should == '2.2'
+    end
+
+    it 'goes to 3.1' do
+      migration.to.should == '3.1'
+    end
+
+  end
+end


### PR DESCRIPTION
Simple migration.  There are many additions to the MDES schema but few changes as explained in the ticket.
