### PR TITLE
display highest ranked contact type per MDES#3973

### DIFF
--- a/lib/ncs_navigator/core/version.rb
+++ b/lib/ncs_navigator/core/version.rb
@@ -2,6 +2,6 @@
 
 module NcsNavigator
   module Core
-    VERSION='1.5.3'
+    VERSION='1.5.4'
   end
 end


### PR DESCRIPTION
This modifies the case status report to display the address and
telephone with the highest ranked contact type per the ordering given
in MDES

The changes are minimal for now until the requirements are more
clear. Currently:
- a contact type will only be shown if one exists with a primary rank.
- if multiple contacts exist with the highest ranked type they will
  both be shown
- adding colums to display the contact type was proposed but cannot be
  tested without further modification
