### PR TITLE
Change 3977 - Add multi_birth_id to the participant_person_links model and included in the appropriate enumerator.

### DIFF
--- a/app/models/participant_person_link.rb
+++ b/app/models/participant_person_link.rb
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130306200153
+# Schema version: 20130502152819
 #
 # Table name: participant_person_links
 #
 #  created_at                  :datetime
 #  id                          :integer          not null, primary key
 #  is_active_code              :integer          not null
+#  multi_birth_id              :string(36)
 #  participant_id              :integer          not null
 #  person_id                   :integer          not null
 #  person_pid_id               :string(36)       not null

--- a/db/migrate/20130502152819_add_multi_birth_id_to_participant_person_link.rb
+++ b/db/migrate/20130502152819_add_multi_birth_id_to_participant_person_link.rb
@@ -1,0 +1,5 @@
+class AddMultiBirthIdToParticipantPersonLink < ActiveRecord::Migration
+  def change
+  	add_column :participant_person_links, :multi_birth_id, :string, :limit => 36, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130415192041) do
+ActiveRecord::Schema.define(:version => 20130502152819) do
 
   create_table "addresses", :force => true do |t|
     t.integer  "psu_code",                                                :null => false
@@ -675,6 +675,7 @@ ActiveRecord::Schema.define(:version => 20130415192041) do
     t.datetime "updated_at"
     t.integer  "response_set_id"
     t.integer  "primary_caregiver_flag_code",               :default => -4, :null => false
+    t.string   "multi_birth_id",              :limit => 36
   end
 
   create_table "participant_staff_relationships", :force => true do |t|

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -93,7 +93,7 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         :relationship_code => :relation,
         :relationship_other => :relation_oth,
       },
-      :ignored_columns => %w(response_set_id primary_caregiver_flag_code)
+      :ignored_columns => %w(response_set_id primary_caregiver_flag_code multi_birth_id)
     )
 
     produce_one_for_one(:ppg_details, :PpgDetails,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -91,7 +91,7 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         :relationship_code => :relation,
         :relationship_other => :relation_oth,
       },
-      :ignored_columns => %w(response_set_id primary_caregiver_flag_code)
+      :ignored_columns => %w(response_set_id primary_caregiver_flag_code multi_birth_id)
     )
 
     produce_one_for_one(:ppg_details, :PpgDetails,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -91,7 +91,7 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         :relationship_code => :relation,
         :relationship_other => :relation_oth,
       },
-      :ignored_columns => %w(response_set_id primary_caregiver_flag_code)
+      :ignored_columns => %w(response_set_id primary_caregiver_flag_code multi_birth_id)
     )
 
     produce_one_for_one(:ppg_details, :PpgDetails,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -91,7 +91,7 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         :relationship_code => :relation,
         :relationship_other => :relation_oth,
       },
-      :ignored_columns => %w(response_set_id primary_caregiver_flag_code)
+      :ignored_columns => %w(response_set_id primary_caregiver_flag_code multi_birth_id)
     )
 
     produce_one_for_one(:ppg_details, :PpgDetails,

--- a/spec/models/participant_person_link_spec.rb
+++ b/spec/models/participant_person_link_spec.rb
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # == Schema Information
-# Schema version: 20130306200153
+# Schema version: 20130502152819
 #
 # Table name: participant_person_links
 #
 #  created_at                  :datetime
 #  id                          :integer          not null, primary key
 #  is_active_code              :integer          not null
+#  multi_birth_id              :string(36)
 #  participant_id              :integer          not null
 #  person_id                   :integer          not null
 #  person_pid_id               :string(36)       not null


### PR DESCRIPTION
Add migration script to add multi_birth_id to the participant_person_link model. Add multi_birth_id to the enumerator for mdes 3.1 and 3.2. 
