### PR TITLE
Use participant consents exclusively to determine when an imported participant switches to hi intensity (#3997)

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1149,7 +1149,7 @@ class Participant < ActiveRecord::Base
   # so it simply will set the state to the most probable given the
   # event type and the current state
   # @param [Event]
-  def set_state_for_event_type(event)
+  def set_state_for_imported_event(event)
     register! if can_register?  # assume known to PSC
 
     case event.event_type.local_code

--- a/app/models/participant_consent.rb
+++ b/app/models/participant_consent.rb
@@ -83,6 +83,14 @@ class ParticipantConsent < ActiveRecord::Base
   CHILD_CONSENT_6_MONTHS_TO_AGE_OF_MAJORITY = 5
   NEW_ADULT_CONSENT = 6
 
+  HIGH_INTENSITY_CONSENT_TYPES = [GENERAL]
+
+  HIGH_INTENSITY_CONSENT_FORM_TYPES = [
+    PREGNANT_WOMAN_CONSENT,
+    NON_PREGNANT_WOMAN_CONSENT,
+    NEW_ADULT_CONSENT
+  ]
+
   def self.consent_types
     NcsNavigatorCore.mdes.types.find { |t| t.name == 'consent_type_cl1' }.
       code_list.collect { |cl| [cl.value, cl.label.to_s.strip] }
@@ -193,6 +201,11 @@ class ParticipantConsent < ActiveRecord::Base
 
   def phase_two?
     !phase_one?
+  end
+
+  def high_intensity?
+    HIGH_INTENSITY_CONSENT_TYPES.include?(consent_type_code) ||
+      HIGH_INTENSITY_CONSENT_FORM_TYPES.include?(consent_form_type_code)
   end
 
   def description

--- a/lib/ncs_navigator/core/record_of_contact_importer.rb
+++ b/lib/ncs_navigator/core/record_of_contact_importer.rb
@@ -62,7 +62,7 @@ class NcsNavigator::Core::RecordOfContactImporter
 
       if !@last_event || event.id != @last_event.id
         # n.b.: implicit assumption is that events are in order
-        participant.set_state_for_event_type(event)
+        participant.set_state_for_imported_event(event)
         @last_event = event
       end
 

--- a/lib/ncs_navigator/core/warehouse/operational_importer.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer.rb
@@ -125,7 +125,7 @@ module NcsNavigator::Core::Warehouse
             events_and_links.each do |event_and_links|
               core_event = apply_mdes_record_to_core(Event, event_and_links[:event])
 
-              participant.set_state_for_event_type(core_event)
+              participant.set_state_for_imported_event(core_event)
 
               @sync_loader.cache_event(core_event, participant) if for_psc
 

--- a/spec/models/participant_consent_spec.rb
+++ b/spec/models/participant_consent_spec.rb
@@ -229,6 +229,26 @@ describe ParticipantConsent do
     end
   end
 
+  describe '#high_intensity?' do
+    it 'is true when the consent is for a phase one high consent' do
+      ParticipantConsent.new(:consent_type_code => 1).should be_high_intensity
+    end
+
+    it 'is not true for phase one low intensity consents' do
+      ParticipantConsent.new(:consent_type_code => 7).should_not be_high_intensity
+    end
+
+    [1, 2, 6].each do |cft|
+      it "is true when the consent is for a phase two high consent form type #{cft}" do
+        ParticipantConsent.new(:consent_form_type_code => cft).should be_high_intensity
+      end
+    end
+
+    it "is not true when the consent is for a phase two low consent form type" do
+      ParticipantConsent.new(:consent_form_type_code => 7).should_not be_high_intensity
+    end
+  end
+
   context "phase 1 versus phase 2 consents" do
 
     describe ".phase_one?" do

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -2212,7 +2212,7 @@ describe Participant do
     end
   end
 
-  describe '#set_state_for_event_type' do
+  describe '#set_state_for_imported_event' do
     describe 'for informed consent' do
       let(:participant) { Factory(:participant) }
 
@@ -2237,23 +2237,23 @@ describe Participant do
         participant.participant_consents = [a_consent]
       end
 
-      shared_context 'set_state_for_event_type leaving hi' do
+      shared_context 'set_state_for_imported_event leaving hi' do
         it 'leaves the participant on hi' do
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_high_intensity
         end
       end
 
-      shared_context 'set_state_for_event_type leaving lo' do
+      shared_context 'set_state_for_imported_event leaving lo' do
         it 'leaves the participant on lo' do
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should_not be_high_intensity
         end
       end
 
-      shared_context 'set_state_for_event_type converting hi' do
+      shared_context 'set_state_for_imported_event converting hi' do
         it 'converts the participant to hi' do
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_high_intensity
         end
       end
@@ -2266,32 +2266,32 @@ describe Participant do
         describe 'and the event has no consents' do
           let(:consent_date) { out_of_event_date }
 
-          include_context 'set_state_for_event_type leaving hi'
+          include_context 'set_state_for_imported_event leaving hi'
         end
 
         describe 'and the event has an old lo consent (7)' do
           let(:consent_type) { 7 }
 
-          include_examples 'set_state_for_event_type leaving hi'
+          include_examples 'set_state_for_imported_event leaving hi'
         end
 
         describe 'and the event has a new lo consent (7)' do
           let(:consent_form_type) { 7 }
 
-          include_context 'set_state_for_event_type leaving hi'
+          include_context 'set_state_for_imported_event leaving hi'
         end
 
         describe 'and the event has an old hi consent (1)' do
           let(:consent_type) { 1 }
 
-          include_context 'set_state_for_event_type leaving hi'
+          include_context 'set_state_for_imported_event leaving hi'
         end
 
         [1, 2, 6].each do |form_type|
           describe "and the event has a new hi consent (#{form_type})" do
             let(:consent_form_type) { form_type }
 
-            include_context 'set_state_for_event_type leaving hi'
+            include_context 'set_state_for_imported_event leaving hi'
           end
         end
       end
@@ -2304,32 +2304,32 @@ describe Participant do
         describe 'and the event has no consents' do
           let(:consent_date) { out_of_event_date }
 
-          include_context 'set_state_for_event_type leaving lo'
+          include_context 'set_state_for_imported_event leaving lo'
         end
 
         describe 'and the event has an old lo consent (7)' do
           let(:consent_type) { 7 }
 
-          include_context 'set_state_for_event_type leaving lo'
+          include_context 'set_state_for_imported_event leaving lo'
         end
 
         describe 'and the event has a new lo consent (7)' do
           let(:consent_form_type) { 7 }
 
-          include_context 'set_state_for_event_type leaving lo'
+          include_context 'set_state_for_imported_event leaving lo'
         end
 
         describe 'and the event has an old hi consent (1)' do
           let(:consent_type) { 1 }
 
-          include_context 'set_state_for_event_type converting hi'
+          include_context 'set_state_for_imported_event converting hi'
         end
 
         [1, 2, 6].each do |form_type|
           describe "and the event has a new hi consent (#{form_type})" do
             let(:consent_form_type) { form_type }
 
-            include_context 'set_state_for_event_type converting hi'
+            include_context 'set_state_for_imported_event converting hi'
           end
         end
 
@@ -2346,7 +2346,7 @@ describe Participant do
             participant.participant_consents << another_consent
           end
 
-          include_context 'set_state_for_event_type converting hi'
+          include_context 'set_state_for_imported_event converting hi'
         end
 
         describe 'when consent is not given' do
@@ -2355,7 +2355,7 @@ describe Participant do
             a_consent.consent_given_code = 2
           end
 
-          include_context 'set_state_for_event_type leaving lo'
+          include_context 'set_state_for_imported_event leaving lo'
         end
       end
     end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -2213,24 +2213,26 @@ describe Participant do
   end
 
   describe '#set_state_for_imported_event' do
-    describe 'for informed consent' do
+    describe 'for consent-based hi-lo conversion' do
       let(:participant) { Factory(:participant) }
 
       let(:event) {
-        Factory(:event, :event_type_code => 10, :event_start_date => Date.new(2010, 4, 1), :participant => participant)
+        Factory(:event, :event_type_code => 13, :participant => participant,
+          :event_start_date => event_start_date, :event_end_date => event_end_date)
       }
 
-      let(:out_of_event_date) { event.event_start_date - 7 }
-      let(:in_event_date) { event.event_start_date + 7 }
+      let(:event_start_date) { Date.new(2010, 4, 8) }
+      let(:event_end_date) { Date.new(2010, 4, 15) }
 
       let(:consent_type) { -4 }
       let(:consent_form_type) { -4 }
-      let(:consent_date) { in_event_date }
+      let(:consent_date) { event_end_date }
+      let(:consent_given_code) { 1 }
 
       let(:a_consent) {
         Factory(:participant_consent, :participant => participant,
-          :consent_given_code => 1, :consent_type_code => consent_type, :consent_form_type_code => consent_form_type,
-          :consent_date => consent_date)
+          :consent_given_code => consent_given_code, :consent_date => consent_date,
+          :consent_type_code => consent_type, :consent_form_type_code => consent_form_type)
       }
 
       before do
@@ -2263,36 +2265,41 @@ describe Participant do
           participant.high_intensity = true
         end
 
-        describe 'and the event has no consents' do
-          let(:consent_date) { out_of_event_date }
-
+        describe 'and the participant has no high consent' do
           include_context 'set_state_for_imported_event leaving hi'
         end
 
-        describe 'and the event has an old lo consent (7)' do
-          let(:consent_type) { 7 }
-
-          include_examples 'set_state_for_imported_event leaving hi'
-        end
-
-        describe 'and the event has a new lo consent (7)' do
-          let(:consent_form_type) { 7 }
-
-          include_context 'set_state_for_imported_event leaving hi'
-        end
-
-        describe 'and the event has an old hi consent (1)' do
-          let(:consent_type) { 1 }
-
-          include_context 'set_state_for_imported_event leaving hi'
-        end
-
-        [1, 2, 6].each do |form_type|
-          describe "and the event has a new hi consent (#{form_type})" do
-            let(:consent_form_type) { form_type }
-
+        shared_context 'set_state_for_imported_event stay hi for all consent types' do
+          describe '(old hi consent)' do
+            let(:consent_type) { 1 }
             include_context 'set_state_for_imported_event leaving hi'
           end
+
+          [1, 2, 6].each do |form_type|
+            describe "(new hi consent #{form_type})" do
+              let(:consent_form_type) { form_type }
+
+              include_context 'set_state_for_imported_event leaving hi'
+            end
+          end
+        end
+
+        describe 'and the participant has hi consent in the future' do
+          let(:consent_date) { event_end_date + 4 }
+
+          include_context 'set_state_for_imported_event stay hi for all consent types'
+        end
+
+        describe 'and the participant has hi consent on the same date as the event' do
+          let(:consent_date) { event_end_date }
+
+          include_context 'set_state_for_imported_event stay hi for all consent types'
+        end
+
+        describe 'and the participant has hi consent in the past' do
+          let(:consent_date) { event_start_date - 4 }
+
+          include_context 'set_state_for_imported_event stay hi for all consent types'
         end
       end
 
@@ -2301,61 +2308,109 @@ describe Participant do
           participant.high_intensity = false
         end
 
-        describe 'and the event has no consents' do
-          let(:consent_date) { out_of_event_date }
-
-          include_context 'set_state_for_imported_event leaving lo'
-        end
-
-        describe 'and the event has an old lo consent (7)' do
-          let(:consent_type) { 7 }
-
-          include_context 'set_state_for_imported_event leaving lo'
-        end
-
-        describe 'and the event has a new lo consent (7)' do
-          let(:consent_form_type) { 7 }
-
-          include_context 'set_state_for_imported_event leaving lo'
-        end
-
-        describe 'and the event has an old hi consent (1)' do
-          let(:consent_type) { 1 }
-
-          include_context 'set_state_for_imported_event converting hi'
-        end
-
-        [1, 2, 6].each do |form_type|
-          describe "and the event has a new hi consent (#{form_type})" do
-            let(:consent_form_type) { form_type }
-
+        shared_context 'set_state_for_imported_event convert to hi for all hi consent types' do
+          describe '(old hi consent)' do
+            let(:consent_type) { 1 }
             include_context 'set_state_for_imported_event converting hi'
           end
+
+          [1, 2, 6].each do |form_type|
+            describe "(new hi consent #{form_type})" do
+              let(:consent_form_type) { form_type }
+
+              include_context 'set_state_for_imported_event converting hi'
+            end
+          end
         end
 
-        describe 'when the event has both a hi and a lo consent' do
-          let(:another_consent) {
-            Factory(:participant_consent, :participant => participant,
-              :consent_given_code => 1, :consent_type_code => 1, :consent_form_type_code => -7,
-              :consent_date => in_event_date)
-          }
-
-          let(:consent_type) { 7 }
-
-          before do
-            participant.participant_consents << another_consent
+        shared_context 'set_state_for_imported_event leave lo for all hi consent types' do
+          describe '(old hi consent)' do
+            let(:consent_type) { 1 }
+            include_context 'set_state_for_imported_event leaving lo'
           end
 
-          include_context 'set_state_for_imported_event converting hi'
+          [1, 2, 6].each do |form_type|
+            describe "(new hi consent #{form_type})" do
+              let(:consent_form_type) { form_type }
+
+              include_context 'set_state_for_imported_event leaving lo'
+            end
+          end
+        end
+
+        describe 'and the participant has hi consent in the future' do
+          let(:consent_date) { event_end_date + 4 }
+
+          include_context 'set_state_for_imported_event leave lo for all hi consent types'
+        end
+
+        describe 'and the participant has hi consent on the same date as the event' do
+          let(:consent_date) { event_end_date }
+
+          include_context 'set_state_for_imported_event convert to hi for all hi consent types'
+        end
+
+        describe 'and the participant has hi consent in the past' do
+          let(:consent_date) { event_start_date - 4 }
+
+          include_context 'set_state_for_imported_event convert to hi for all hi consent types'
         end
 
         describe 'when consent is not given' do
-          before do
-            a_consent.consent_form_type_code = 1
-            a_consent.consent_given_code = 2
+          let(:consent_given_code) { 2 }
+
+          describe 'and the participant has hi consent in the future' do
+            let(:consent_date) { event_end_date + 4 }
+
+            include_context 'set_state_for_imported_event leave lo for all hi consent types'
           end
 
-          include_context 'set_state_for_imported_event leaving lo'
+          describe 'and the participant has hi consent on the same date as the event' do
+            let(:consent_date) { event_end_date }
+
+            include_context 'set_state_for_imported_event leave lo for all hi consent types'
+          end
+
+          describe 'and the participant has hi consent in the past' do
+            let(:consent_date) { event_start_date - 4 }
+
+            include_context 'set_state_for_imported_event leave lo for all hi consent types'
+          end
+        end
+
+        describe 'when the event has no end date' do
+          let(:event_end_date) { nil }
+
+          describe 'and the participant has hi consent in the future from the start date' do
+            let(:consent_date) { event_start_date + 4 }
+
+            include_context 'set_state_for_imported_event leave lo for all hi consent types'
+          end
+
+          describe 'and the participant has hi consent on the start date of the event' do
+            let(:consent_date) { event_start_date }
+
+            include_context 'set_state_for_imported_event convert to hi for all hi consent types'
+          end
+
+          describe 'and the participant has hi consent in the past' do
+            let(:consent_date) { event_start_date - 4 }
+
+            include_context 'set_state_for_imported_event convert to hi for all hi consent types'
+          end
+        end
+
+        describe 'when the event has no dates at all' do
+          let(:event_start_date) { nil }
+          let(:event_end_date) { nil }
+
+          include_context 'set_state_for_imported_event leave lo for all hi consent types'
+        end
+
+        describe 'when a hi consent has no date' do
+          let(:consent_date) { nil }
+
+          include_context 'set_state_for_imported_event leave lo for all hi consent types'
         end
       end
     end

--- a/spec/models/participant_state_spec.rb
+++ b/spec/models/participant_state_spec.rb
@@ -255,18 +255,10 @@ describe Participant do
       end
 
       describe "given Pre-Pregnancy Visit" do
-        it "should be in the following high intensity state" do
+        it "does nothing" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 11))
           participant.set_state_for_imported_event(event)
-          participant.should be_following_high_intensity
-          participant.should be_high_intensity
-        end
-
-        it "should be in the pre_pregnancy state" do
-          event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 12))
-          participant.set_state_for_imported_event(event)
-          participant.should be_following_high_intensity
-          participant.should be_high_intensity
+          participant.should be_consented_low_intensity
         end
       end
 
@@ -290,18 +282,10 @@ describe Participant do
       end
 
       describe "given Pregnancy Visit 1" do
-        it "should be in the pregnancy_one state" do
+        it "does nothing" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13))
           participant.set_state_for_imported_event(event)
-          participant.should be_pregnancy_one
-          participant.should be_high_intensity
-        end
-
-        it "should be in the pregnancy_one state" do
-          event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 14))
-          participant.set_state_for_imported_event(event)
-          participant.should be_pregnancy_one
-          participant.should be_high_intensity
+          participant.should be_consented_low_intensity
         end
       end
 
@@ -317,18 +301,10 @@ describe Participant do
       end
 
       describe "given Pregnancy Visit 2" do
-        it "should be in the pregnancy_two state" do
+        it "does nothing" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 15))
           participant.set_state_for_imported_event(event)
-          participant.should be_pregnancy_two
-          participant.should be_high_intensity
-        end
-
-        it "should be in the pregnancy_two state" do
-          event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 16))
-          participant.set_state_for_imported_event(event)
-          participant.should be_pregnancy_two
-          participant.should be_high_intensity
+          participant.should be_consented_low_intensity
         end
       end
 

--- a/spec/models/participant_state_spec.rb
+++ b/spec/models/participant_state_spec.rb
@@ -128,7 +128,7 @@ describe Participant do
           participant.low_intensity_state = 'in_pregnancy_probability_group'
           participant.should be_in_pregnancy_probability_group
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 1))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_in_pregnancy_probability_group
         end
       end
@@ -136,25 +136,25 @@ describe Participant do
       describe "given any Pregnancy Screener event" do
         it "should be in the in_pregnancy_probability_group state for Pregnancy Screener" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 29))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_in_pregnancy_probability_group
         end
 
         it "should be in the in_pregnancy_probability_group state for Pregnancy Screening - Provider Group" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 4))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_in_pregnancy_probability_group
         end
 
         it "should be in the in_pregnancy_probability_group state for Pregnancy Screening – High Intensity  Group" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 5))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_in_pregnancy_probability_group
         end
 
         it "should be in the in_pregnancy_probability_group state for Pregnancy Screening – Low Intensity Group " do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 6))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_in_pregnancy_probability_group
         end
       end
@@ -179,7 +179,7 @@ describe Participant do
       describe "given Pregnancy Probability" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 7))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
       end
@@ -187,14 +187,14 @@ describe Participant do
       describe "given PPG Follow-Up by Mailed SAQ" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 8))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
 
         it "should not move within the high intensity state machine arm" do
           participant.should be_low_intensity
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 8))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should_not be_following_high_intensity
         end
       end
@@ -202,7 +202,7 @@ describe Participant do
       describe "given Low Intensity Data Collection" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 33))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
       end
@@ -231,7 +231,7 @@ describe Participant do
       describe "given Pregnancy Screener" do
         it "should be in the consented_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 29))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_consented_low_intensity
         end
       end
@@ -239,7 +239,7 @@ describe Participant do
       describe "given Low Intensity Data Collection" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 33))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
 
@@ -248,7 +248,7 @@ describe Participant do
           pregnant_participant = Factory(:low_intensity_ppg1_participant)
           pregnant_participant.ppg_status.local_code.should == 1
           pregnant_participant.should be_pregnant
-          pregnant_participant.set_state_for_event_type(event)
+          pregnant_participant.set_state_for_imported_event(event)
           pregnant_participant.should be_pregnant_low
         end
 
@@ -257,14 +257,14 @@ describe Participant do
       describe "given Pre-Pregnancy Visit" do
         it "should be in the following high intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 11))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_high_intensity
           participant.should be_high_intensity
         end
 
         it "should be in the pre_pregnancy state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 12))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_high_intensity
           participant.should be_high_intensity
         end
@@ -273,7 +273,7 @@ describe Participant do
       describe "given Pregnancy Probability" do
         it "should be in the pre_pregnancy state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 7))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
           participant.should be_low_intensity
         end
@@ -283,7 +283,7 @@ describe Participant do
           pregnant_participant = Factory(:low_intensity_ppg1_participant)
           pregnant_participant.ppg_status.local_code.should == 1
           pregnant_participant.should be_pregnant
-          pregnant_participant.set_state_for_event_type(event)
+          pregnant_participant.set_state_for_imported_event(event)
           pregnant_participant.should be_pregnant_low
         end
 
@@ -292,14 +292,14 @@ describe Participant do
       describe "given Pregnancy Visit 1" do
         it "should be in the pregnancy_one state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_one
           participant.should be_high_intensity
         end
 
         it "should be in the pregnancy_one state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 14))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_one
           participant.should be_high_intensity
         end
@@ -310,7 +310,7 @@ describe Participant do
           status4a = NcsCode.for_list_name_and_local_code("PPG_STATUS_CL1", 4)
 
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 18))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_postnatal
           participant.ppg_status.should == status4a
         end
@@ -319,14 +319,14 @@ describe Participant do
       describe "given Pregnancy Visit 2" do
         it "should be in the pregnancy_two state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 15))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_two
           participant.should be_high_intensity
         end
 
         it "should be in the pregnancy_two state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 16))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_two
           participant.should be_high_intensity
         end
@@ -353,7 +353,7 @@ describe Participant do
       describe "given Pregnancy Screener" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 29))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
       end
@@ -361,7 +361,7 @@ describe Participant do
       describe "given Pregnancy Probability" do
         it "should be in the following_low_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 7))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
           participant.should be_low_intensity
         end
@@ -370,7 +370,7 @@ describe Participant do
       describe "given Informed Consent" do
         it "should be in the following_high_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 10))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_low_intensity
         end
       end
@@ -394,7 +394,7 @@ describe Participant do
       describe "given Pregnancy Probability" do
         it "should be in the following_high_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 7))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           # participant.should be_pre_pregnancy
           # participant.should be_following_high_intensity
           # TODO: check if this happens in cases of loss
@@ -404,7 +404,7 @@ describe Participant do
       describe "given Pregnancy Visit  1" do
         it "should be in the pregnancy_one state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_one
         end
       end
@@ -428,7 +428,7 @@ describe Participant do
       describe "given Pregnancy Visit  2" do
         it "should be in the pregnancy_two state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 15))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_two
         end
       end
@@ -436,7 +436,7 @@ describe Participant do
       describe "given Birth" do
         it "should be in the parenthood state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 18))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_parenthood
         end
       end
@@ -459,7 +459,7 @@ describe Participant do
       describe "given Birth" do
         it "should be in the parenthood state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 18))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_parenthood
         end
       end
@@ -485,7 +485,7 @@ describe Participant do
       describe "given Pre-Pregnancy Visit" do
         it "should be in the pre_pregnancy state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 11))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_high_intensity
         end
       end
@@ -493,7 +493,7 @@ describe Participant do
       describe "given Pregnancy Visit  1" do
         it "should be in the pregnancy_one state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_pregnancy_one
         end
       end
@@ -501,7 +501,7 @@ describe Participant do
       describe "given Pregnancy Probability" do
         it "should be in the following_high_intensity state" do
           event = Factory(:event, :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 7))
-          participant.set_state_for_event_type(event)
+          participant.set_state_for_imported_event(event)
           participant.should be_following_high_intensity
         end
       end
@@ -519,7 +519,7 @@ describe Participant do
         participant.person = person
         event = Factory(:event,
           :event_type => NcsCode.for_list_name_and_local_code('EVENT_TYPE_CL1', 13))
-        participant.set_state_for_event_type(event)
+        participant.set_state_for_imported_event(event)
         participant.should be_pregnancy_one
 
         Factory(:ppg_detail, :participant => participant, :ppg_first => status1a,


### PR DESCRIPTION
Changes the importer event/state processing to move a participant to high at the point in her event history where her consent history indicates she consented to high. Pseudocode:

```
 foreach event
    move_to_high_if_not_in_high_and_consented_as_of(event.some_concrete_date)
    import event
 end
```
