### PR TITLE
PSC sync: do not schedule hi events for lo participants (#3998, #4010)

### DIFF
--- a/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
@@ -177,7 +177,7 @@ module NcsNavigator::Core::Warehouse
       label = event_details['event_type_label']
       arm = event_details['recruitment_arm']
 
-      if label == 'informed_consent'
+      if informed_consent_label?(label)
         say_subtask_message("skipping informed consent event")
         log.debug("Skipping informed consent for #{p_id} on #{start_date} (#{event_id})")
         return
@@ -270,6 +270,10 @@ module NcsNavigator::Core::Warehouse
       possible_segments.size == 2 && segment_names.include?('Birth Cohort') && segment_names.uniq.size == 2
     end
     private :segment_selectable_by_birth_cohort?
+
+    def informed_consent_label?(label)
+      label == 'informed_consent'
+    end
 
     ###### CONTACT LINK SA HISTORY UPDATES
 
@@ -431,7 +435,7 @@ module NcsNavigator::Core::Warehouse
           find_psc_event([psc_event], imported_event['start_date'], imported_event['event_type_label'])
         }
       }.reject { |psc_event| latest_imported_event_date && (psc_event[:start_date] < latest_imported_event_date) }.
-        reject { |psc_event| psc_event[:event_type_label] == 'informed_consent' }
+        reject { |psc_event| informed_consent_label?(psc_event[:event_type_label]) }
 
       scheduled_events.each do |implied_event|
         event_type_label = implied_event[:event_type_label]

--- a/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
@@ -199,10 +199,6 @@ module NcsNavigator::Core::Warehouse
 
       if possible_segments.size == 1
         selected_segment = possible_segments.first
-      elsif segment_selectable_by_hi_v_lo?(possible_segments)
-        selected_segment = possible_segments.inject({}) { |h, seg|
-          h[seg.parent['name'] == 'LO-Intensity' ? 'lo' : 'hi'] = seg; h
-        }[event_details['recruitment_arm']]
       elsif segment_selectable_by_pre_post_natal?(possible_segments)
         pre_or_post = redis.get(sync_key['p', p_id, 'postnatal']) ? 'post' : 'pre'
         selected_segment = possible_segments.inject({}) { |h, seg|
@@ -254,13 +250,6 @@ module NcsNavigator::Core::Warehouse
       (segment_elt.parent['name'] == 'LO-Intensity') ^ (recruit_arm == 'hi')
     end
     private :eligible_segment_for_arm?
-
-    def segment_selectable_by_hi_v_lo?(possible_segments)
-      epoch_names = possible_segments.collect { |seg| seg.parent['name'] }
-      # "there are two different epochs and one of them is LO-Intensity"
-      epoch_names.size == 2 && epoch_names.include?('LO-Intensity') && epoch_names.uniq.size == 2
-    end
-    private :segment_selectable_by_hi_v_lo?
 
     def segment_selectable_by_pre_post_natal?(possible_segments)
       segment_names = possible_segments.collect { |seg| seg['name'] }

--- a/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
+++ b/lib/ncs_navigator/core/warehouse/operational_importer_psc_sync.rb
@@ -177,6 +177,12 @@ module NcsNavigator::Core::Warehouse
       label = event_details['event_type_label']
       arm = event_details['recruitment_arm']
 
+      if label == 'informed_consent'
+        say_subtask_message("skipping informed consent event")
+        log.debug("Skipping informed consent for #{p_id} on #{start_date} (#{event_id})")
+        return
+      end
+
       say_subtask_message("looking for #{label} in template for #{arm}")
       possible_segments = select_segments(label)
       selected_segment = nil


### PR DESCRIPTION
Prevents the sync from attempting to schedule lo segments for hi participants and vice versa. Differs from the existing behavior in that, e.g., the presence of a (bad, hi-only) 6M event in the event history of a lo participant will not result in the lo participant being scheduled for the full course of hi events.

Extra bonus issue addressed: #4010. Eliminates "errors" about unsyncable informed consent events by not trying to sync them. These are known to be unsyncable and it is not likely that that will ever change. The logs don't need to be full of "errors" reminding us, especially when those logs may obscure actual errors logged due to a lo person having a hi event.
