### PR TITLE
3897 duplicate informed consent events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -187,7 +187,7 @@ class EventsController < ApplicationController
   # @param [Participant]
   def cancel_scheduled_consents_for_consented_participant(participant)
     psc.scheduled_activities(participant).each do |a|
-      if psc.should_cancel_consent_activity?(a)
+      if a.cancelable_consent_activity?
         psc.update_activity_state(a.activity_id, participant, Psc::ScheduledActivity::CANCELED, Date.parse(a.ideal_date),
           "Consent activity cancelled as the Participant [#{participant.p_id}] has already consented.")
       end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -47,26 +47,8 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if @event.update_attributes(params[:event])
-        mark_activity_occurred
-        @event.update_associated_informed_consent_event
 
-        notice = 'Event was successfully updated.'
-
-        if @event.provider_recruitment_event?
-          # do not set participant
-        elsif participant = @event.participant
-          if participant.ineligible?
-            if @event.screener_event?
-              Participant.adjudicate_eligibility_and_disqualify_ineligible(participant)
-              @event.reload
-            end
-          elsif @event.informed_consent? && participant.withdrawn?
-            participant.unenroll!(psc, "Participant has withdrawn from the study.")
-          else
-            resp = participant.advance(psc)
-            notice += " Scheduled next event [#{participant.next_study_segment}]" if resp
-          end
-        end
+        post_update_event_actions(@event, @event.participant)
 
         format.html do
           if params[:commit] == "Continue" && @contact_link
@@ -108,79 +90,142 @@ class EventsController < ApplicationController
     end
   end
 
-  private
+  def set_suggested_values_for_event
+    @event.set_suggested_event_disposition(@contact_link)
+    @event.set_suggested_event_disposition_category(@contact_link)
+    @event.set_suggested_event_repeat_key
+    @event.set_suggested_event_breakoff(@contact_link)
+  end
+  private :set_suggested_values_for_event
 
-    def set_suggested_values_for_event
-      @event.set_suggested_event_disposition(@contact_link)
+  def redirect_path
+    path = events_path
+    if @event.provider_recruitment_event?
+      path = provider_recruitment_event_redirect_path
+    elsif !@event.participant.nil?
+      path = participant_path(@event.participant)
+    end
+    path
+  end
+  private :redirect_path
 
-      @event.set_suggested_event_disposition_category(@contact_link)
+  def provider_recruitment_event_redirect_path
+    provider = @event.contact_links.find { |cl| !cl.provider.nil? }.try(:provider)
+    provider.nil? ? pbs_lists_path : pbs_list_path(provider.pbs_list)
+  end
+  private :provider_recruitment_event_redirect_path
 
-      @event.set_suggested_event_repeat_key
+  def post_update_event_actions(event, participant)
+    # Update PSC activities
+    mark_activity_occurred(event, participant)
 
-      @event.set_suggested_event_breakoff(@contact_link)
+    # For a consent event if the participant has consented, cancel all upcoming consent activities in PSC.
+    if event.consent_event? && participant.try(:consented?)
+      cancel_scheduled_consents_for_consented_participant(participant)
     end
 
-    def redirect_path
-      path = events_path
-      if @event.provider_recruitment_event?
-        path = provider_recruitment_event_redirect_path
-      elsif !@event.participant.nil?
-        path = participant_path(@event.participant)
-      end
-      path
-    end
+    # If necessary, update associated event information
+    event.update_associated_informed_consent_event
 
-    def provider_recruitment_event_redirect_path
-      provider = @event.contact_links.find { |cl| !cl.provider.nil? }.try(:provider)
-      provider.nil? ? pbs_lists_path : pbs_list_path(provider.pbs_list)
-    end
-    private :provider_recruitment_event_redirect_path
+    # Update Participant state
+    update_participant_state(event, participant) unless event.provider_recruitment_event?
+  end
+  private :post_update_event_actions
 
-    ##
-    # Updates activities associated with this event
-    # in PSC as 'occurred'
-    def mark_activity_occurred
-      if !@event.event_end_date.blank? && !@event.provider_recruitment_event?
-  	    psc.activities_for_event(@event).each do |a|
-  	      if @event.matches_activity(a)
-            psc.update_activity_state(a.activity_id,
-                                      @event.participant,
-                                      Psc::ScheduledActivity::OCCURRED)
-          end
+  ##
+  # Upon completion of an Event we advance the Participant to the
+  # next state. However in the case of a screened Participant found to
+  # be ineligible we adjudicate the Participant and act accordingly or if
+  # the Participant has withdrawn from the study we unenroll the Participant.
+  # @see Participant#advance
+  # @see Participant#adjudicate_eligibility_and_disqualify_ineligible
+  # @see Participant#unenroll
+  # @param [Event]
+  # @param [Participant]
+  def update_participant_state(event, participant)
+    if participant
+      if participant.ineligible?
+        if event.screener_event?
+          Participant.adjudicate_eligibility_and_disqualify_ineligible(participant)
         end
+      elsif event.informed_consent? && participant.withdrawn?
+        participant.unenroll!(psc, "Participant has withdrawn from the study.")
+      else
+        participant.advance(psc)
       end
     end
+  end
+  private :update_participant_state
 
-    ##
-	  # Determine the disposition group to be used from the contact type or instrument taken
-	  def set_disposition_group
-	    @disposition_group = nil
-	    if @event.event_disposition_category_code.to_i > 0
-	      @disposition_group =
-	        DispositionMapper.for_event_disposition_category_code(@event.event_disposition_category_code)
-	    else
-  	    case @event.event_type.to_s
-  	    when "Pregnancy Screener"
-          @disposition_group = DispositionMapper::PREGNANCY_SCREENER_EVENT
-        when "Provider-Based Recruitment"
-          @disposition_group = DispositionMapper::PROVIDER_RECRUITMENT_EVENT
-        when "PBS Participant Eligibility Screening"
-          @disposition_group = DispositionMapper::PBS_ELIGIBILITY_EVENT
-        when "Informed Consent"
-          if @event.try(:participant).low_intensity?
-            @disposition_group = DispositionMapper::TELEPHONE_INTERVIEW_EVENT
-          else
-            @disposition_group = DispositionMapper::GENERAL_STUDY_VISIT_EVENT
-          end
+  ##
+  # Updates activities associated with this event
+  # in PSC as 'occurred'
+  def mark_activity_occurred(event, participant)
+    if participant && event.closed? && !event.provider_recruitment_event?
+      mark_event_activities_occurred(event, participant)
+    end
+  end
+  private :mark_activity_occurred
+
+  ##
+  # For the given event, find the scheduled activities that match this event
+  # and mark those activities as occurred.
+  # @param [Event]
+  # @param [Participant]
+  def mark_event_activities_occurred(event, participant)
+    psc.activities_for_event(event).each do |a|
+      if event.matches_activity(a)
+        psc.update_activity_state(a.activity_id, participant, Psc::ScheduledActivity::OCCURRED)
+      end
+    end
+  end
+  private :mark_event_activities_occurred
+
+  ##
+  # For all scheduled activities for the given participant,
+  # cancel those that are consent activities
+  # @param [Participant]
+  def cancel_scheduled_consents_for_consented_participant(participant)
+    psc.scheduled_activities(participant).each do |a|
+      if psc.should_cancel_consent_activity?(a)
+        psc.update_activity_state(a.activity_id, participant, Psc::ScheduledActivity::CANCELED, Date.parse(a.ideal_date),
+          "Consent activity cancelled as the Participant [#{participant.p_id}] has already consented.")
+      end
+    end
+  end
+  private :cancel_scheduled_consents_for_consented_participant
+
+  ##
+  # Determine the disposition group to be used from the contact type or instrument taken
+  def set_disposition_group
+    @disposition_group = nil
+    if @event.event_disposition_category_code.to_i > 0
+      @disposition_group =
+        DispositionMapper.for_event_disposition_category_code(@event.event_disposition_category_code)
+    else
+	    case @event.event_type.to_s
+	    when "Pregnancy Screener"
+        @disposition_group = DispositionMapper::PREGNANCY_SCREENER_EVENT
+      when "Provider-Based Recruitment"
+        @disposition_group = DispositionMapper::PROVIDER_RECRUITMENT_EVENT
+      when "PBS Participant Eligibility Screening"
+        @disposition_group = DispositionMapper::PBS_ELIGIBILITY_EVENT
+      when "Informed Consent"
+        if @event.try(:participant).low_intensity?
+          @disposition_group = DispositionMapper::TELEPHONE_INTERVIEW_EVENT
         else
-          contact = @event.contact_links.last.contact unless @event.contact_links.blank?
-          if contact && contact.contact_type
-    	      @disposition_group = contact.contact_type.to_s
-    	    else
-    	      @disposition_group = DispositionMapper::GENERAL_STUDY_VISIT_EVENT
-          end
+          @disposition_group = DispositionMapper::GENERAL_STUDY_VISIT_EVENT
+        end
+      else
+        contact = @event.contact_links.last.contact unless @event.contact_links.blank?
+        if contact && contact.contact_type
+  	      @disposition_group = contact.contact_type.to_s
+  	    else
+  	      @disposition_group = DispositionMapper::GENERAL_STUDY_VISIT_EVENT
         end
       end
-	  end
+    end
+  end
+  private :set_disposition_group
 
 end

--- a/app/models/scheduled_activity.rb
+++ b/app/models/scheduled_activity.rb
@@ -156,6 +156,21 @@ class ScheduledActivity
   end
 
   ##
+  # True if the activity is a consent activity, but is not a child consent activity
+  # and is not a part of the Informed Consent Epoch
+  # @return [Boolean]
+  def cancelable_consent_activity?
+    skippable_segments = [
+      PatientStudyCalendar::INFORMED_CONSENT_GENERAL_CONSENT,
+      PatientStudyCalendar::INFORMED_CONSENT_CHILD_CONSENT_BIRTH,
+      PatientStudyCalendar::INFORMED_CONSENT_CHILD_CONSENT_SIX_MONTHS,
+      PatientStudyCalendar::INFORMED_CONSENT_WITHDRAWAL,
+      PatientStudyCalendar::INFORMED_CONSENT_RECONSENT,
+    ]
+    consent_activity? && !child_consent? && !skippable_segments.include?(study_segment)
+  end
+
+  ##
   # All other consent activities that are not a child consent
   # reconsent or withdrawal
   # @return [Boolean]

--- a/lib/patient_study_calendar.rb
+++ b/lib/patient_study_calendar.rb
@@ -640,26 +640,10 @@ class PatientStudyCalendar
   def cancel_consent_activities(participant, scheduled_study_segment_identifier, date, reason)
     return unless participant.consented?
     activities_for_scheduled_segment(participant, scheduled_study_segment_identifier).each do |a|
-      if should_cancel_consent_activity?(a)
+      if a.cancelable_consent_activity?
         update_activity_state(a.activity_id, participant, Psc::ScheduledActivity::CANCELED, date, reason)
       end
     end
-  end
-
-  ##
-  # True if the activity is a consent activity, but is not a child consent activity
-  # and is not a part of the Informed Consent Epoch
-  # @param activity [ScheduledActivity]
-  # @return [Boolean]
-  def should_cancel_consent_activity?(activity)
-    skippable_segments = [
-      INFORMED_CONSENT_GENERAL_CONSENT,
-      INFORMED_CONSENT_CHILD_CONSENT_BIRTH,
-      INFORMED_CONSENT_CHILD_CONSENT_SIX_MONTHS,
-      INFORMED_CONSENT_WITHDRAWAL,
-      INFORMED_CONSENT_RECONSENT,
-    ]
-    activity.consent_activity? && !activity.child_consent? && !skippable_segments.include?(activity.study_segment)
   end
 
   ##

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -366,7 +366,7 @@ namespace :import do
         next
       elsif part.consented?
         psc.scheduled_activities(part).each do |a|
-          if psc.should_cancel_consent_activity?(a)
+          if a.cancelable_consent_activity?
             msg = "Activity #{a.activity_name} is a consent activity. Canceling activity for participant #{part.p_id}."
             $stderr.print("\n#{msg}")
             Rails.logger.info(msg)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -370,7 +370,7 @@ namespace :import do
             msg = "Activity #{a.activity_name} is a consent activity. Canceling activity for participant #{part.p_id}."
             $stderr.print("\n#{msg}")
             Rails.logger.info(msg)
-            reason ="Study Center is not configured to collection samples or specimens."
+            reason = msg
             psc.update_activity_state(a.activity_id, part, Psc::ScheduledActivity::CANCELED, Date.parse(a.ideal_date), reason)
           end
         end

--- a/spec/models/scheduled_activity_spec.rb
+++ b/spec/models/scheduled_activity_spec.rb
@@ -46,6 +46,50 @@ describe ScheduledActivity do
     end
   end
 
+  describe "#cancelable_consent_activity?" do
+    let(:sa) do
+      ScheduledActivity.new(
+        :activity_type => activity_type,
+        :activity_name => activity_name,
+        :study_segment => study_segment)
+    end
+
+    describe "an Instrument activity type" do
+      let(:activity_type) { 'Instrument' }
+      let(:activity_name) { 'New Adult Consent' }
+      let(:study_segment) { PatientStudyCalendar::CHILD_CHILD }
+      it "is false" do
+        sa.should_not be_cancelable_consent_activity
+      end
+    end
+
+    describe "a child consent activity" do
+      let(:activity_type) { 'Consent' }
+      let(:activity_name) { 'Child Consent' }
+      let(:study_segment) { PatientStudyCalendar::CHILD_CHILD }
+      it "is false" do
+        sa.should_not be_cancelable_consent_activity
+      end
+    end
+
+    describe "an activity in the Informed Consent Epoch" do
+      let(:activity_type) { 'Consent' }
+      let(:activity_name) { 'New Adult Consent' }
+      let(:study_segment) { PatientStudyCalendar::INFORMED_CONSENT_RECONSENT }
+      it "is false" do
+        sa.should_not be_cancelable_consent_activity
+      end
+    end
+
+    describe "a non child consent activity not in the Informed Consent Epoch" do
+      let(:activity_type) { 'Consent' }
+      let(:activity_name) { 'New Adult Consent' }
+      let(:study_segment) { PatientStudyCalendar::CHILD_CHILD }
+      it "is true" do
+        sa.should be_cancelable_consent_activity
+      end
+    end
+  end
 
   describe "#open?" do
     let(:sa) { ScheduledActivity.new(attrs) }


### PR DESCRIPTION
Added method in `post_update_event_actions` to cancel scheduled consent activities in PSC if the Participant has consented.
