### PR TITLE
Ineligible participant redirect is incorrect #4069

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -83,7 +83,7 @@ class ContactsController < ApplicationController
         format.json { render :json => @contact }
       else
         set_disposition_group
-        format.html { render :action => "new" }
+        format.html { render :action => "edit" }
         format.json { render :json => @contact.errors }
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -986,7 +986,11 @@ class Event < ActiveRecord::Base
   end
 
   def set_suggested_event_repeat_key
-    self.participant.events.where(:event_type_code => self.event_type_code).count - 1
+    if self.participant.nil?
+      0
+    else
+      self.participant.events.where(:event_type_code => self.event_type_code).count - 1
+    end
   end
 
   ##


### PR DESCRIPTION
If the participant is ineligible redirect the user
to the events index page.
