### PR TITLE
Event.with_psc_data, a method to load scheduled activities for events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -715,8 +715,15 @@ class Event < ActiveRecord::Base
     implied_by?(label, scheduled_activity.ideal_date)
   end
 
-  def implied_by?(label, date)
-    self.label == label && psc_ideal_date.to_s == date
+  def implied_by?(*args)
+    if args.length == 1
+      activity = args.first
+      self.label == activity.event_label.try(:content) && psc_ideal_date.to_s == activity.ideal_date
+    elsif args.length == 2
+      self.label == args.first && psc_ideal_date.to_s == args.second
+    else
+      raise ArgumentError, "wrong number of arguments (#{args.length} for 1 or 2)"
+    end
   end
 
   def set_event_disposition_category(contact)

--- a/spec/fixtures/vcr_cassettes/psc/schedules_with_labels.yml
+++ b/spec/fixtures/vcr_cassettes/psc/schedules_with_labels.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ncsn-psc.local/api/v1/subjects/test/schedules.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic cGZyOTU3OnBzYw==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - Restlet-Framework/2.0.3
+      Date:
+      - Fri, 26 Aug 2011 18:54:05 GMT
+      Vary:
+      - Accept-Charset, Accept-Encoding, Accept-Language, Accept
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Transfer-Encoding:
+      - chunked
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "days": {
+                "2011-08-29": {
+                    "activities": [
+                        {
+                            "activity": {
+                                "name": "Pregnancy Screener Instrument",
+                                "type": "Instrument"
+                            },
+                            "assignment": {
+                                "id": "todo_1314638760",
+                                "name": "NCS Hi-Lo",
+                                "privileges": [
+                                    "update"
+                                ],
+                                "subject_coordinator": {
+                                    "username": "pfr957"
+                                }
+                            },
+                            "current_state": {
+                                "date": "2011-08-29",
+                                "name": "scheduled",
+                                "reason": "Initialized from template"
+                            },
+                            "formatted_plan_day": "Day 1",
+                            "id": "c32af1e0-3483-4a28-87b4-1b2019abc082",
+                            "ideal_date": "2011-08-29",
+                            "labels": "event:pregnancy_screener",
+                            "plan_day": "1",
+                            "state_history": [
+                                {
+                                    "date": "2011-08-29",
+                                    "name": "scheduled",
+                                    "reason": "Initialized from template"
+                                }
+                            ],
+                            "study": "NCS Hi-Lo",
+                            "study_segment": "LO-Intensity: Pregnancy Screener",
+                            "subject": "Ella Fitzgerald"
+                        }
+                    ],
+                    "hidden_activities": "false"
+                }
+            },
+            "study_segments": [
+                {
+                    "assignment": {
+                        "id": "todo_1314638760",
+                        "name": "NCS Hi-Lo",
+                        "privileges": [
+                            "update"
+                        ],
+                        "subject_coordinator": {
+                            "username": "pfr957"
+                        }
+                    },
+                    "id": "3a0e383d-e3d0-4756-ae61-4d2de92067e7",
+                    "name": "LO-Intensity: Pregnancy Screener",
+                    "planned": {
+                        "epoch": {
+                            "id": "73f6c858-4069-411a-8d82-c9d558c07d68",
+                            "name": "LO-Intensity"
+                        },
+                        "segment": {
+                            "id": "6caf9143-bfb0-47e4-b1e4-ccc810a4cbc8",
+                            "name": "Pregnancy Screener"
+                        },
+                        "study": {
+                            "assigned_identifier": "NCS Hi-Lo"
+                        }
+                    },
+                    "range": {
+                        "start_date": "2011-08-29",
+                        "stop_date": "2011-08-29"
+                    },
+                    "subject": "Ella Fitzgerald"
+                }
+            ],
+            "subject": {
+                "birth_date": "1931-08-29",
+                "first_name": "Ella",
+                "full_name": "Ella Fitzgerald",
+                "gender": "Male",
+                "last_first": "Fitzgerald, Ella",
+                "last_name": "Fitzgerald",
+                "properties": []
+            }
+        }
+    http_version: '1.1'
+  recorded_at: Thu, 10 Jan 2013 18:04:42 GMT
+recorded_with: VCR 2.4.0

--- a/spec/integration/models/event_spec.rb
+++ b/spec/integration/models/event_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'logger'
+require 'stringio'
+
+describe Event do
+  describe '.with_psc_data' do
+    let(:user) { mock(:username => 'dude', :cas_proxy_ticket => 'PT-cas-ticket') }
+
+    let(:e1) do
+      # Type 29 designates a pregnancy screener.
+      Factory(:event, :psc_ideal_date => '2011-08-29', :event_type_code => 29)
+    end
+
+    let(:psc) { PatientStudyCalendar.new(user, Logger.new(nil)) }
+
+    around do |example|
+      VCR.use_cassette('psc/schedules_with_labels') { example.call }
+    end
+
+    before do
+      # These are needed for participant -> PSC subject correspondence.
+      pe = Factory(:person, :person_id => 'test')
+      pa = Factory(:participant)
+
+      Factory(:participant_person_link, :participant => pa, :person => pe, :relationship_code => 1)
+      e1.participant = pa
+      e1.save!
+    end
+
+    it 'loads scheduled activities for each event in a relation' do
+      es = Event.where(:id => e1.id).with_psc_data(psc)
+
+      es.length.should == 1
+      es.first.scheduled_activities.length.should == 1
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -761,6 +761,49 @@ describe Event do
     end
   end
 
+  describe '#implied_by?' do
+    let(:event) { Event.new }
+
+    before do
+      event.psc_ideal_date = '2000-01-01'
+      event.stub!(:label => 'foo_bar')
+    end
+
+    describe 'given an event label and ideal date' do
+      it "returns true if its label and ideal date match what's given" do
+        event.implied_by?('foo_bar', '2000-01-01').should be_true
+      end
+
+      it "returns false if its label does not match" do
+        event.implied_by?('baz', '2000-01-01').should be_false
+      end
+
+      it "returns false if its ideal date does not match" do
+        event.implied_by?('foo_bar', '1999-12-31').should be_false
+      end
+    end
+
+    describe 'given a Psc::ScheduledActivity' do
+      let(:sa) { Psc::ScheduledActivity.new(:ideal_date => '2000-01-01', :labels => 'event:foo_bar') }
+
+      it "returns true if its label and ideal date match the activity" do
+        event.implied_by?(sa).should be_true
+      end
+
+      it "returns false if its label does not match the activity's event label" do
+        sa.labels = 'event:baz'
+
+        event.implied_by?(sa).should be_false
+      end
+
+      it "returns false if its ideal date does not match" do
+        sa.ideal_date = '1999-12-31'
+
+        event.implied_by?(sa).should be_false
+      end
+    end
+  end
+
   describe '#disposition_code' do
     let(:version) { NcsNavigator::Core::Mdes::Version.new('3.1') }
     let(:spec) { version.specification }


### PR DESCRIPTION
This pull request contains an implementation of `Event.with_psc_data`, a method to load scheduled activities from PSC for a set of Events.

Also contained in this PR is a change of `Event#scheduled_activities` to `Event#load_scheduled_activities` and scheduled activity caching.  This does not introduce any additional test failures, but I find it odd that `Event#scheduled_activities` was evidently not used anywhere else.  Review of this situation would be appreciated.

This addresses https://code.bioinformatics.northwestern.edu/issues/issues/show/4085.
