### PR TITLE
Ensure Answer associated with Question #4084

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -31,6 +31,20 @@ class Response < ActiveRecord::Base
 
   default_scope includes(:answer, :question)
 
+  # TODO: remove this validation if Surveyor is ever updated to include same
+  validate :answer_associated_with_question
+
+  def answer_associated_with_question
+    answer_ids = Answer.where(:question_id => self.question_id).map(&:id)
+    unless answer_ids.blank?
+      # not certain if the validates_presence_of, :answer_id is fired before this check
+      if !self.answer_id.blank? && !answer_ids.include?(self.answer_id)
+        errors.add(:base,
+          "answer_id #{self.answer_id} not in collection of answers [#{answer_ids}] associated with question #{self.question_id} ")
+      end
+    end
+  end
+
   with_options(:as => :system) do |r|
     r.attr_accessible :answer, :question, :value
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -31,16 +31,16 @@ class Response < ActiveRecord::Base
 
   default_scope includes(:answer, :question)
 
-  # TODO: remove this validation if Surveyor is ever updated to include same
-  validate :answer_associated_with_question
+  validate :ensure_association_integrity
 
-  def answer_associated_with_question
-    answer_ids = Answer.where(:question_id => self.question_id).map(&:id)
-    unless answer_ids.blank?
-      # not certain if the validates_presence_of, :answer_id is fired before this check
-      if !self.answer_id.blank? && !answer_ids.include?(self.answer_id)
-        errors.add(:base,
-          "answer_id #{self.answer_id} not in collection of answers [#{answer_ids}] associated with question #{self.question_id} ")
+  ##
+  # Raise an error if the answer associated with this Response
+  # is not in the set of answers for the associated Question.
+  def ensure_association_integrity
+    if answer_id && question
+      valid_answer_ids = Answer.where(:question_id => self.question_id).map(&:id)
+      unless valid_answer_ids.include?(answer_id)
+        raise "Error: answer_id #{answer_id} not in the set of answers [#{valid_answer_ids}] for question #{question.id}"
       end
     end
   end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -70,6 +70,40 @@ describe Response do
     end
   end
 
+  describe "#answer_associated_with_question" do
+    let!(:q) { Factory(:question,
+      :text => 'What is your date of birth?',
+      :reference_identifier => 'DOB',
+      :data_export_identifier => 'TABLE_NAME.DOB') }
+    let!(:a1) { Factory(:answer, :question => q, :response_class => 'date', :text => 'DATE') }
+
+    let!(:a_other_q) { Factory(:answer, :question => Factory(:question),
+      :response_class => 'answer', :text => 'FOO') }
+
+    describe "on create" do
+      it "is invalid if the answer_id is not associated with the response question" do
+        response = Factory.build(:response, :question => q, :answer => a_other_q)
+        response.should_not be_valid
+      end
+      it "raises error" do
+        lambda { Factory(:response, :question => q, :answer => a_other_q) }.should raise_error
+      end
+    end
+
+    describe "on update" do
+      it "is invalid if the answer_id is not associated with the response question" do
+        response = Factory(:response, :question => q, :answer => a1)
+        response.answer = a_other_q
+        response.should_not be_valid
+      end
+      it "raises error" do
+        response = Factory(:response, :question => q, :answer => a1)
+        response.answer = a_other_q
+        lambda { response.save! }.should raise_error
+      end
+    end
+  end
+
   it_should_behave_like 'a publicly identified record' do
     let(:a) { Factory(:answer) }
     let(:q) { Factory(:question) }

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -70,7 +70,7 @@ describe Response do
     end
   end
 
-  describe "#answer_associated_with_question" do
+  describe "#ensure_association_integrity" do
     let!(:q) { Factory(:question,
       :text => 'What is your date of birth?',
       :reference_identifier => 'DOB',
@@ -81,40 +81,40 @@ describe Response do
       :response_class => 'answer', :text => 'FOO') }
 
     describe "on create" do
-      it "is invalid if the answer_id is not associated with the response question" do
-        response = Factory.build(:response, :question => q, :answer => a_other_q)
-        response.should_not be_valid
-      end
-      it "raises error" do
-        lambda { Factory(:response, :question => q, :answer => a_other_q) }.should raise_error
+      describe "when answer references another question" do
+        let(:response) { Factory.build(:response, :question => q, :answer => a_other_q) }
+        it "raises error on save" do
+          lambda { response.save }.should raise_error
+        end
       end
     end
 
     describe "on update" do
-      it "is invalid if the answer_id is not associated with the response question" do
-        response = Factory(:response, :question => q, :answer => a1)
-        response.answer = a_other_q
-        response.should_not be_valid
-      end
-      it "raises error" do
-        response = Factory(:response, :question => q, :answer => a1)
-        response.answer = a_other_q
-        lambda { response.save! }.should raise_error
+      describe "when updated answer references another question" do
+        let(:response) { Factory(:response, :question => q, :answer => a1) }
+
+        before do
+          response.answer = a_other_q
+        end
+
+        it "raises error on save" do
+          lambda { response.save }.should raise_error
+        end
       end
     end
   end
 
   it_should_behave_like 'a publicly identified record' do
-    let(:a) { Factory(:answer) }
     let(:q) { Factory(:question) }
+    let(:a) { Factory(:answer, :question => q) }
 
     let(:o1) { Factory(:response, :answer => a, :question => q) }
     let(:o2) { Factory(:response, :answer => a, :question => q) }
   end
 
   it_should_behave_like 'an optimistically locked record' do
-    let(:a) { Factory(:answer) }
     let(:q) { Factory(:question) }
+    let(:a) { Factory(:answer, :question => q) }
 
     subject { Factory(:response, :answer => a, :question => q) }
 


### PR DESCRIPTION
When creating or updating a Response validate that the
Answer being set is one of the Answers associated with the Question.

This probably should be added to Surveyor as a validation but is included
here to address the #4084 issue going forward with Cases. If Surveyor is
ever changed to add this validation we should remove it here
(see TODO note above validate callback)
