### PR TITLE
Populate an SA's responsible user.  #3662.

### DIFF
--- a/app/models/psc/scheduled_activity.rb
+++ b/app/models/psc/scheduled_activity.rb
@@ -18,6 +18,7 @@ module Psc
     ideal_date
     labels
     person_id
+    responsible_user
     study_segment
   ).map(&:to_sym)
 
@@ -175,6 +176,7 @@ module Psc
         a.ideal_date = row['ideal_date']
         a.labels = row['labels']
         a.person_id = row['subject']['person_id'] if row['subject']
+        a.responsible_user = row['responsible_user']
       end
     end
 
@@ -193,8 +195,12 @@ module Psc
           a.current_state = state['name']
         end
 
-        if row['assignment']
-          a.person_id = row['assignment']['id']
+        if (assign = row['assignment'])
+          a.person_id = assign['id']
+
+          if assign['subject_coordinator']
+            a.responsible_user = assign['subject_coordinator']['username']
+          end
         end
 
         a.activity_id = row['id']

--- a/spec/models/psc/scheduled_activity_contexts.rb
+++ b/spec/models/psc/scheduled_activity_contexts.rb
@@ -86,17 +86,20 @@ shared_context 'from schedule' do
               "type": "Instrument"
           },
           "assignment": {
-              "id": "mother"
+              "id": "mother",
+              "subject_coordinator": {
+                  "username": "abc123"
+              }
           },
           "current_state": {
-              "name": "scheduled",
               "date": "2011-01-01",
+              "name": "scheduled",
               "time": "14:10"
           },
-          "study_segment": "HI-Intensity: Child",
           "id": "11",
           "ideal_date": "2011-01-01",
-          "labels": "event:birth instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_baby_name instrument:3.0:ins_que_birth_int_ehpbhi_p2_v3.0_baby_name references:2.0:ins_que_birth_int_ehpbhi_p2_v2.0 references:3.0:ins_que_birth_int_ehpbhi_p2_v3.0 order:01_02 participant_type:child collection:biological"
+          "labels": "event:birth instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_baby_name instrument:3.0:ins_que_birth_int_ehpbhi_p2_v3.0_baby_name references:2.0:ins_que_birth_int_ehpbhi_p2_v2.0 references:3.0:ins_que_birth_int_ehpbhi_p2_v3.0 order:01_02 participant_type:child collection:biological",
+          "study_segment": "HI-Intensity: Child"
       }
     })
   end

--- a/spec/models/psc/scheduled_activity_spec.rb
+++ b/spec/models/psc/scheduled_activity_spec.rb
@@ -32,6 +32,7 @@ module Psc
       it_maps 'grid_id' => 'activity_id'
       it_maps 'ideal_date' => 'ideal_date'
       it_maps 'labels' => 'labels'
+      it_maps 'responsible_user' => 'responsible_user'
       it_maps 'scheduled_date' => 'activity_date'
       it_maps 'subject.person_id' => 'person_id'
 
@@ -46,6 +47,7 @@ module Psc
       it_maps 'activity.name' => 'activity_name'
       it_maps 'activity.type' => 'activity_type'
       it_maps 'assignment.id' => 'person_id'
+      it_maps 'assignment.subject_coordinator.username' => 'responsible_user'
       it_maps 'current_state.date' => 'activity_date'
       it_maps 'current_state.name' => 'current_state'
       it_maps 'current_state.time' => 'activity_time'


### PR DESCRIPTION
This pull request contains a prerequisite for https://code.bioinformatics.northwestern.edu/issues/issues/show/3662.  In particular, this lays the foundation for event selection by data collector.

The only basis I have for the activity mappings established in this commit is "well, they're the only usernames I see in the activity JSON", which doesn't really mean anything.  Please review whether or not they're correct.

Additionally, I would like a word on whether or not the `if assign['subject_coordinator']` is actually required.  Some test data omits the assignment.subject_coordinator block, but it's possible that the test data is wrong, and I haven't yet dug into PSC's code or API docs to see what guarantees it provides.
