### PR TITLE
Kill defaults in PSC#scheduled_activities_report.  #3662.

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -23,7 +23,7 @@ class WelcomeController < ApplicationController
   end
 
   def overdue_activities
-    criteria = { :end_date => 1.day.ago.to_date.to_s }
+    criteria = { :end_date => 1.day.ago.to_date.to_s, :state => Psc::ScheduledActivity::SCHEDULED }
     @scheduled_activities = Psc::ScheduledActivityCollection.from_report(
         psc.scheduled_activities_report(criteria)).sort_by{ |sa| sa.activity_date }
     if params[:export] && @scheduled_activities
@@ -127,7 +127,7 @@ class WelcomeController < ApplicationController
       @end_date = Date.parse(params[:end_date]) unless params[:end_date].nil?
       @start_date = 1.day.ago.to_date if @start_date.nil?
       @end_date   = 6.weeks.from_now.to_date if @end_date.nil?
-      criteria = { :start_date => @start_date, :end_date => @end_date, :current_user => nil }
+      criteria = { :start_date => @start_date, :end_date => @end_date, :state => Psc::ScheduledActivity::SCHEDULED }
       criteria.merge!(options) if options
 
       psc.scheduled_activities_report(criteria)

--- a/lib/patient_study_calendar.rb
+++ b/lib/patient_study_calendar.rb
@@ -441,16 +441,14 @@ class PatientStudyCalendar
   private :participant_activities
 
   def scheduled_activities_report(options = {})
-    filters = {:state => Psc::ScheduledActivity::SCHEDULED, :end_date => 3.months.from_now.to_date.to_s, :current_user => nil }
-    filters.merge!(options)
+    params = {
+      'state' => options[:state],
+      'end-date' => options[:end_date],
+      'start-date' => options[:start_date],
+      'responsible-user' => options[:current_user]
+    }.reject { |_, v| v.blank? }
 
-    path = "reports/scheduled-activities.json?"
-    path << "state=#{filters[:state]}"
-    path << "&end-date=#{filters[:end_date]}" if filters[:end_date]
-    path << "&start-date=#{filters[:start_date]}" if filters[:start_date]
-    path << "&responsible-user=#{filters[:current_user]}" if filters[:current_user]
-
-    get(path)
+    get "reports/scheduled-activities.json?#{Rack::Utils.build_query(params)}"
   end
 
   ##


### PR DESCRIPTION
The [events API](https://code.bioinformatics.northwestern.edu/issues/wiki/ncs-navigator-core/Event_API) needs to be able to make queries that are otherwise blocked by defaults.  Two examples:
1. a scheduled activity report not filtered by state
2. a scheduled activity report whose end date is unspecified

@pfriedman and I think that the only places where defaults need to be filled in is `WelcomeController`, but `PatientStudyCalendar#scheduled_activities_report` is used in a lot of places, and frankly it's faster to submit this and ask others to check than it is to wait for the test suite to finish.  (Which might not check this sort of thing anyway.)  In other words: reviews needed.
