### PR TITLE
Prepopulate multi-part instruments for Field

### DIFF
--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -270,9 +270,7 @@ module Field
             when 'child'
               c.push(*pm.children.map(&:participant))
               if pm.children.empty?
-                if pm.participant
-                  c << pm.participant.build_child_person_and_participant
-                end
+                c << pm.participant.build_child_person_and_participant if pm.participant
               end
             else
               raise "Cannot resolve participant type '#{participant_type}'' for survey '#{resolved_survey.title}'"

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -255,7 +255,7 @@ module Field
         em  = m instrument.event
 
         instrument_plan.surveys.each do |survey|
-          sm  = m instrument.survey
+          sm  = m survey
           rm  = m instrument.referenced_survey
 
           participant_type = survey.participant_type.try(:content)

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -235,11 +235,7 @@ module Field
               c.push(*pm.children.map(&:participant))
               if pm.children.empty?
                 if pm.participant
-                  new_child_pa = pm.participant.build_child_person_and_participant
-                  prng = Random.new
-                  resolutions[prng.rand] = new_child_pa
-                  resolutions[prng.rand] = new_child_pa.person
-                  c << new_child_pa
+                  c << pm.participant.build_child_person_and_participant
                 end
               end
             else

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -241,7 +241,8 @@ module Field
             if !existing
               resolutions[derived] = ::Instrument.start(pm, pam, rm, sm, em)
             else
-              resolutions[derived] = pm.start_instrument(sm, pam, nil, em, existing)
+              response_set = existing.response_sets.detect { |rs| rs.survey == sm && rs.person == pm}
+              resolutions[derived] = pm.start_instrument(sm, pam, nil, em, existing) if !response_set
             end
           end
         end

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -273,7 +273,7 @@ module Field
                 c << pm.participant.build_child_person_and_participant if pm.participant
               end
             else
-              raise "Cannot resolve participant type '#{participant_type}'' for survey '#{resolved_survey.title}'"
+              raise "Cannot resolve participant type '#{participant_type}'' for survey '#{sm.title}'"
             end
           end
 

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -25,7 +25,7 @@ module Field
     end
 
     ##
-    # Intermediate instruments generated when impied instruments 
+    # Intermediate instruments generated when implied instruments 
     # (i.e. Psc::ImpliedEntities::Instrument) are resolved to entities from the 
     # Cases' database.
     def intermediate_instruments

--- a/app/models/field/model_resolution.rb
+++ b/app/models/field/model_resolution.rb
@@ -248,6 +248,10 @@ module Field
       end
     end
 
+    ###
+    # Builds a hash with the key the derived instrument
+    # and the value is an array of instrument data needed
+    # to start an instrument via ::Instrument#start
     def generate_intermediate_instruments
       instrument_plans.each do |instrument_plan|
         instrument = instrument_plan.root

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -352,6 +352,21 @@ class Participant < ActiveRecord::Base
      child_participant
   end
 
+  def build_child_person_and_participant(person_attrs = {})
+    child_person = Person.new(:psu_code => NcsNavigatorCore.psu)
+      # 6 - NCS Child - Participant Type
+    Participant.new(:psu_code => NcsNavigatorCore.psu, :p_type_code => 6).tap do |child_participant|
+      # Building participant_person_link instead of using person= because person= uses ids (which we don't have yet)
+      child_participant.participant_person_links.build(:relationship_code => 1, :participant => child_participant, :person => child_person, :psu => self.psu)
+      child_person.participant_person_links.build(:relationship_code => 1, :participant => child_participant, :person => child_person, :psu => self.psu)
+
+      # 2 - Mother, associating child participant with its mother - ParticipantPersonRelationship
+      self.participant_person_links.build(:participant => child_participant, :person => self.person, :relationship_code => 2)
+      # 8 - Child, associating mother participant with its child - ParticipantPersonRelationship
+      self.participant_person_links.build(:participant => self, :person => child_person, :relationship_code => 8)
+    end
+  end
+
   ##
   # True if the participant has children
   # @return[Boolean]

--- a/app/models/participant_person_link.rb
+++ b/app/models/participant_person_link.rb
@@ -44,8 +44,11 @@ class ParticipantPersonLink < ActiveRecord::Base
   # huge speedup in the importer; if validating the associated
   # instance is necessary, we should provide a scoped validation so it
   # can be excluded in the importer context.
-  validates_presence_of :person_id
-  validates_presence_of :participant_id
+  validates_presence_of :person_id, :on => :update
+  validates_presence_of :participant_id, :on => :update
+
+  validates_presence_of :person, :on => :create
+  validates_presence_of :participant, :on => :create
 
   def initialize(*args)
     super

--- a/features/api/fieldwork.feature
+++ b/features/api/fieldwork.feature
@@ -156,3 +156,83 @@ Feature: Fieldwork check-out and check-in
     Then the response body satisfies
       | /contacts/0/events/0/instruments/0/name | Pregnancy Probability Group Follow-Up SAQ       |
       | /contacts/0/events/0/instruments/1/name | Pregnancy Probability Group Follow-Up Interview |
+
+  Scenario: POST /api/v1/fieldwork returns instruments in template-prescribed order
+    This scenario relies on data in
+    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json; refer to
+    the Birth event in that file for more information.
+
+    Given an authenticated user
+    And the participant
+      | p_id              | abc-de-fghi         |
+      | person/first_name | Aria                |
+      | person/last_name  | Appleton            |
+      | person/person_id  | registered_with_psc |
+    And the event
+      | event_id         | f74a5ff2-100b-451e-902c-80ee08873144 |
+      | event_type       | Birth                                |
+      | event_start_date | 2013-04-24                           |
+    And the surveys
+      | instrument_version | title                                                  |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_part_one              |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_birth_visit_baby_name |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_part_two              |
+
+    When I POST /api/v1/fieldwork.json with
+      | start_date         | 2013-04-24 |
+      | end_date           | 2013-05-01 |
+      | header:X-Client-ID | 1234567890 |
+
+    Then the response body satisfies
+      | /contacts/0/events/0/name | Birth |
+      | /contacts/0/events/0/instruments/0/response_sets/0/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/1/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/2/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/0/p_id | abc-de-fghi |
+      | /contacts/0/events/0/instruments/0/response_sets/2/p_id | abc-de-fghi |
+    And the response body has "2" distinct values for "p_id" at "/contacts/0/events/0/instruments/0/response_sets"
+      
+  Scenario: POST /api/v1/fieldwork returns instruments in template-prescribed order
+    This scenario relies on data in
+    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json; refer to
+    the Birth event in that file for more information. This is for when the
+    child exists.
+
+    Given an authenticated user
+    And the participant
+      | p_id              | jkl-mn-opqr           |
+      | person/first_name | Baby                  |
+      | person/last_name  | Appleton              |
+      | person/person_id  | registered_with_psc_2 |
+    And the participant
+      | p_id              | abc-de-fghi         |
+      | person/first_name | Aria                |
+      | person/last_name  | Appleton            |
+      | person/person_id  | registered_with_psc |
+    And the participant person link
+      | p_id        | person_id             | relationship_code |
+      | abc-de-fghi | registered_with_psc_2 | 8                 |
+    And the event
+      | event_id         | f74a5ff2-100b-451e-902c-80ee08873144 |
+      | event_type       | Birth                                |
+      | event_start_date | 2013-04-24                           |
+    And the surveys
+      | instrument_version | title                                                  |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_part_one              |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_birth_visit_baby_name |
+      | 2.0                | ins_que_birth_int_ehpbhi_p2_v2.0_part_two              |
+
+    When I POST /api/v1/fieldwork.json with
+      | start_date         | 2013-04-24 |
+      | end_date           | 2013-05-01 |
+      | header:X-Client-ID | 1234567890 |
+
+    Then the response body satisfies
+      | /contacts/0/events/0/name | Birth |
+      | /contacts/0/events/0/instruments/0/response_sets/0/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/1/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/2/person_id | registered_with_psc |
+      | /contacts/0/events/0/instruments/0/response_sets/0/p_id | abc-de-fghi |
+      | /contacts/0/events/0/instruments/0/response_sets/1/p_id | jkl-mn-opqr |
+      | /contacts/0/events/0/instruments/0/response_sets/2/p_id | abc-de-fghi |
+      

--- a/features/api/fieldwork.feature
+++ b/features/api/fieldwork.feature
@@ -158,9 +158,9 @@ Feature: Fieldwork check-out and check-in
       | /contacts/0/events/0/instruments/1/name | Pregnancy Probability Group Follow-Up Interview |
 
   Scenario: POST /api/v1/fieldwork returns instruments in template-prescribed order
-    This scenario relies on data in
-    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json; refer to
-    the Birth event in that file for more information.
+    This scenarios tests fieldwork generation for the birth instrument before a
+    child has been created. It relies on data in
+    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json.
 
     Given an authenticated user
     And the participant
@@ -184,19 +184,18 @@ Feature: Fieldwork check-out and check-in
       | header:X-Client-ID | 1234567890 |
 
     Then the response body satisfies
-      | /contacts/0/events/0/name | Birth |
+      | /contacts/0/events/0/name                                    | Birth               |
       | /contacts/0/events/0/instruments/0/response_sets/0/person_id | registered_with_psc |
       | /contacts/0/events/0/instruments/0/response_sets/1/person_id | registered_with_psc |
       | /contacts/0/events/0/instruments/0/response_sets/2/person_id | registered_with_psc |
-      | /contacts/0/events/0/instruments/0/response_sets/0/p_id | abc-de-fghi |
-      | /contacts/0/events/0/instruments/0/response_sets/2/p_id | abc-de-fghi |
+      | /contacts/0/events/0/instruments/0/response_sets/0/p_id      | abc-de-fghi         |
+      | /contacts/0/events/0/instruments/0/response_sets/2/p_id      | abc-de-fghi         |
     And the response body has "2" distinct values for "p_id" at "/contacts/0/events/0/instruments/0/response_sets"
       
   Scenario: POST /api/v1/fieldwork returns instruments in template-prescribed order
-    This scenario relies on data in
-    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json; refer to
-    the Birth event in that file for more information. This is for when the
-    child exists.
+    This scenarios tests fieldwork generation for the birth instrument after a
+    child has been created. It relies on data in
+    features/fixtures/fakeweb/scheduled_activities_2013-04-24.json.
 
     Given an authenticated user
     And the participant
@@ -228,11 +227,11 @@ Feature: Fieldwork check-out and check-in
       | header:X-Client-ID | 1234567890 |
 
     Then the response body satisfies
-      | /contacts/0/events/0/name | Birth |
+      | /contacts/0/events/0/name                                    | Birth               |
       | /contacts/0/events/0/instruments/0/response_sets/0/person_id | registered_with_psc |
       | /contacts/0/events/0/instruments/0/response_sets/1/person_id | registered_with_psc |
       | /contacts/0/events/0/instruments/0/response_sets/2/person_id | registered_with_psc |
-      | /contacts/0/events/0/instruments/0/response_sets/0/p_id | abc-de-fghi |
-      | /contacts/0/events/0/instruments/0/response_sets/1/p_id | jkl-mn-opqr |
-      | /contacts/0/events/0/instruments/0/response_sets/2/p_id | abc-de-fghi |
+      | /contacts/0/events/0/instruments/0/response_sets/0/p_id      | abc-de-fghi         |
+      | /contacts/0/events/0/instruments/0/response_sets/1/p_id      | jkl-mn-opqr         |
+      | /contacts/0/events/0/instruments/0/response_sets/2/p_id      | abc-de-fghi         |
       

--- a/features/fixtures/fakeweb/scheduled_activities_2013-04-24.json
+++ b/features/fixtures/fakeweb/scheduled_activities_2013-04-24.json
@@ -1,0 +1,125 @@
+{
+    "filters": {
+        "end_date": "2013-05-01", 
+        "responsible_user": "jdi613", 
+        "start_date": "2013-04-24", 
+        "states": [
+            "Scheduled"
+        ]
+    }, 
+    "rows": [
+        {
+            "activity_name": "Birth Interview Part Two", 
+            "activity_status": "Scheduled", 
+            "activity_type": "Instrument", 
+            "details": "w/in 10 days of birth", 
+            "grid_id": "bf8bd56a-1e86-472d-a528-36896052c9c8", 
+            "ideal_date": "2013-04-24", 
+            "labels": [
+                "event:birth", 
+                "instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_part_two", 
+                "instrument:2.1:ins_que_birth_int_ehpbhi_p2_v2.0_part_two", 
+                "instrument:2.2:ins_que_birth_int_ehpbhi_p2_v2.0_part_two", 
+                "instrument:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_two", 
+                "instrument:3.1:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_two", 
+                "instrument:3.2:ins_que_birth_int_m3.2_v3.1_part_two", 
+                "order:01_03", 
+                "participant_type:mother", 
+                "references:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:2.1:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:2.2:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "references:3.1:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "references:3.2:ins_que_birth_int_m3.2_v3.1_part_one"
+            ], 
+            "last_change_reason": "Initialized from template", 
+            "responsible_user": "jdi613", 
+            "scheduled_date": "2013-04-24", 
+            "scheduled_study_segment": {
+                "grid_id": "8f852201-e7fc-4454-9f0b-5ad48f3400de", 
+                "start_date": "2013-04-24", 
+                "start_day": 1
+            }, 
+            "site": "Training", 
+            "study": "NCS Hi-Lo", 
+            "subject": {
+                "grid_id": "a0579e0f-d7a3-48b1-8cef-91d4bc7e71a0", 
+                "name": "Aria Appleton", 
+                "person_id": "registered_with_psc"
+            }
+        }, 
+        {
+            "activity_name": "Birth Interview Baby Name", 
+            "activity_status": "Scheduled", 
+            "activity_type": "Instrument", 
+            "details": "for each child", 
+            "grid_id": "36dcb0f5-8fb9-4f5b-8fc5-753dabb7fac7", 
+            "ideal_date": "2013-04-24", 
+            "labels": [
+                "event:birth", 
+                "instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_birth_visit_baby_name", 
+                "instrument:2.1:ins_que_birth_int_ehpbhi_p2_v2.0_birth_visit_baby_name", 
+                "instrument:2.2:ins_que_birth_int_ehpbhi_p2_v2.0_birth_visit_baby_name", 
+                "instrument:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_birth_visit_baby_name_3", 
+                "instrument:3.1:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_birth_visit_baby_name_3", 
+                "instrument:3.2:ins_que_birth_int_m3.2_v3.1_birth_visit_baby_name", 
+                "order:01_02", 
+                "participant_type:child", 
+                "references:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:2.1:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:2.2:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "references:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "references:3.1:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "references:3.2:ins_que_birth_int_m3.2_v3.1_part_one"
+            ], 
+            "last_change_reason": "Initialized from template", 
+            "responsible_user": "jdi613", 
+            "scheduled_date": "2013-04-24", 
+            "scheduled_study_segment": {
+                "grid_id": "8f852201-e7fc-4454-9f0b-5ad48f3400de", 
+                "start_date": "2013-04-24", 
+                "start_day": 1
+            }, 
+            "site": "Training", 
+            "study": "NCS Hi-Lo", 
+            "subject": {
+                "grid_id": "a0579e0f-d7a3-48b1-8cef-91d4bc7e71a0", 
+                "name": "Aria Appleton", 
+                "person_id": "registered_with_psc"
+            }
+        }, 
+        {
+            "activity_name": "Birth Interview Part One", 
+            "activity_status": "Scheduled", 
+            "activity_type": "Instrument", 
+            "grid_id": "f74a5ff2-100b-451e-902c-80ee08873144", 
+            "ideal_date": "2013-04-24", 
+            "labels": [
+                "event:birth", 
+                "instrument:2.0:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "instrument:2.1:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "instrument:2.2:ins_que_birth_int_ehpbhi_p2_v2.0_part_one", 
+                "instrument:3.0:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "instrument:3.1:ins_que_birth_int_ehpbhipbs_m3.0_v3.0_part_one", 
+                "instrument:3.2:ins_que_birth_int_m3.2_v3.1_part_one", 
+                "order:01_01", 
+                "participant_type:mother"
+            ], 
+            "last_change_reason": "Initialized from template", 
+            "responsible_user": "jdi613", 
+            "scheduled_date": "2013-04-24", 
+            "scheduled_study_segment": {
+                "grid_id": "8f852201-e7fc-4454-9f0b-5ad48f3400de", 
+                "start_date": "2013-04-24", 
+                "start_day": 1
+            }, 
+            "site": "Training", 
+            "study": "NCS Hi-Lo", 
+            "subject": {
+                "grid_id": "a0579e0f-d7a3-48b1-8cef-91d4bc7e71a0", 
+                "name": "Aria Appleton", 
+                "person_id": "registered_with_psc"
+            }
+        }
+    ]
+}

--- a/features/step_definitions/fieldwork_steps.rb
+++ b/features/step_definitions/fieldwork_steps.rb
@@ -63,3 +63,23 @@ Then /^I see the conflict report$/ do |table|
 
   table.diff!(actual)
 end
+
+Given /^the participant person link$/ do |table|
+  table.map_column!('relationship_code') { |c| c.to_i }
+  table.hashes.each do |hash|
+    p_id = hash.delete('p_id')
+    person_id = hash.delete('person_id')
+    hash.merge!(
+      :participant => Participant.where(:p_id => p_id).first, 
+      :person => Person.where(:person_id => person_id).first)
+
+    Factory(:participant_person_link, hash)
+  end
+end
+
+Then /^the response body has "([^"]*)" distinct values for "([^"]*)" at "([^"]*)"$/ do |count, element, root|
+  json = JSON.parse(last_response.body)
+  ptr = Hana::Pointer.new(root)
+  val = ptr.eval(json)
+  val.map{|v| v[element] }.uniq.size.should == count.to_i
+end

--- a/features/support/fakeweb.rb
+++ b/features/support/fakeweb.rb
@@ -38,7 +38,8 @@ FakeWeb.register_uri(:post, /\/api\/v1\/studies\/(.*)\/sites\/(.*)\/subject-assi
   %w(end-date=2005-07-30&responsible-user=test_user&start-date=2005-07-01&state=scheduled scheduled_activities_for_july_2005.json),
   %w(end-date=2012-03-01&responsible-user=test_user&start-date=2012-02-01&state=scheduled scheduled_activities_for_february.json),
   %w(end-date=2013-01-07&responsible-user=test_user&start-date=2013-01-01&state=scheduled scheduled_activities_2013-01-01.json),
-  %w(end-date=2013-04-13&responsible-user=test_user&start-date=2013-04-08&state=scheduled scheduled_activities_for_appointment_sheet.json)
+  %w(end-date=2013-04-13&responsible-user=test_user&start-date=2013-04-08&state=scheduled scheduled_activities_for_appointment_sheet.json),
+  %w(end-date=2013-05-01&responsible-user=test_user&start-date=2013-04-24&state=scheduled scheduled_activities_2013-04-24.json)
 ].each do |qs, fn|
   FakeWeb.register_uri(:get, %r[/api/v1/reports/scheduled-activities\.json\?#{qs}$],
                        :body => File.expand_path("../../fixtures/fakeweb/#{fn}", __FILE__),

--- a/spec/models/field/model_resolution_spec.rb
+++ b/spec/models/field/model_resolution_spec.rb
@@ -158,6 +158,39 @@ module Field
               instrument.survey.should == s
             end
           end
+
+          describe "the intermediate instruments" do
+            let(:derived) { report.intermediate_instruments.keys[0] }
+            let(:intermediate) { report.intermediate_instruments[derived][0] }
+
+            before do
+              report.reify_models
+            end
+
+            it "should generate one" do
+              report.intermediate_instruments[derived].size.should == 1
+            end
+
+            it "should have respondent" do
+              intermediate.respondent.should == p
+            end
+
+            it "should have a concerning participant" do
+              intermediate.concerning.should == pa
+            end
+
+            it "should have a survey" do
+              intermediate.survey.should == s
+            end
+
+            it "should not have a referenced survey" do
+              intermediate.referenced_survey.should be_nil
+            end
+
+            it "should have an event" do
+              intermediate.event.should == e
+            end
+          end
         end
       end
 

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -2769,4 +2769,29 @@ describe Participant do
     end
 
   end
+
+  describe "#build_child_person_and_participant" do
+    let!(:mother) { Factory(:participant) }
+    let!(:child) { mother.build_child_person_and_participant }
+
+    it "should be a new record" do
+      child.should be_new_record
+    end
+
+    it "should be linked to a person" do
+      child.person.should be_new_record
+    end
+
+    it "should make a person linked back to the participant" do
+      child.person.participant.should == child
+    end
+
+    it "should be child of mother" do
+      mother.children[0].should == child.person
+    end
+
+    it "should be child of mother" do
+      child.mother.should == mother.person
+    end
+  end
 end


### PR DESCRIPTION
Currently only the last response set in a multi-part instrument is sent to Field. This changes the instrument generation so all response sets are sent.

This is redmine ticket..
https://code.bioinformatics.northwestern.edu/issues/issues/show/3592
