### PR TITLE
Bug 4069 person is ineligible throwing it into error page

### DIFF
--- a/app/context/eligibility_adjudicator.rb
+++ b/app/context/eligibility_adjudicator.rb
@@ -6,12 +6,12 @@ module EligibilityAdjudicator
   module ClassMethods
     # Elibilility can be adjudicated for one or more participants and then ineligible
     # participants are disqualified from the study. See usage below:
-    # 
+    #
     # Participant.adjudicate_eligibility_and_disqualify_ineligible(
     # => participant1, participant2, participant3)
     #
     # @param [*Participant]
-    # @return [Hash] Participants grouped by eligibility. 
+    # @return [Hash] Participants grouped by eligibility.
     # => ex. {:eligible => [participant1, participant3], :ineligible => [participant2]}
     def adjudicate_eligibility_and_disqualify_ineligible(*participants)
       adjudicate_eligibility(*participants).tap do |adj|
@@ -44,6 +44,8 @@ module EligibilityAdjudicator
           delete_participant_person_links(p)
           disassociates_participant_from_all_events(p)
           disassociates_participant_from_response_sets(p)
+          delete_participant_consent_samples(p)
+          delete_participant_consents(p)
           remove_participant(p)
         end
       end
@@ -70,6 +72,14 @@ module EligibilityAdjudicator
 
     def disassociates_participant_from_response_sets(participant)
       participant.response_sets.each { |rs| rs.update_attribute(:participant_id, nil) }
+    end
+
+    def delete_participant_consent_samples(participant)
+      participant.participant_consents.each { |c| c.participant_consent_samples.destroy_all }
+    end
+
+    def delete_participant_consents(participant)
+      participant.participant_consents.destroy_all
     end
 
     def remove_participant(participant)

--- a/app/views/contact_links/_instruments_for_upcoming_events.html.haml
+++ b/app/views/contact_links/_instruments_for_upcoming_events.html.haml
@@ -9,5 +9,8 @@
   - participant = @contact_link.event.participant
   = link_to "New Child", new_child_people_path(:participant_id => participant.id, :contact_link_id => @contact_link.id),
     :class => "add_link icon_link", :confirm => "Are you certain you would like to create a new child record?"
+- elsif @event.participant.ineligible?
+  %p
+    Participant is ineligible. No further activities are necessary.
 - else
   = render "activity_list", :initial_instrument_for_contact => initial_instrument_for_contact


### PR DESCRIPTION
### Summary

Adding consents and consent samples to the records deleted when a participant is found to be ineligible. 

Preventing further activity links from showing if a participant is ineligible.
