### PR TITLE
Add household and dwelling unit identifier to instrument enumerator

### DIFF
--- a/app/models/communication_rank_cl_one.rb
+++ b/app/models/communication_rank_cl_one.rb
@@ -1,7 +1,7 @@
 # Helper methods for dealing with the COMMUNICATION_RANK_CL1 code list
 #
 module CommunicationRankCLOne
-  ORDER = [1, 2, -5, 3, 4, -4].map do |rank|
+  ORDER = [1, 2, 3, 4, -5, -4].map do |rank|
     NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', rank)
   end
 

--- a/app/models/communication_rank_cl_one.rb
+++ b/app/models/communication_rank_cl_one.rb
@@ -8,8 +8,11 @@ module CommunicationRankCLOne
   ##
   # Returns index of the COMMUNICATION_RANK_CL1 that can be used
   # by sort_by to rank from MOST -> LEAST important.
+  #
+  # If rank not found is RANK, size is returned
+  #
   # @return[Integer]
   def self.sort_by_index(rank)
-    ORDER.index(rank)
+    ORDER.include?(rank) ? ORDER.index(rank) : ORDER.size
   end
 end

--- a/app/models/communication_rank_cl_one.rb
+++ b/app/models/communication_rank_cl_one.rb
@@ -1,0 +1,15 @@
+# Helper methods for dealing with the COMMUNICATION_RANK_CL1 code list
+#
+module CommunicationRankCLOne
+  ORDER = [1, 2, -5, 3, 4, -4].map do |rank|
+    NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', rank)
+  end
+
+  ##
+  # Returns index of the COMMUNICATION_RANK_CL1 that can be used
+  # by sort_by to rank from MOST -> LEAST important.
+  # @return[Integer]
+  def self.sort_by_index(rank)
+    ORDER.index(rank)
+  end
+end

--- a/app/models/dwelling_household_link.rb
+++ b/app/models/dwelling_household_link.rb
@@ -47,9 +47,8 @@ class DwellingHouseholdLink < ActiveRecord::Base
 
   DU_RANK_ORDER = [1, 2, -5, 3, 4, -4]
   def self.order_by_rank(dwelling_household_links)
-    DU_RANK_ORDER.inject([]) do |accum, num|
-      found = dwelling_household_links.select{ |l| l.du_rank.local_code == num }
-      accum.push(*found)
+    dwelling_household_links.sort_by do |link|
+      DU_RANK_ORDER.index(link.du_rank.local_code)
     end
   end
 end

--- a/app/models/dwelling_household_link.rb
+++ b/app/models/dwelling_household_link.rb
@@ -45,5 +45,12 @@ class DwellingHouseholdLink < ActiveRecord::Base
   ncs_coded_attribute :is_active, 'CONFIRM_TYPE_CL2'
   ncs_coded_attribute :du_rank,   'COMMUNICATION_RANK_CL1'
 
+  DU_RANK_ORDER = [1, 2, -5, 3, 4, -4]
+  def self.order_by_rank(dwelling_household_links)
+    DU_RANK_ORDER.inject([]) do |accum, num|
+      found = dwelling_household_links.select{ |l| l.du_rank.local_code == num }
+      accum.push(*found)
+    end
+  end
 end
 

--- a/app/models/dwelling_household_link.rb
+++ b/app/models/dwelling_household_link.rb
@@ -45,10 +45,9 @@ class DwellingHouseholdLink < ActiveRecord::Base
   ncs_coded_attribute :is_active, 'CONFIRM_TYPE_CL2'
   ncs_coded_attribute :du_rank,   'COMMUNICATION_RANK_CL1'
 
-  DU_RANK_ORDER = [1, 2, -5, 3, 4, -4]
   def self.order_by_rank(dwelling_household_links)
     dwelling_household_links.sort_by do |link|
-      DU_RANK_ORDER.index(link.du_rank.local_code)
+      CommunicationRankCLOne.sort_by_index(link.du_rank)
     end
   end
 end

--- a/app/models/household_person_link.rb
+++ b/app/models/household_person_link.rb
@@ -42,7 +42,7 @@ class HouseholdPersonLink < ActiveRecord::Base
   HH_RANK_ORDER = [1, 2, -5, 3, 4, -4]
   def self.order_by_rank(household_person_links)
     HH_RANK_ORDER.inject([]) do |accum, num|
-      found = household_person_links.select{ |l| l.hh_rank == num }
+      found = household_person_links.select{ |l| l.hh_rank.local_code == num }
       accum.push(*found)
     end
   end

--- a/app/models/household_person_link.rb
+++ b/app/models/household_person_link.rb
@@ -41,9 +41,8 @@ class HouseholdPersonLink < ActiveRecord::Base
 
   HH_RANK_ORDER = [1, 2, -5, 3, 4, -4]
   def self.order_by_rank(household_person_links)
-    HH_RANK_ORDER.inject([]) do |accum, num|
-      found = household_person_links.select{ |l| l.hh_rank.local_code == num }
-      accum.push(*found)
+    household_person_links.sort_by do |link|
+      HH_RANK_ORDER.index(link.hh_rank.local_code)
     end
   end
 end

--- a/app/models/household_person_link.rb
+++ b/app/models/household_person_link.rb
@@ -38,5 +38,13 @@ class HouseholdPersonLink < ActiveRecord::Base
   ncs_coded_attribute :psu,       'PSU_CL1'
   ncs_coded_attribute :is_active, 'CONFIRM_TYPE_CL2'
   ncs_coded_attribute :hh_rank,   'COMMUNICATION_RANK_CL1'
+
+  HH_RANK_ORDER = [1, 2, -5, 3, 4, -4]
+  def self.order_by_rank(household_person_links)
+    HH_RANK_ORDER.inject([]) do |accum, num|
+      found = household_person_links.select{ |l| l.hh_rank == num }
+      accum.push(*found)
+    end
+  end
 end
 

--- a/app/models/household_person_link.rb
+++ b/app/models/household_person_link.rb
@@ -39,10 +39,9 @@ class HouseholdPersonLink < ActiveRecord::Base
   ncs_coded_attribute :is_active, 'CONFIRM_TYPE_CL2'
   ncs_coded_attribute :hh_rank,   'COMMUNICATION_RANK_CL1'
 
-  HH_RANK_ORDER = [1, 2, -5, 3, 4, -4]
   def self.order_by_rank(household_person_links)
     household_person_links.sort_by do |link|
-      HH_RANK_ORDER.index(link.hh_rank.local_code)
+      CommunicationRankCLOne.sort_by_index(link.hh_rank)
     end
   end
 end

--- a/app/models/household_unit.rb
+++ b/app/models/household_unit.rb
@@ -58,5 +58,9 @@ class HouseholdUnit < ActiveRecord::Base
   has_many :dwelling_units, :through => :dwelling_household_links
 
   accepts_nested_attributes_for :household_person_links, :allow_destroy => true
+
+  def highest_ranked_dwelling_household_link
+    DwellingHouseholdLink.order_by_rank(dwelling_household_links).first
+  end
 end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -387,10 +387,10 @@ class Person < ActiveRecord::Base
   end
 
   ##
-  # Returns the highest ranked HouseholdUnit associated with the person or nil
-  # @return[HouseholdUnit]
-  def primary_household_unit
-    primary_dwelling_household_link.try(:household_unit) || household_units.first
+  # Returns the highest ranked HouseholdPersonLink associated with the person or nil
+  # @return[HouseholdPersonLink]
+  def highest_ranked_household_person_link
+    HouseholdPersonLink.order_by_rank(household_person_links).first
   end
 
   ##

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -371,6 +371,29 @@ class Person < ActiveRecord::Base
   end
 
   ##
+  # Returns the highest ranked DwellingHouseholdLink associated with the person
+  # or nil
+  # @return[DwellingHouseholdLink]
+  def primary_dwelling_household_link
+    DwellingHouseholdLink.where(:dwelling_unit_id => dwelling_units
+                               ).order(:du_rank_code).first
+  end
+
+  ##
+  # Returns the highest ranked DwellingUnit associated with the person or nil
+  # @return[DwellingUnit]
+  def primary_dwelling_unit
+    primary_dwelling_household_link.try(:dwelling_unit)
+  end
+
+  ##
+  # Returns the highest ranked HouseholdUnit associated with the person or nil
+  # @return[HouseholdUnit]
+  def primary_household_unit
+    primary_dwelling_household_link.try(:household_unit) || household_units.first
+  end
+
+  ##
   # Returns true if a dwelling_unit has a tsu_is and this person has an association to the
   # tsu dwelling unit through their household
   # @return [true,false]

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -371,22 +371,6 @@ class Person < ActiveRecord::Base
   end
 
   ##
-  # Returns the highest ranked DwellingHouseholdLink associated with the person
-  # or nil
-  # @return[DwellingHouseholdLink]
-  def primary_dwelling_household_link
-    DwellingHouseholdLink.where(:dwelling_unit_id => dwelling_units
-                               ).order(:du_rank_code).first
-  end
-
-  ##
-  # Returns the highest ranked DwellingUnit associated with the person or nil
-  # @return[DwellingUnit]
-  def primary_dwelling_unit
-    primary_dwelling_household_link.try(:dwelling_unit)
-  end
-
-  ##
   # Returns the highest ranked HouseholdPersonLink associated with the person or nil
   # @return[HouseholdPersonLink]
   def highest_ranked_household_person_link

--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -19,7 +19,9 @@ module NcsNavigator::Core::Warehouse
       # sets.
       :person_id => 'response_sets.first.person.person_id',
       # TODO: See #3193
-      :ppg_first => 'response_sets.first.participant.ppg_details.first.ppg_first_code'
+      :ppg_first => 'response_sets.first.participant.ppg_details.first.ppg_first_code',
+      :hh_id => 'response_sets.first.person.primary_household_unit.public_id',
+      :du_id => 'response_sets.first.person.primary_dwelling_unit.public_id'
     }
 
     ##
@@ -114,6 +116,8 @@ module NcsNavigator::Core::Warehouse
     private :wh_resolve_internal_references
 
     def wh_select_best_match(response_bin, candidate_pairs)
+      if candidate_pairs.present?
+      end
       if candidate_pairs.size == 1
         return candidate_pairs.first.first
       end

--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -21,7 +21,7 @@ module NcsNavigator::Core::Warehouse
       # TODO: See #3193
       :ppg_first => 'response_sets.first.participant.ppg_details.first.ppg_first_code',
       :hh_id => 'response_sets.first.person.highest_ranked_household_person_link.household_unit.public_id',
-      :du_id => 'response_sets.first.person.primary_dwelling_unit.public_id'
+      :du_id => 'response_sets.first.person.highest_ranked_household_person_link.household_unit.highest_ranked_dwelling_household_link.dwelling_unit.public_id'
     }
 
     ##

--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -20,7 +20,7 @@ module NcsNavigator::Core::Warehouse
       :person_id => 'response_sets.first.person.person_id',
       # TODO: See #3193
       :ppg_first => 'response_sets.first.participant.ppg_details.first.ppg_first_code',
-      :hh_id => 'response_sets.first.person.primary_household_unit.public_id',
+      :hh_id => 'response_sets.first.person.highest_ranked_household_person_link.household_unit.public_id',
       :du_id => 'response_sets.first.person.primary_dwelling_unit.public_id'
     }
 
@@ -116,8 +116,6 @@ module NcsNavigator::Core::Warehouse
     private :wh_resolve_internal_references
 
     def wh_select_best_match(response_bin, candidate_pairs)
-      if candidate_pairs.present?
-      end
       if candidate_pairs.size == 1
         return candidate_pairs.first.first
       end

--- a/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
@@ -70,6 +70,20 @@ module NcsNavigator::Core::Warehouse
 
       let(:rs_participant) { Factory(:participant) }
       let(:rs_person) { Factory(:person) }
+      let(:dwelling_unit) { Factory(:dwelling_unit) }
+      let(:household_unit) { Factory(:household_unit) }
+      let(:dwelling_household_link) {
+        Factory(:dwelling_household_link,
+                :dwelling_unit => dwelling_unit,
+                :household_unit => household_unit
+               )
+      }
+      let(:household_person_link) {
+        Factory(:household_person_link,
+                :person => rs_person,
+                :household_unit => household_unit
+               )
+      }
       let(:response_set) {
         ResponseSet.new.tap { |rs|
           rs.survey = survey
@@ -140,11 +154,15 @@ module NcsNavigator::Core::Warehouse
         end
 
         it 'uses the public ID for the dwelling unit' do
-          pending 'Is this necessary? Documentation scarce.'
+          household_person_link.should_not be_nil
+          dwelling_household_link.should_not be_nil
+          primary.du_id.should == dwelling_unit.public_id
         end
 
         it 'uses the public ID for the household unit' do
-          pending 'Needs a different instrument'
+          pending "Needs a different mdes table."
+          household_person_link.should_not be_nil
+          primary.hh_id.should == household_unit.public_id
         end
 
         context do

--- a/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
@@ -50,14 +50,11 @@ module NcsNavigator::Core::Warehouse
     describe 'for a single-survey instrument' do
       let(:questions_dsl) {
         <<-DSL
-        q_health "Would you say your health in general is...",
+        q_hemophilia "Do you have hemophilia or any bleeding disorder?",
           :pick=>:one,
-          :data_export_identifier=>"PRE_PREG.HEALTH"
-          a_1 "Excellent"
-          a_2 "Very good,"
-          a_3 "Good,"
-          a_4 "Fair, or"
-          a_5 "Poor?"
+          :data_export_identifier=>"SPEC_BLOOD.HEMOPHILIA"
+          a_1 "Yes"
+          a_2 "No"
           a_neg_1 "Refused"
           a_neg_2 "Don't know"
         DSL
@@ -72,13 +69,13 @@ module NcsNavigator::Core::Warehouse
       let(:rs_person) { Factory(:person) }
       let(:dwelling_unit) { Factory(:dwelling_unit) }
       let(:household_unit) { Factory(:household_unit) }
-      let(:dwelling_household_link) {
+      let!(:dwelling_household_link) {
         Factory(:dwelling_household_link,
                 :dwelling_unit => dwelling_unit,
                 :household_unit => household_unit
                )
       }
-      let(:household_person_link) {
+      let!(:household_person_link) {
         Factory(:household_person_link,
                 :person => rs_person,
                 :household_unit => household_unit
@@ -95,11 +92,11 @@ module NcsNavigator::Core::Warehouse
       }
 
       context 'external references' do
-        let(:primary) { records.find { |rec| rec.class.mdes_table_name == 'pre_preg' } }
-        let(:question) { questions_map['health'] }
+        let(:primary) { records.find { |rec| rec.class.mdes_table_name == 'spec_blood' } }
+        let(:question) { questions_map['hemophilia'] }
         let!(:response) {
           create_response_for(question) { |r|
-            r.answer = question.answers.find_by_text('Excellent')
+            r.answer = question.answers.find_by_text('Yes')
           }
         }
 
@@ -109,7 +106,7 @@ module NcsNavigator::Core::Warehouse
         end
 
         it 'uses the imported ID as the PK if the responses were imported' do
-          response.source_mdes_table = 'pre_preg'
+          response.source_mdes_table = 'spec_blood'
           response.source_mdes_id = 'Eleventy-two'
           response.save!
 
@@ -154,14 +151,10 @@ module NcsNavigator::Core::Warehouse
         end
 
         it 'uses the public ID for the dwelling unit' do
-          household_person_link.should_not be_nil
-          dwelling_household_link.should_not be_nil
           primary.du_id.should == dwelling_unit.public_id
         end
 
         it 'uses the public ID for the household unit' do
-          pending "Needs a different mdes table."
-          household_person_link.should_not be_nil
           primary.hh_id.should == household_unit.public_id
         end
 
@@ -216,14 +209,14 @@ module NcsNavigator::Core::Warehouse
       end
 
       describe 'with a purely coded question' do
-        let(:question) { questions_map['health'] }
+        let(:question) { questions_map['hemophilia'] }
 
         it 'sets a positive code correctly' do
           create_response_for(question) { |r|
-            r.answer = question.answers.find_by_text('Poor?')
+            r.answer = question.answers.find_by_text('No')
           }
 
-          records.first.health.should == '5'
+          records.first.hemophilia.should == '2'
         end
 
         it 'sets a negative code correctly' do
@@ -231,7 +224,7 @@ module NcsNavigator::Core::Warehouse
             r.answer = question.answers.find_by_text('Refused')
           }
 
-          records.first.health.should == '-1'
+          records.first.hemophilia.should == '-1'
         end
       end
 

--- a/spec/models/dwelling_household_link_spec.rb
+++ b/spec/models/dwelling_household_link_spec.rb
@@ -51,5 +51,17 @@ describe DwellingHouseholdLink do
     end
   end
 
+  describe "#order_by_rank" do
+    let(:primary)   { Factory(:dwelling_household_link, :du_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', 1))  }
+    let(:secondary) { Factory(:dwelling_household_link, :du_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', 2))  }
+    let(:other)     { Factory(:dwelling_household_link, :du_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', -5)) }
+    let(:unordered) { [other, primary, secondary] }
+
+    it "should be ordered" do
+      DwellingHouseholdLink.order_by_rank(unordered).should == [primary, secondary, other]
+    end
+  end
+
+
 end
 

--- a/spec/models/household_person_link_spec.rb
+++ b/spec/models/household_person_link_spec.rb
@@ -53,5 +53,16 @@ describe HouseholdPersonLink do
     end
   end
 
+  describe "#order_by_rank" do
+    let(:primary)   { Factory(:household_person_link, :hh_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', 1))  }
+    let(:secondary) { Factory(:household_person_link, :hh_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', 2))  }
+    let(:other)     { Factory(:household_person_link, :hh_rank => NcsCode.for_list_name_and_local_code('COMMUNICATION_RANK_CL1', -5)) }
+    let(:unordered) { [other, primary, secondary] }
+
+    it "should have primary first" do
+      HouseholdPersonLink.order_by_rank(unordered).should == [primary, secondary, other]
+    end
+  end
+
 end
 


### PR DESCRIPTION
Added ability for the instrument enumerator to map household and dwelling unit ids.  It uses the public_id from the the highest ranking household or dwelling unit.

For bug details see..
https://code.bioinformatics.northwestern.edu/issues/issues/show/4121
