### PR TITLE
Store null event_start_dates in MDES format #4105

### DIFF
--- a/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator.rb
@@ -128,7 +128,12 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -139,10 +144,11 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator.rb
@@ -128,7 +128,12 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -139,10 +144,11 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator.rb
@@ -128,7 +128,12 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -139,10 +144,11 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator.rb
@@ -162,7 +162,12 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -173,10 +178,11 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator.rb
@@ -161,7 +161,12 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -172,10 +177,11 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
+++ b/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator.rb
@@ -162,7 +162,12 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
             WHEN t.event_end_date IS NULL
                  THEN t.event_disposition % 500
             ELSE t.event_disposition % 500 + 500
-            END) normalized_event_disposition}
+            END) normalized_event_disposition},
+        %q{(CASE
+            WHEN t.event_start_date IS NULL
+                 THEN '9666-96-96'
+            ELSE to_char(t.event_start_date, 'YYYY-MM-DD')
+            END) non_null_event_start_date}
       ],
       :where => %q{
         t.event_disposition IS NOT NULL OR
@@ -173,10 +178,11 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         :normalized_event_disposition => :event_disp,
         :event_disposition_category_code => :event_disp_cat,
         :event_incentive_cash => :event_incent_cash,
-        :event_incentive_noncash => :event_incent_noncash
+        :event_incentive_noncash => :event_incent_noncash,
+        :non_null_event_start_date => :event_start_date
       },
       :ignored_columns => %w(event_disposition scheduled_study_segment_identifier
-        psc_ideal_date lock_version imported_invalid)
+        psc_ideal_date lock_version imported_invalid event_start_date)
     )
 
     produce_one_for_one(:instruments, :Instrument,

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_one/operational_enumerator_spec.rb
@@ -596,6 +596,18 @@ module NcsNavigator::Core::Warehouse::ThreePointOne
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_two/operational_enumerator_spec.rb
@@ -596,6 +596,18 @@ module NcsNavigator::Core::Warehouse::ThreePointTwo
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil

--- a/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/three_point_zero/operational_enumerator_spec.rb
@@ -596,6 +596,18 @@ module NcsNavigator::Core::Warehouse::ThreePointZero
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_one/operational_enumerator_spec.rb
@@ -594,6 +594,18 @@ module NcsNavigator::Core::Warehouse::TwoPointOne
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_two/operational_enumerator_spec.rb
@@ -594,6 +594,18 @@ module NcsNavigator::Core::Warehouse::TwoPointTwo
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil

--- a/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/two_point_zero/operational_enumerator_spec.rb
@@ -594,6 +594,18 @@ module NcsNavigator::Core::Warehouse::TwoPointZero
         results.first.participant_id.should == Participant.first.p_id
       end
 
+      it 'uses MDES "unknown" date on null event_start_date' do
+        event.event_start_date = nil
+        event.save!
+        results.first.event_start_date.should == '9666-96-96'
+      end
+
+      it 'uses the event\'s event_start_date if event_start_date is not null' do
+        event.event_start_date = '2013-05-15'
+        event.save!
+        results.first.event_start_date.should == '2013-05-15'
+      end
+
       describe 'with no disposition' do
         before do
           event.event_disposition = nil


### PR DESCRIPTION
Cases can't store event_start_date in the 'special' MDES date format, and instead makes it null when importing.  Warehouse refuses to take nulls for event_start_date and so we make them into MDES formatted strings signifying an unknow date: `9666-96-96` during operational enumeration.
