### PR TITLE
Fix interaction of field log writer with worker forking

### DIFF
--- a/config/initializers/field_log_writer.rb
+++ b/config/initializers/field_log_writer.rb
@@ -1,8 +1,19 @@
 require 'celluloid'
 
-log_writer_name = NcsNavigator::Core::Field::LogDevice.file_writer_name
-NcsNavigator::Core::Field::LogDevice.file_writer.supervise_as log_writer_name
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    log_writer_name = NcsNavigator::Core::Field::LogDevice.file_writer_name
+    NcsNavigator::Core::Field::LogDevice.file_writer.supervise_as log_writer_name
 
-at_exit do
-  Celluloid::Actor[log_writer_name].close
+    at_exit do
+      Celluloid::Actor[log_writer_name].close
+    end
+  end
+else
+  log_writer_name = NcsNavigator::Core::Field::LogDevice.file_writer_name
+  NcsNavigator::Core::Field::LogDevice.file_writer.supervise_as log_writer_name
+
+  at_exit do
+    Celluloid::Actor[log_writer_name].close
+  end
 end


### PR DESCRIPTION
`fork(2)` copies only a single thread from its parent process, which is the thread that called `fork(2)`.  All other parent threads do not exist in the child.  

Ruby 1.9.x maps Ruby threads to system threads, so we need to account for this.  (Previously, we weren't accounting for this, which meant that the field log writer wasn't responding to messages at all.)

The accounting method is pretty simple: if we're in a known workers-will-fork situation, then we start the field log writer supervisor (and, by extension, the writer) for each worker process (not the master).  If we're not in a situation like that, we assume starting the writer supervisor at startup is the right thing to do.  AFAICT, this covers all NUBIC use cases.
