### PR TITLE
Address proper event; restore dependent PSC fixture.

### DIFF
--- a/spec/fixtures/vcr_cassettes/psc/schedules_with_labels.yml
+++ b/spec/fixtures/vcr_cassettes/psc/schedules_with_labels.yml
@@ -2,6 +2,221 @@
 http_interactions:
 - request:
     method: get
+    uri: https://ncsn-psc.local/api/v1/subjects/test/schedules.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic cGZyOTU3OnBzYw==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - Restlet-Framework/2.0.3
+      Date:
+      - Fri, 26 Aug 2011 18:54:05 GMT
+      Vary:
+      - Accept-Charset, Accept-Encoding, Accept-Language, Accept
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Transfer-Encoding:
+      - chunked
+      Pragma:
+      - no-cache
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+            "days": {
+                "2011-08-29": {
+                    "activities": [
+                        {
+                            "activity": {
+                                "name": "Pregnancy Screener Instrument",
+                                "type": "Instrument"
+                            },
+                            "assignment": {
+                                "id": "todo_1314638760",
+                                "name": "NCS Hi-Lo",
+                                "privileges": [
+                                    "update"
+                                ],
+                                "subject_coordinator": {
+                                    "username": "pfr957"
+                                }
+                            },
+                            "current_state": {
+                                "date": "2011-08-29",
+                                "name": "scheduled",
+                                "reason": "Initialized from template"
+                            },
+                            "formatted_plan_day": "Day 1",
+                            "id": "c32af1e0-3483-4a28-87b4-1b2019abc082",
+                            "ideal_date": "2011-08-29",
+                            "labels": "event:pregnancy_screener",
+                            "plan_day": "1",
+                            "state_history": [
+                                {
+                                    "date": "2011-08-29",
+                                    "name": "scheduled",
+                                    "reason": "Initialized from template"
+                                }
+                            ],
+                            "study": "NCS Hi-Lo",
+                            "study_segment": "LO-Intensity: Pregnancy Screener",
+                            "subject": "Ella Fitzgerald"
+                        }
+                    ],
+                    "hidden_activities": "false"
+                },
+                "2011-10-01": {
+                    "activities": [
+                        {
+                            "activity": {
+                                "name": "Pregnancy Visit 1 Instrument",
+                                "type": "Instrument"
+                            },
+                            "assignment": {
+                                "id": "todo_1317445200",
+                                "name": "NCS Hi-Lo",
+                                "privileges": [
+                                    "update"
+                                ],
+                                "subject_coordinator": {
+                                    "username": "abc123"
+                                }
+                            },
+                            "current_state": {
+                                "date": "2011-10-01",
+                                "name": "scheduled",
+                                "reason": "Initialized from template"
+                            },
+                            "formatted_plan_day": "Day 1",
+                            "id": "7afb008d-2e6a-422d-8332-55c63f57ed3f",
+                            "ideal_date": "2011-09-03",
+                            "labels": "event:pregnancy_visit_1",
+                            "plan_day": "1",
+                            "state_history": [
+                                {
+                                    "date": "2011-09-03",
+                                    "name": "scheduled",
+                                    "reason": "Initialized from template"
+                                },
+                                {
+                                    "date": "2011-09-27",
+                                    "name": "scheduled",
+                                    "reason": "Bumped"
+                                }
+                            ],
+                            "study": "NCS Hi-Lo",
+                            "study_segment": "LO-Intensity: Pregnancy Screener",
+                            "subject": "Ella Fitzgerald"
+                        }
+                    ],
+                    "hidden_activities": "false"
+                },
+                "2011-12-01": {
+                    "activities": [
+                        {
+                            "activity": {
+                                "name": "Pregnancy Visit 1 Instrument",
+                                "type": "Instrument"
+                            },
+                            "assignment": {
+                                "id": "todo_1317445200",
+                                "name": "NCS Hi-Lo",
+                                "privileges": [
+                                    "update"
+                                ],
+                                "subject_coordinator": {
+                                    "username": "pfr957"
+                                }
+                            },
+                            "current_state": {
+                                "date": "2011-12-01",
+                                "name": "scheduled",
+                                "reason": "Initialized from template"
+                            },
+                            "formatted_plan_day": "Day 1",
+                            "id": "23f0a2c7-785b-48ab-81a7-289c4ff45543",
+                            "ideal_date": "2011-11-25",
+                            "labels": "event:pregnancy_visit_1",
+                            "plan_day": "1",
+                            "state_history": [
+                                {
+                                    "date": "2011-11-25",
+                                    "name": "scheduled",
+                                    "reason": "Initialized from template"
+                                },
+                                {
+                                    "date": "2011-11-27",
+                                    "name": "scheduled",
+                                    "reason": "Bumped"
+                                }
+                            ],
+                            "study": "NCS Hi-Lo",
+                            "study_segment": "LO-Intensity: Pregnancy Screener",
+                            "subject": "Ella Fitzgerald"
+                        }
+                    ],
+                    "hidden_activities": "false"
+                }
+            },
+            "study_segments": [
+                {
+                    "assignment": {
+                        "id": "todo_1314638760",
+                        "name": "NCS Hi-Lo",
+                        "privileges": [
+                            "update"
+                        ],
+                        "subject_coordinator": {
+                            "username": "pfr957"
+                        }
+                    },
+                    "id": "3a0e383d-e3d0-4756-ae61-4d2de92067e7",
+                    "name": "LO-Intensity: Pregnancy Screener",
+                    "planned": {
+                        "epoch": {
+                            "id": "73f6c858-4069-411a-8d82-c9d558c07d68",
+                            "name": "LO-Intensity"
+                        },
+                        "segment": {
+                            "id": "6caf9143-bfb0-47e4-b1e4-ccc810a4cbc8",
+                            "name": "Pregnancy Screener"
+                        },
+                        "study": {
+                            "assigned_identifier": "NCS Hi-Lo"
+                        }
+                    },
+                    "range": {
+                        "start_date": "2011-08-29",
+                        "stop_date": "2011-08-29"
+                    },
+                    "subject": "Ella Fitzgerald"
+                }
+            ],
+            "subject": {
+                "birth_date": "1931-08-29",
+                "first_name": "Ella",
+                "full_name": "Ella Fitzgerald",
+                "gender": "Male",
+                "last_first": "Fitzgerald, Ella",
+                "last_name": "Fitzgerald",
+                "properties": []
+            }
+        }
+    http_version: '1.1'
+  recorded_at: Thu, 10 Jan 2013 18:04:42 GMT
+- request:
+    method: get
     uri: https://ncsn-psc.local/api/v1/reports/scheduled-activities.json?end-date=2011-10-30&start-date=2011-08-01
     body:
       encoding: US-ASCII

--- a/spec/integration/models/event_spec.rb
+++ b/spec/integration/models/event_spec.rb
@@ -9,7 +9,7 @@ describe Event do
     include_context 'event-PSC linkage'
 
     it 'loads scheduled activities for each event in a relation' do
-      es = Event.where(:id => [screener, pv1].map(&:id)).with_psc_data(psc)
+      es = Event.where(:id => [screener, pv1_1].map(&:id)).with_psc_data(psc)
 
       es.length.should == 2
       es.all? { |e| e.scheduled_activities.length == 1 }.should be_true


### PR DESCRIPTION
99d2028c77c646e5be7334cb082fec54e745c0f7 erroneously removed a test fixture used by the spec affected in this commit.   This commit restores that fixture and updates said spec for other changes in the event-PSC linkage context.
