### PR TITLE
ODE email, phone processors take mdes codes #4262

### DIFF
--- a/app/models/operational_data_extractor/base.rb
+++ b/app/models/operational_data_extractor/base.rb
@@ -761,7 +761,7 @@ module OperationalDataExtractor
 
     def process_telephone(owner, map, phone_type = home_phone_type, phone_rank = primary_rank)
       phone_nr = value_by_attribute(map, 'phone_nbr')
-      return if !phone_nr || phone_nr.empty?
+      return if phone_nr.blank? || !phone_nr.is_a?(String)
 
       phone = find_or_create_telephone(owner, phone_nr, phone_type, phone_rank)
       map.each do |key, attribute|
@@ -797,7 +797,7 @@ module OperationalDataExtractor
 
     def process_email(map, email_type = personal_email_type)
       email_address = value_by_attribute(map, 'email')
-      return if !email_address or email_address.empty?
+      return if email_address.blank? || !email_address.is_a?(String)
 
       email = find_or_create_email(person, email_address, email_type)
       map.each do |key, attribute|

--- a/spec/support/test_surveys/tracing.rb
+++ b/spec/support/test_surveys/tracing.rb
@@ -70,9 +70,15 @@ module Tracing
     # Home Phone
     q = Factory(:question, :reference_identifier => "HOME_PHONE", :data_export_identifier => "TRACING_INT.HOME_PHONE", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Phone Number", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "REFUSED", :response_class => "answer", :reference_identifier => "neg_1")
+    a = Factory(:answer, :question_id => q.id, :text => "DON'T KNOW", :response_class => "answer", :reference_identifier => "neg_2")
+    a = Factory(:answer, :question_id => q.id, :text => "NO HOME PHONE", :response_class => "answer", :reference_identifier => "neg_7")
     # Cell Phone
     q = Factory(:question, :reference_identifier => "CELL_PHONE", :data_export_identifier => "TRACING_INT.CELL_PHONE", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Phone Number", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "REFUSED", :response_class => "answer", :reference_identifier => "neg_1")
+    a = Factory(:answer, :question_id => q.id, :text => "DON'T KNOW", :response_class => "answer", :reference_identifier => "neg_2")
+    a = Factory(:answer, :question_id => q.id, :text => "NO CELL PHONE", :response_class => "answer", :reference_identifier => "neg_7")
     # Can call cell?
     q = Factory(:question, :reference_identifier => "CELL_PHONE_2", :data_export_identifier => "TRACING_INT.CELL_PHONE_2", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Yes", :response_class => "answer", :reference_identifier => "1")
@@ -91,6 +97,9 @@ module Tracing
     # Email
     q = Factory(:question, :reference_identifier => "EMAIL", :data_export_identifier => "TRACING_INT.EMAIL", :survey_section_id => survey_section.id)
     a = Factory(:answer, :question_id => q.id, :text => "Email", :response_class => "string")
+    a = Factory(:answer, :question_id => q.id, :text => "REFUSED", :response_class => "answer", :reference_identifier => "neg_1")
+    a = Factory(:answer, :question_id => q.id, :text => "DON'T KNOW", :response_class => "answer", :reference_identifier => "neg_2")
+    a = Factory(:answer, :question_id => q.id, :text => "NO EMAIL ACCOUNT", :response_class => "answer", :reference_identifier => "neg_7")
 
     survey
   end


### PR DESCRIPTION
ODE phone and email processors made assumptions that value being extracted is either a string or nil.  This patch checks to make sure that we only extract if value is a non-empty string.
