### PR TITLE
Fix CI Error Specs #4257

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,7 +40,6 @@ Factory.define :person do |pers|
   pers.person_comment                 nil
   pers.transaction_type               nil
   pers.person_id                      nil
-  pers.household_units { |household| [household.association(:household_unit)] }
 end
 
 Factory.define :person_race do |pr|

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -637,11 +637,6 @@ describe Person do
     describe "#in_tsu?" do
 
       describe "without associated addresses or household_units" do
-        before do
-          person.addresses.should be_empty
-          person.household_units.should be_empty
-        end
-
         it "is not in a tsu" do
           person.should_not be_in_tsu
         end
@@ -653,7 +648,6 @@ describe Person do
           before do
             du.update_attribute(:tsu_id, "tsu_id")
             person.addresses << Factory(:address, :person => person, :dwelling_unit => du)
-            person.household_units.should be_empty
           end
 
           it "is in a tsu" do
@@ -665,10 +659,10 @@ describe Person do
           before do
             du.tsu_id.should be_nil
             person.addresses << Factory(:address, :person => person, :dwelling_unit => du)
-            person.household_units.should be_empty
           end
 
           it "is not in a tsu" do
+            person.addresses.reload
             person.should_not be_in_tsu
           end
         end
@@ -687,6 +681,7 @@ describe Person do
           end
 
           it "is in a tsu" do
+            person.household_units.reload
             person.should be_in_tsu
           end
         end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -518,7 +518,7 @@ describe Person do
           Factory(:dwelling_household_link, :dwelling_unit => du, :household_unit => hu)
           Factory(:household_person_link, :person => person, :household_unit => hu)
           person.addresses.should be_empty
-          person.reload.dwelling_units.should == [du]
+          person.dwelling_units.should == [du]
         end
       end
 
@@ -661,7 +661,7 @@ describe Person do
           end
 
           it "is not in a tsu" do
-            person.reload.should_not be_in_tsu
+            person.should_not be_in_tsu
           end
         end
 
@@ -679,7 +679,7 @@ describe Person do
           end
 
           it "is in a tsu" do
-            person.reload.should be_in_tsu
+            person.should be_in_tsu
           end
         end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -499,54 +499,36 @@ describe Person do
     let(:hu) { Factory(:household_unit) }
 
     describe "#dwelling_units" do
-
       describe "without associated addresses or household_units" do
-        before do
-          person.addresses.should be_empty
-          person.household_units.should be_empty
-        end
-
         it "is empty when the person addresses and household_units associations are empty" do
+          person.addresses.should be_empty
           person.dwelling_units.should be_empty
         end
       end
 
       describe "with associated addresses but no household_unit association" do
-
-        before do
-          person.addresses << Factory(:address, :person => person, :dwelling_unit => du)
-          person.household_units.should be_empty
-        end
-
         it "returns the person addresses dwelling_unit associations" do
+          person.addresses << Factory(:address, :person => person, :dwelling_unit => du)
           person.dwelling_units.should == [du]
         end
       end
 
       describe "with associated household units but no address association" do
-
-        before do
+        it "returns the person household_units dwelling_unit associations" do
           Factory(:dwelling_household_link, :dwelling_unit => du, :household_unit => hu)
           Factory(:household_person_link, :person => person, :household_unit => hu)
-
+          person.household_units.reload
           person.addresses.should be_empty
-        end
-
-        it "returns the person household_units dwelling_unit associations" do
           person.dwelling_units.should == [du]
         end
       end
 
       describe "with household units and addresses associations" do
-
-        before do
+        it "returns the all uniq dwelling_unit associations" do
           Factory(:dwelling_household_link, :dwelling_unit => du, :household_unit => hu)
           Factory(:household_person_link, :person => person, :household_unit => hu)
           person.addresses << Factory(:address, :person => person, :dwelling_unit => du)
           person.addresses << Factory(:address, :person => person, :dwelling_unit => du2)
-        end
-
-        it "returns the all uniq dwelling_unit associations" do
           person.dwelling_units.should == [du, du2]
         end
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -517,9 +517,8 @@ describe Person do
         it "returns the person household_units dwelling_unit associations" do
           Factory(:dwelling_household_link, :dwelling_unit => du, :household_unit => hu)
           Factory(:household_person_link, :person => person, :household_unit => hu)
-          person.household_units.reload
           person.addresses.should be_empty
-          person.dwelling_units.should == [du]
+          person.reload.dwelling_units.should == [du]
         end
       end
 
@@ -662,8 +661,7 @@ describe Person do
           end
 
           it "is not in a tsu" do
-            person.addresses.reload
-            person.should_not be_in_tsu
+            person.reload.should_not be_in_tsu
           end
         end
 
@@ -681,8 +679,7 @@ describe Person do
           end
 
           it "is in a tsu" do
-            person.household_units.reload
-            person.should be_in_tsu
+            person.reload.should be_in_tsu
           end
         end
 


### PR DESCRIPTION
The factory for person had household_units auto associated to it and therefore caused errors to happen in certain specs. This is because specs expected household units to be empty in which it really had 1 record because of the person factory having that association set. This was also the root of warehouse specs failing. This line is unnecessary and if needed, can really be tied in the spec. Specs are now passing again.
