### PR TITLE
#4257 fix ci errors revised

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ group :development, :test, :ci do
 
   gem 'ci_reporter'
   gem 'pry'
+  gem 'pry-debugger'
 end
 
 group :test, :ci do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,9 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-debugger (0.2.2)
+      debugger (~> 1.3)
+      pry (~> 0.9.10)
     psc (0.0.2)
       activesupport (>= 2.3)
       builder (>= 2.1.2)
@@ -521,6 +524,7 @@ DEPENDENCIES
   pg
   pickle
   pry
+  pry-debugger
   psc
   rack-test
   rails (= 3.2.13)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,7 +40,6 @@ Factory.define :person do |pers|
   pers.person_comment                 nil
   pers.transaction_type               nil
   pers.person_id                      nil
-  pers.household_units { |household| [household.association(:household_unit)] }
 end
 
 Factory.define :person_race do |pr|


### PR DESCRIPTION
The factory for person had household_units auto associated to it and therefore caused errors to happen in certain specs. This is because specs expected household units to be empty in which it really had 1 record because of the person factory having that association set. This was also the root of warehouse specs failing. This line is unnecessary and if needed, can really be tied in the spec. Specs are now passing again.
