### PR TITLE
Require at least one NCS role to access GET /api/v1/events.

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,4 +1,6 @@
 class Api::EventsController < ApiController
+  permit *Role::ALL_ROLES
+
   def index
     range = params[:scheduled_date]
     codes = params[:types].try(:map, &:to_i)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -2,16 +2,18 @@
 
 
 module Role
-  SYSTEM_ADMINISTRATOR          = "System Administrator"
-  USER_ADMINISTRATOR            = "User Administrator"
-  STAFF_SUPERVISOR              = "Staff Supervisor"
-  FIELD_STAFF                   = "Field Staff"
-  PHONE_STAFF                   = "Phone Staff"
-  OUTREACH_STAFF                = "Outreach Staff"
-  BIOLOGICAL_SPECIMEN_COLLECTOR = "Biological Specimen Collector"
-  SPECIMEN_PROCESSOR            = "Specimen Processor"
-  DATA_READER                   = "Data Reader"
-  ADMINISTRATIVE_STAFF          = "Administrative Staff"
+  ALL_ROLES = [
+    SYSTEM_ADMINISTRATOR          = "System Administrator",
+    USER_ADMINISTRATOR            = "User Administrator",
+    STAFF_SUPERVISOR              = "Staff Supervisor",
+    FIELD_STAFF                   = "Field Staff",
+    PHONE_STAFF                   = "Phone Staff",
+    OUTREACH_STAFF                = "Outreach Staff",
+    BIOLOGICAL_SPECIMEN_COLLECTOR = "Biological Specimen Collector",
+    SPECIMEN_PROCESSOR            = "Specimen Processor",
+    DATA_READER                   = "Data Reader",
+    ADMINISTRATIVE_STAFF          = "Administrative Staff"
+  ]
 
   SUPERVISORS = [SYSTEM_ADMINISTRATOR, USER_ADMINISTRATOR, ADMINISTRATIVE_STAFF, STAFF_SUPERVISOR]
 end

--- a/config/logins/static_auth.yml
+++ b/config/logins/static_auth.yml
@@ -11,7 +11,7 @@ users:
       staff_id: test_user
     portals:
       - NCSNavigator:
-        - staff
+        - Field Staff
     last_name: Usr
     email: t-usr@dev.null
     first_name: T.
@@ -22,7 +22,7 @@ users:
       staff_id: staff_user
     portals:
       - NCSNavigator:
-        - staff_user
+        - Field Staff
     last_name: Usr
     email: staff_user@dev.null
     first_name: staff
@@ -48,3 +48,12 @@ users:
     last_name: Usr
     email: spec_proc@dev.null
     first_name: specimen
+
+  no_portal:
+    password: no_portal
+    portals: []
+
+  no_roles:
+    password: no_roles
+    portals:
+      - NCSNavigator

--- a/features/api/events.feature
+++ b/features/api/events.feature
@@ -40,3 +40,21 @@ Feature: Event search API
 
     Then the response status is 200
     And the response body satisfies the event search schema
+
+  Scenario: GET /api/v1/events returns 403 for users with no NCS roles
+    Given I log in as "no_roles"
+
+    When I GET /api/v1/events with
+      | header:X-Client-ID | foo |
+      | types[]            | 10  |
+
+    Then the response status is 403
+
+  Scenario: GET /api/v1/events returns 403 for users not in the correct portal
+    Given I log in as "no_portal"
+
+    When I GET /api/v1/events with
+      | header:X-Client-ID | foo |
+      | types[]            | 10  |
+
+    Then the response status is 403

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -49,7 +49,6 @@ Around do |scenario, block|
 end
 
 Given /^an authenticated user with a role of "([^"]*)"$/ do |role|
-
   config = NcsNavigatorCore.configuration
   config.suite_configuration.core["with_specimens"] = 'true'
 
@@ -74,5 +73,16 @@ Given /^an authenticated user with a role of "([^"]*)"$/ do |role|
       And I press "Log in"
     }
   end
+end
 
+Given /^an authenticated user not in the NCSNavigator portal$/ do
+  steps %Q{
+    Given I log in as "no_portal"
+  }
+end
+
+Given /^an authenticated user with no roles$/ do
+  steps %Q{
+    Given I log in as "no_roles"
+  }
 end


### PR DESCRIPTION
We need to require that authenticated users belong to at least one NCS role, too.

This applies to develop (which will happen transitively when 1.8.0 is merged back to master and master to develop) and 1.7.0.pbs.  I'm handling the PBS release.
