### PR TITLE
#3916 edit survey responses for non participants

### DIFF
--- a/app/controllers/surveyor_controller.rb
+++ b/app/controllers/surveyor_controller.rb
@@ -10,7 +10,16 @@ class SurveyorController < ApplicationController
   # Overridden from Surveyor::SurveyorControllerMethods
   # to handle Operational Data Extraction and to determine
   # whether or not this is a part of a multi-part survey
+  # if no participant, person url is specified for redirect
   def surveyor_finish
+    if @response_set.participant
+      finish_off_participant
+    else
+      @response_set.person
+    end
+  end
+
+  def finish_off_participant
     # sets @event and @participant
     set_activity_plan_for_participant
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -94,7 +94,7 @@ class WelcomeController < ApplicationController
     end
 
     def create_pregnancy_screener_event_record
-      dates = create_screener_event_record(NcsCode.pregnancy_screener)
+      dates = create_screener_activity_in_psc(NcsCode.pregnancy_screener)
       create_screener_event_record(NcsCode.pregnancy_screener, dates) unless dates.empty?
     end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -51,70 +51,72 @@ class WelcomeController < ApplicationController
 
   def start_pregnancy_screener_instrument
     person = Person.create(:psu_code => @psu_code)
-    participant = Participant.create(:psu_code => @psu_code)
-    participant.person = person
-    household = HouseholdUnit.create!
-    HouseholdPersonLink.create!(:person => person, :household_unit => household)
-    participant.save!
+    resp = prepare_for_screener(person)
 
-    resp = psc.assign_subject(participant)
     if resp && resp.status.to_i < 299
-      create_pregnancy_screener_event_record(participant)
+      create_pregnancy_screener_event_record
       redirect_to new_person_contact_path(person)
     else
-      destroy_participant_and_redirect(participant, person, resp)
+      destroy_participant_and_redirect(@participant, person, resp)
     end
   end
 
   def start_pbs_eligibility_screener_instrument
     person = Person.find(params[:person_id])
+    resp = prepare_for_screener(person)
+
     if person.sampled_ineligible?
       flash[:warning] = "Person is ineligible - cannot start eligibility screener"
       redirect_to request.referer
     else
-      participant = Participant.create(:psu_code => @psu_code)
-      participant.person = person
-      household = HouseholdUnit.create!
-      HouseholdPersonLink.create!(:person => person, :household_unit => household)
-      participant.save!
-      resp = psc.assign_subject(participant)
       if resp && resp.status.to_i < 299
-        create_pbs_eligibility_screener_event_record(participant)
+        create_pbs_eligibility_screener_event_record
         redirect_to new_person_contact_path(person)
       else
-        destroy_participant_and_redirect(participant, person, resp, false)
+        destroy_participant_and_redirect(@participant, person, resp, false)
       end
     end
   end
 
   private
 
-    def create_pbs_eligibility_screener_event_record(participant)
-      create_screener_event_record(participant, NcsCode.pbs_eligibility_screener)
+    def prepare_for_screener(person)
+      person.find_or_create_household_unit
+      @participant = Participant.create(:psu_code => @psu_code)
+      @participant.person = person
+      @participant.save!
+      psc.assign_subject(@participant)
     end
 
-    def create_pregnancy_screener_event_record(participant)
-      create_screener_event_record(participant, NcsCode.pregnancy_screener)
+    def create_pbs_eligibility_screener_event_record
+      dates = create_screener_activity_in_psc(NcsCode.pbs_eligibility_screener)
+      create_screener_event_record(NcsCode.pbs_eligibility_screener, dates) unless dates.empty?
     end
 
-    def create_screener_event_record(participant, event_type)
-      if activity_plan = psc.build_activity_plan(participant)
-        dates = []
+    def create_pregnancy_screener_event_record
+      dates = create_screener_event_record(NcsCode.pregnancy_screener)
+      create_screener_event_record(NcsCode.pregnancy_screener, dates) unless dates.empty?
+    end
+
+    def create_screener_activity_in_psc(event_type)
+      dates = []
+      if activity_plan = psc.build_activity_plan(@participant)
         # get dates for scheduled pbs_eligibility_screener activity for participant
         activity_plan.scheduled_activities.each do |a|
           code = NcsCode.find_event_by_lbl(a.event)
           dates << a.ideal_date if code == event_type
         end
-        # create a placeholder event for each date
-        dates.uniq.each do |dt|
-          Event.create( :participant => participant, :psu_code => participant.psu_code,
-                        :event_start_date => dt, :event_type => event_type)
-
-        end
       end
+      dates
     end
 
-
+    def create_screener_event_record(event_type, dates)
+      # create a placeholder event for each date
+      dates.uniq.each do |dt|
+        Event.create( :participant => @participant, :psu_code => @participant.psu_code,
+                      :event_start_date => dt, :event_type => event_type)
+      end
+    end
 
     def destroy_participant_and_redirect(participant, person, resp, destroy_person = true)
       ppl = participant.participant_person_links.where(:relationship_code => 1).first

--- a/app/helpers/surveyor_helper.rb
+++ b/app/helpers/surveyor_helper.rb
@@ -10,7 +10,7 @@ module SurveyorHelper
     # use copy in memory instead of making extra db calls
     if @sections.last == @section
       txt = t('surveyor.next_section').html_safe
-      if @activity_plan.final_survey_part?(@response_set, @event)
+      if !@response_set.participant || @activity_plan.final_survey_part?(@response_set, @event)
         txt = t('surveyor.click_here_to_finish').html_safe
       end
       submit_tag(txt, :name => "finish")

--- a/app/views/people/_survey_responses.html.haml
+++ b/app/views/people/_survey_responses.html.haml
@@ -9,7 +9,7 @@
       .survey
         = rs.created_at.to_s(:db)
         = link_to rs.survey.title, surveyor.view_my_survey_path(:survey_code => rs.survey.access_code, :response_set_code => rs.access_code), :class => "show_link icon_link"
-        = link_to "Edit Instrument", edit_instrument_contact_link_path(rs.instrument.contact_link), :class => "edit_link icon_link"
+        = link_to "Edit Instrument", edit_instrument_path(rs.instrument), :class => "edit_link icon_link"
 
     %p
       = link_to "Search for Responses", responses_for_person_path(@person), :class => "search_link icon_link"

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -10,7 +10,10 @@
     = render '/surveyor/section_menu' # unless @sections.size < 3
 
     .survey_header
-      = "#{@response_set.survey.description} for #{@response_set.participant.person.to_s}"
+      - if @response_set.participant
+        = "#{@response_set.survey.description} for #{@response_set.participant.person.to_s}"
+      - else
+        = "#{@response_set.survey.description} for #{@response_set.person.to_s}"
       .event
         = @event.to_s
 


### PR DESCRIPTION
This pull request aims to resolve the issue of not being able to edit survey responses for non-participants. For example, a person who is ineligible would lose their participant record via normal behavior but they would still like a way to edit/update survey information entered. This scenario would originally produce a something went wrong error in production and should now be addressed. The person should be able to click 'Edit Instrument' and then see a link for 'Edit Responses' which would then allow them to achieve this. When their updates are complete in the survey, they are redirected to their person show page after clicking the normal 'Finish' button.

Piotr also assisted with Refactors he found necessary as we add a new feature in the near future.
