### PR TITLE
Export answers of -1, -2, etc. as MDES-coded dates / times (PBS)

### DIFF
--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -336,6 +336,7 @@ module NcsNavigator::Core::Warehouse
         create_base_record(instrument, wh_config, serial).tap do |record|
           apply_response_values(record)
           set_missing_values(record)
+          transform_exceptional_dts(record)
         end
       end
 
@@ -404,6 +405,48 @@ module NcsNavigator::Core::Warehouse
         end
       end
       private :set_missing_values
+
+      # For some questions that should really be MDES-coded dates (or times),
+      # we may receive values that aren't dates or times.  This occurs when
+      # selecting something like "Invalid" (-1) or "Don't know" (-2).  These
+      # need to be coded appropriately.  We parameterize coding on the format
+      # validation regex (which is present for all such fields).
+      #
+      # VERY IMPORTANT NOTE: YOU MUST KEEP THE REGEXES IN SYNC WITH THE
+      # WAREHOUSE.  That is, if you change the format regexes in the generated
+      # warehouse models, update them here too.
+      #
+      # In the future, we will handle more granular special-case values: for
+      # example, MDES specifies dates like 2009-01-92, which is interpreted as
+      # "January 2009 and I don't know the day".  This transformation process
+      # is transparent to that requirement, though: when the frontend supports
+      # such entry, the incoming value (from Surveyor) will be valid, and
+      # there will be no need for these transformations.
+      dt_code = lambda { |mask, v| mask.gsub('#', v.to_s.sub('-', '')) }
+
+      DT_TRANSFORMS = {
+        # Suggests -x => [-x, 9x:9x].
+        /^([0-9][0-9]:[0-9][0-9])?$/ => lambda { |val| [val, dt_code['9#:9#', val]] },
+
+        # Suggests -x => [-x, 9xxx-9x-9x].
+        /^([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])?$/ => lambda { |val| [val, dt_code['9###-9#-9#', val]] },
+      }
+
+      def transform_exceptional_dts(record)
+        record.class.properties.each do |variable|
+          if (format = variable.options[:format])
+            candidates = DT_TRANSFORMS[format]
+
+            if candidates
+              variable_name = variable.name
+              original_value = record.send(variable_name)
+
+              set_first_valid(record, variable_name, candidates.call(original_value))
+            end
+          end
+        end
+      end
+      private :transform_exceptional_dts
 
       def set_first_valid(record, variable_name, possible_values)
         record.send("#{variable_name}=", possible_values.shift)

--- a/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
@@ -772,7 +772,7 @@ module NcsNavigator::Core::Warehouse
           }
 
           create_response_for(extra_info_q) { |r|
-            r.answer = annotated_q.answers.first
+            r.answer = extra_info_q.answers.first
             r.string_value = 'foo'
           }
         end

--- a/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
@@ -783,9 +783,117 @@ module NcsNavigator::Core::Warehouse
       end
 
       describe 'coding in date and time fields' do
-        it 'works for time-formatted questions'
-        it 'works for date-formatted questions'
-        it 'works for timestamp-formatted questions'
+        include NcsNavigator::Core::Surveyor::SurveyTaker
+
+        let(:primary) { records.find { |rec| rec.class.mdes_table_name == 'spec_blood_2' } }
+        let(:questions_dsl) {
+          <<-DSL
+            q_TIME_STAMP_2 "INSERT DATE/TIME STAMP", :data_export_identifier=>"SPEC_BLOOD_2.TIME_STAMP_2"
+            a_timestamp :datetime, :custom_class => "datetime"
+
+            q_LAST_DATE_EAT "LAST TIME ATE OR DRANK - DATE",
+            :data_export_identifier=>"SPEC_BLOOD_2.LAST_DATE_EAT",
+            :pick => :one
+            a_date "DATE", :date, :custom_class => "date"
+            a_neg_1 "REFUSED"
+            a_neg_2 "DON'T KNOW"
+
+            q_LAST_TIME_EAT "LAST TIME ATE OR DRANK - TIME",
+            :pick => :one,
+            :data_export_identifier=>"SPEC_BLOOD_2.LAST_TIME_EAT"
+            a_time "HH:MM", :time, :custom_class => "12hr_time"
+            a_neg_1 "REFUSED"
+            a_neg_2 "DON'T KNOW"
+          DSL
+        }
+
+        describe 'on time-formatted questions' do
+          it 'passes HH:MM through' do
+            respond(response_set) do |r|
+              r.answer 'LAST_TIME_EAT', 'time', :value => '12:34'
+            end
+
+            response_set.save!
+
+            primary.last_time_eat.should == '12:34'
+          end
+
+          it 'passes 12:92 through' do
+            pending "Surveyor does not handle MDES date/time coding"
+
+            respond(response_set) do |r|
+              r.answer 'LAST_TIME_EAT', 'time', :value => '12:92'
+            end
+
+            response_set.save!
+
+            primary.last_time_eat.should == '12:92'
+          end
+
+          it 'transforms -2 into 92:92' do
+            respond(response_set) do |r|
+              r.answer 'LAST_TIME_EAT', 'neg_2'
+            end
+
+            response_set.save!
+
+            primary.last_time_eat.should == '92:92'
+          end
+
+          it 'transforms -1 into 91:91' do
+            respond(response_set) do |r|
+              r.answer 'LAST_TIME_EAT', 'neg_1'
+            end
+
+            response_set.save!
+
+            primary.last_time_eat.should == '91:91'
+          end
+        end
+
+        describe 'on date-formatted questions' do
+          it 'passes YYYY-MM-DD through' do
+            respond(response_set) do |r|
+              r.answer 'LAST_DATE_EAT', 'date', :value => '2001-01-01'
+            end
+
+            response_set.save!
+
+            primary.last_date_eat.should == '2001-01-01'
+          end
+
+          it 'passes 2009-01-92 through' do
+            pending "Surveyor does not handle MDES date/time coding"
+
+            respond(response_set) do |r|
+              r.answer 'LAST_DATE_EAT', 'date', :value => '2009-01-92'
+            end
+
+            response_set.save!
+
+            primary.last_date_eat.should == '2009-01-92'
+          end
+
+          it 'transforms -2 into 9222-92-92' do
+            respond(response_set) do |r|
+              r.answer 'LAST_DATE_EAT', 'neg_2'
+            end
+
+            response_set.save!
+
+            primary.last_date_eat.should == '9222-92-92'
+          end
+        end
+
+        it 'works for timestamp-formatted questions' do
+          respond(response_set) do |r|
+            r.answer 'TIME_STAMP_2', 'timestamp', :value => '2000-01-01T12:34:56'
+          end
+
+          response_set.save!
+
+          primary.time_stamp_2.should == '2000-01-01T12:34:56'
+        end
       end
     end
 


### PR DESCRIPTION
This addresses https://code.bioinformatics.northwestern.edu/issues/issues/show/4379.

Previously, the instrument warehouse code passed answers of -1, -2, etc. straight through to the MDES warehouse.  In places where dates or times were expected, this caused a format validation failure.

This PR codes -x as 9xxx-9x-9x (for dates) and 9x:9x (for times), using the "9-followed-by-the-code" notation described in the MDES spreadsheets.  Currently, it does so by first trying the value as-is.  If that's valid, we accept it.   Otherwise, we generate possibilities based on the validation format and try those.

This PR is for `1.7.0.pbs`. The main `develop` branch needs this as well; that PR is tracked as #232.
