### PR TITLE
Avoid find_by_id given an id with alphanumeric in ParticipantController

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -448,11 +448,21 @@ class ParticipantsController < ApplicationController
 
     def load_participant
       return unless params[:id]
-      @participant =
-        Participant.find_by_id(params[:id]) ||
-        Participant.find_by_p_id(params[:id]) ||
-        Person.includes(:participant_person_links => :participant).where(:person_id => params[:id]).first.try(:participant) ||
-        raise(ActiveRecord::RecordNotFound, "Couldn't find Participant with id=#{params[:id]} or p_id=#{params[:id]} or self person_id=#{params[:id]}")
+      
+      @participant = 
+        if params[:id] =~ /\A\d+\Z/
+          begin
+            Participant.find(params[:id])
+          rescue ActiveRecord::RecordNotFound
+            nil
+          end
+        end
+
+      @participant = @participant ||
+          Participant.find_by_p_id(params[:id]) ||
+          Person.includes(:participant_person_links => :participant).where(:person_id => params[:id]).first.try(:participant)
+
+      raise(ActiveRecord::RecordNotFound, "Couldn't find Participant with id=#{params[:id]} or p_id=#{params[:id]} or self person_id=#{params[:id]}") unless @participant
     end
 
 end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -57,6 +57,7 @@ describe ParticipantsController do
       let!(:p1) { Factory(:participant, :id => 9000, :p_id => '4500', :person => Factory(:person, :person_id => 'A')) }
       let!(:p2) { Factory(:participant, :id => 6000, :p_id => '9000', :person => Factory(:person, :person_id => 'B')) }
       let!(:p3) { Factory(:participant, :id => 3000, :p_id => '1500', :person => Factory(:person, :person_id => 'C')) }
+      let!(:p4) { Factory(:participant, :id => 8000, :p_id => '3000_abc', :person => Factory(:person, :person_id => 'D'))}
 
       before do
         InstrumentPlan.stub!(:from_schedule).and_return(InstrumentPlan.new)
@@ -78,6 +79,12 @@ describe ParticipantsController do
         get :show, :id => 'B'
 
         assigns[:participant].should == p2
+      end
+
+      it 'resolves participant 3000_abc' do
+        get :show, :id => '3000_abc'
+
+        assigns[:participant].should == p4
       end
 
       describe 'when the ID cannot be resolved' do


### PR DESCRIPTION
When using the p_id to find the participant on the participants page, if the beginning of the id contains an integer it will truncate the rest of the p_id and search using the integer.
Example..
1. requesting /participants/044_abc
2. participants page found for participant with id 44, not p_id 044_abc

Ticket is https://code.bioinformatics.northwestern.edu/issues/issues/show/4397
