### PR TITLE
#4382 pbs ineligible person reopen event with screener

### DIFF
--- a/app/helpers/instruments_helper.rb
+++ b/app/helpers/instruments_helper.rb
@@ -1,0 +1,24 @@
+module InstrumentsHelper
+  def determine_links_for_editing(instrument, rs)
+    if instrument.person.participant
+      edit_instrument_responses_link(rs)
+    else
+      restart_link(rs) + edit_instrument_responses_link(rs)
+    end
+  end
+
+  def restart_link(rs)
+    link_to "Recreate Participant and Restart Screener",
+      restart_screener_for_ineligible_path(response_set_code: rs.access_code),
+      class: "edit_link icon_link",
+      confirm: 'Are you sure you would like to restart?',
+      title: rs.survey.title
+  end
+
+  def edit_instrument_responses_link(rs)
+    link_to "Edit Instrument Responses",
+      surveyor.edit_my_survey_path(survey_code: rs.survey.access_code, response_set_code: rs.access_code),
+      class: "edit_link icon_link",
+      title: rs.survey.title
+  end
+end

--- a/app/views/instruments/edit.html.haml
+++ b/app/views/instruments/edit.html.haml
@@ -11,10 +11,7 @@
         Instrument
       - @instrument.response_sets.each do |rs|
         .survey
-          = link_to "Edit Instrument Responses",
-            surveyor.edit_my_survey_path(:survey_code => rs.survey.access_code, :response_set_code => rs.access_code),
-            :class => "edit_link icon_link",
-            :title => rs.survey.title
+          = determine_links_for_editing(@instrument, rs)
 
       = fields_for @instrument do |instrument|
         = render "form_fields", { :f => instrument }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,7 @@ NcsNavigatorCore::Application.routes.draw do
   match "/welcome/pending_events", :to => "welcome#pending_events"
   match "welcome/start_pregnancy_screener_instrument", :to => "welcome#start_pregnancy_screener_instrument", :as => "start_pregnancy_screener_instrument"
   match "welcome/start_pbs_eligibility_screener_instrument", :to => "welcome#start_pbs_eligibility_screener_instrument", :as => "start_pbs_eligibility_screener_instrument"
+  match "welcome/restart_screener_for_ineligible", :to => "welcome#restart_screener_for_ineligible", :as => "restart_screener_for_ineligible", :via => [:get]
   match "appointment_sheet/:person/:date", :to => "appointment_sheets#show", :as => "appointment_sheet", :via => [:get]
 
   root :to => "welcome#index"

--- a/lib/patient_study_calendar.rb
+++ b/lib/patient_study_calendar.rb
@@ -294,11 +294,8 @@ class PatientStudyCalendar
   #
   # @param [Participant,String]
   # @return [Array<ScheduledActivity>]
-  def scheduled_activities(participant)
-    build_scheduled_activities(
-      participant_activities(schedules(participant)),
-      Psc::ScheduledActivity::OPEN_STATES
-    )
+  def scheduled_activities(participant, activity_states = Psc::ScheduledActivity::OPEN_STATES)
+    build_scheduled_activities(participant_activities(schedules(participant)), activity_states)
   end
 
   ##

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,8 +1,66 @@
 # -*- coding: utf-8 -*-
-
-
 require 'spec_helper'
 
 describe WelcomeController do
+
+  describe "GET restart_screener_for_ineligible" do
+    context "with an authenticated user" do
+      before(:each) do
+        @person = Factory(:person)
+        @inst = Factory(:instrument, person: @person)
+
+        @event = Factory :event,
+                         event_start_date: Date.parse('2013-06-26'),
+                         event_end_date: nil,
+                         event_end_time: nil,
+                         event_type: NcsCode.pbs_eligibility_screener
+
+        @contact = Factory(:contact)
+
+        @contact_link = Factory :contact_link,
+                                contact: @contact,
+                                person: @person,
+                                event: @event,
+                                instrument: @inst
+
+        @rs = Factory :response_set,
+                      instrument: @inst,
+                      person: @person
+
+        ResponseSet.stub(:where).and_return([@rs])
+        login(user_login)
+      end
+
+      describe "setting instance variables" do
+        it "should set response set from params" do
+          get :restart_screener_for_ineligible
+          assigns[:response_set].should eql(@rs)
+        end
+
+        it "should set person from response set" do
+          get :restart_screener_for_ineligible
+          assigns[:person].should eql(@person)
+        end
+      end
+
+      describe "redirecting" do
+        it "should redirect to new person contact path for person" do
+          get :restart_screener_for_ineligible
+          response.should redirect_to(new_person_contact_path(@person))
+        end
+      end
+
+      context "with a newly created participant" do
+        it "should create a new participant" do
+          expect{get :restart_screener_for_ineligible}.to change(Participant, :count).by(1)
+        end
+
+        it "should be associated to person" do
+          get :restart_screener_for_ineligible
+          assigns[:participant].person.should eql(@person)
+        end
+      end
+    end
+  end
 
 end

--- a/spec/features/welcome/restart_screener_for_ineligible.rb
+++ b/spec/features/welcome/restart_screener_for_ineligible.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+feature 'Restarting Screener for Ineligible', :clean_with_truncation, :js do
+
+  before do
+    ResponseSet.stub(:where).and_return([rs])
+    PatientStudyCalendar.any_instance.stub(:scheduled_activities).and_return([scheduled_activity])
+    PatientStudyCalendar.any_instance.stub(:update_activity_state).and_return(true)
+    NcsNavigator::Authorization::Core::Authority.stub_chain(:new, :find_users).and_return(false)
+    capybara_login('admin_user')
+  end
+
+  let!(:person) {Factory(:person)}
+  let!(:inst) {Factory(:instrument, person: person)}
+  let!(:event) {Factory(:event)}
+  let!(:contact) {Factory(:contact)}
+  let!(:contact_link) {Factory(:contact_link, contact: contact, event: event, instrument: inst)}
+  let!(:rs) {Factory(:response_set, instrument: inst, person: person)}
+  let(:scheduled_activity) { Factory.build(:scheduled_activity, activity_name: 'PBS Eligibility Screener Interview') }
+
+  context 'when there is no participant' do
+    it 'should show both links for Screener' do
+      visit edit_instrument_path(inst.id)
+      find_link('Edit Instrument Responses').visible?.should be_true
+      find_link('Recreate Participant and Restart Screener').visible?.should be_true
+    end
+
+    it 'should redirect to new person contact path for person' do
+      visit edit_instrument_path(inst.id)
+      click_link('Recreate Participant and Restart Screener')
+      page.driver.browser.switch_to.alert.accept
+      page.should have_content('New Contact')
+    end
+  end
+
+  context 'when there is a participant' do
+    it 'should show edit responses link only' do
+      person.participant = Factory(:participant)
+      person.save!
+      visit edit_instrument_path(inst.id)
+      find_link('Edit Instrument Responses').visible?.should be_true
+      page.has_link?('Recreate Participant and Restart Screener').should be_false
+    end
+  end
+
+end

--- a/spec/lib/patient_study_calendar_spec.rb
+++ b/spec/lib/patient_study_calendar_spec.rb
@@ -577,7 +577,14 @@ describe PatientStudyCalendar do
             sss.activity_name.should == "Low-Intensity Interview"
             sss.current_state.should == Psc::ScheduledActivity::SCHEDULED
           end
-
+        end
+        it 'returns occurred scheduled activities' do
+          VCR.use_cassette('psc/janedoe_canceled_activities') do
+            subject_occurred_statuses = subject.scheduled_activities(@participant, [Psc::ScheduledActivity::OCCURRED])
+            subject_occurred_statuses.size.should == 1
+            sss = subject_occurred_statuses.first
+            sss.current_state.should == Psc::ScheduledActivity::OCCURRED
+          end
         end
       end
 


### PR DESCRIPTION
This pull request allows a person deemed ineligible, to have an option on the edit instrument page called "Recreate Participant and Restart Screener". This will remove their old data, create the participant, reactivate their screener activities from occurred to scheduled and redirect them back to the beginning steps of the participant eligibility screener.

Redmine Link: https://code.bioinformatics.northwestern.edu/issues/issues/show/4382

This pull request is for pbs and is identical to #240 which is waiting to be code reviewed.
