### PR TITLE
Fixed prepopulator response for NUM_HH #3758

### DIFF
--- a/app/models/response_set_prepopulation/postnatal.rb
+++ b/app/models/response_set_prepopulation/postnatal.rb
@@ -57,9 +57,7 @@ module ResponseSetPrepopulation
               answer_for(question,
                          was_answer_to_mult_child_yes?("TWELVE_MTH_MOTHER"))
             when "prepopulated_should_show_num_hh_group"
-              ans = answer_for(question, was_household_number_collected?)
-              ans.text == "TRUE" ? ans.text = "FALSE" : ans.text = "TRUE"
-              ans
+              ans = answer_for(question, was_household_number_not_collected?)
             when "prepopulated_is_valid_work_name_provided"
               answer_for(question, was_work_name_collected?)
             when "prepopulated_is_valid_work_address_provided"
@@ -148,8 +146,8 @@ module ResponseSetPrepopulation
         }
     end
 
-    def was_household_number_collected?
-      check_multiple_surveys_for_response("NUM_HH")
+    def was_household_number_not_collected?
+      !check_multiple_surveys_for_response("NUM_HH")
     end
 
     def was_work_name_collected?

--- a/app/models/response_set_prepopulation/postnatal.rb
+++ b/app/models/response_set_prepopulation/postnatal.rb
@@ -57,7 +57,9 @@ module ResponseSetPrepopulation
               answer_for(question,
                          was_answer_to_mult_child_yes?("TWELVE_MTH_MOTHER"))
             when "prepopulated_should_show_num_hh_group"
-              answer_for(question, was_household_number_collected?)
+              ans = answer_for(question, was_household_number_collected?)
+              ans.text == "TRUE" ? ans.text = "FALSE" : ans.text = "TRUE"
+              ans
             when "prepopulated_is_valid_work_name_provided"
               answer_for(question, was_work_name_collected?)
             when "prepopulated_is_valid_work_address_provided"

--- a/spec/models/response_set_prepopulation/postnatal_spec.rb
+++ b/spec/models/response_set_prepopulation/postnatal_spec.rb
@@ -194,24 +194,24 @@ module ResponseSetPrepopulation
           init_common_vars
         end
 
-        it "should be TRUE when valid answers to NUM_HH exist" do
+        it "should be FALSE when valid answers to NUM_HH exist" do
           take_num_hh_surveys("24M", true)
+          run_populator
+          get_response_as_string(@response_set,
+                      "prepopulated_should_show_num_hh_group").should == "FALSE"
+        end
+
+        it "should be TRUE when only invalid answers to NUM_HH exist" do
+          take_num_hh_surveys("24M", false)
           run_populator
           get_response_as_string(@response_set,
                       "prepopulated_should_show_num_hh_group").should == "TRUE"
         end
 
-        it "should be FALSE when only invalid answers to NUM_HH exist" do
-          take_num_hh_surveys("24M", false)
+        it "should be TRUE when no responses to NUM_HH exist" do
           run_populator
           get_response_as_string(@response_set,
-                      "prepopulated_should_show_num_hh_group").should == "FALSE"
-        end
-
-        it "should be FALSE when no responses to NUM_HH exist" do
-          run_populator
-          get_response_as_string(@response_set,
-                      "prepopulated_should_show_num_hh_group").should == "FALSE"
+                      "prepopulated_should_show_num_hh_group").should == "TRUE"
         end
       end
 
@@ -224,24 +224,24 @@ module ResponseSetPrepopulation
           init_common_vars
         end
 
-        it "should be TRUE when valid answers to NUM_HH exist" do
+        it "should be FALSE when valid answers to NUM_HH exist" do
           take_num_hh_surveys("18M", true)
+          run_populator
+          get_response_as_string(@response_set,
+                      "prepopulated_should_show_num_hh_group").should == "FALSE"
+        end
+
+        it "should be TRUE when only invalid answers to NUM_HH exist" do
+          take_num_hh_surveys("18M", false)
           run_populator
           get_response_as_string(@response_set,
                       "prepopulated_should_show_num_hh_group").should == "TRUE"
         end
 
-        it "should be FALSE when only invalid answers to NUM_HH exist" do
-          take_num_hh_surveys("18M", false)
+        it "should be TRUE when no responses to NUM_HH exist" do
           run_populator
           get_response_as_string(@response_set,
-                      "prepopulated_should_show_num_hh_group").should == "FALSE"
-        end
-
-        it "should be FALSE when no responses to NUM_HH exist" do
-          run_populator
-          get_response_as_string(@response_set,
-                      "prepopulated_should_show_num_hh_group").should == "FALSE"
+                      "prepopulated_should_show_num_hh_group").should == "TRUE"
         end
       end
 


### PR DESCRIPTION
The prepopulator 
"prepopulated_should_show_num_hh_group" had its
values reversed. The NUM_HH group should show if
there AREN'T any previous responses for NUM_HH.
In other words, the prepopulator should indicate
"FALSE" when previous NUM_HH responses exist.
