### PR TITLE
#4537 Birth Cohort Pre-populator fails when p type code is 14

### DIFF
--- a/app/models/response_set_prepopulation/birth_cohort_prepopulator.rb
+++ b/app/models/response_set_prepopulation/birth_cohort_prepopulator.rb
@@ -2,7 +2,9 @@ require 'ncs_navigator/core'
 module ResponseSetPrepopulation
   module BirthCohortPrepopulator
     def is_p_type_15?(question, participant)
-      if ((participant.p_type.local_code == 15) || (participant.mother && participant.mother.participant.p_type.local_code == 15))
+      if participant.p_type.local_code == 15
+        answer_for(question, true)
+      elsif participant.child_participant? && participant.mother.try(:participant) && participant.mother.participant.p_type.local_code == 15
         answer_for(question, true)
       else
         answer_for(question, false)


### PR DESCRIPTION
This pull request resolves the method is_p_type_15? from breaking when the p type local code is 14 in survey: INS_QUE_Birth_INT_M3.2_V3.1_PART_TWO 

participant.mother.participant would be nil and break when p_type was called on it

Redmine Reference: https://code.bioinformatics.northwestern.edu/issues/issues/show/4537
