### PR TITLE
fix check for invalid codes during ode #4535

### DIFF
--- a/app/models/operational_data_extractor/base.rb
+++ b/app/models/operational_data_extractor/base.rb
@@ -22,6 +22,26 @@ module OperationalDataExtractor
           extractor[1].new(response_set)
         end
       end
+
+      ##
+      # Some instruments use code lists that differ from the
+      # code list used for an attribute on the Operational Data
+      # record. cf.https://code.bioinformatics.northwestern.edu/issues/issues/show/4448
+      # This method checks thats value is in the code list associated with attribute on klass
+      # @param klass     - a class which contains ncs_coded_attributes
+      # @param attribute - the name of an ncs_coded_attribute
+      # @param value     - value to check against the code list of attribute
+      # @return[Boolean]
+      def legal_ncs_code_list_value_for_attribute_of_class?(klass, attribute, value)
+        is_legal = true
+        if klass.respond_to?(:ncs_coded_attributes)
+          if nca = klass.ncs_coded_attributes.select{|nca| nca == attribute.to_sym}[attribute.to_sym]
+            legal_values = nca.code_list.collect(&:local_code)
+            is_legal = legal_values.include?(value)
+          end
+        end
+        is_legal
+      end
     end
 
     def initialize(response_set)
@@ -302,31 +322,12 @@ module OperationalDataExtractor
       @other_institution_type ||= NcsCode.for_list_name_and_local_code('ORGANIZATION_TYPE_CL1', -5)
     end
 
-    ##
-    # Some instruments use code lists that differ from the
-    # code list used for an attribute on the Operational Data
-    # record. cf.https://code.bioinformatics.northwestern.edu/issues/issues/show/4448
-    # This method checks that value is in code list
-    # @return[Boolean]
-    def legal_ncs_code_list_value_for_attribute_of_class?(obj, attribute, value)
-      is_legal = true
-      cls = obj.class
-      if cls.respond_to?(:ncs_coded_attributes)
-        if nca = cls.ncs_coded_attributes.select{|nca| nca == attribute.to_sym}[attribute.to_sym]
-          legal_values = nca.code_list.collect(&:local_code)
-          is_legal = legal_values.include?(value)
-        end
-      end
-      is_legal
-    end
-    private :legal_ncs_code_list_value_for_attribute_of_class?
-
     def set_value(obj, attribute, value)
       if value.blank?
         log_error(obj, "#{attribute} not set because value is blank.")
-      elsif attribute.include?('_code')
+      elsif attribute =~ /_code$/
 
-        if legal_ncs_code_list_value_for_attribute_of_class?(obj, attribute, value)
+        if self.class.legal_ncs_code_list_value_for_attribute_of_class?(obj.class, attribute.sub(/_code$/,''), value)
           obj.send("#{attribute}=", value)
         end
       else

--- a/spec/models/operational_data_extractor/base_spec.rb
+++ b/spec/models/operational_data_extractor/base_spec.rb
@@ -31,6 +31,28 @@ describe OperationalDataExtractor::Base do
 
   end
 
+  describe "legal_ncs_code_list_value_for_attribute_of_class?" do
+    context "invalid codes" do
+      it "returns false" do
+        OperationalDataExtractor::Base.
+          legal_ncs_code_list_value_for_attribute_of_class?(Person,
+                                                            "ethnic_group",
+                                                            -2).should be_false
+      end
+    end
+
+    context "valid codes" do
+      it "returns true" do
+        [-6,-4,-1,1,2].each do |code| #ETHNICITY_CL1
+        OperationalDataExtractor::Base.
+          legal_ncs_code_list_value_for_attribute_of_class?(Person,
+                                                            "ethnic_group",
+                                                            code).should be_true
+          end
+      end
+    end
+  end
+
   describe "determining the proper data extractor to use" do
     let(:person) { Factory(:person) }
     let(:participant) { Factory(:participant) }


### PR DESCRIPTION
This should solve a category of erros where the code list being
extracted to in operational data is slightly different than the code
list in instrument data.

There is an argument for not even extracting these code lists but this
fix simply prevents trying to extract invalid codes and is the minimal
change.

also see #4448
