### PR TITLE
A terrible yet workable last-ditch solution for missing values.  #4571.

### DIFF
--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -337,6 +337,7 @@ module NcsNavigator::Core::Warehouse
           apply_response_values(record)
           set_missing_values(record)
           transform_exceptional_dts(record)
+          last_ditch_validity_push(record)
         end
       end
 
@@ -405,6 +406,17 @@ module NcsNavigator::Core::Warehouse
         end
       end
       private :set_missing_values
+
+      def last_ditch_validity_push(record)
+        record.class.properties.each do |prop|
+          name = prop.name
+
+          if record.send(name).blank? && record.class.properties[name].required?
+            set_first_valid(record, name, [-4])
+          end
+        end
+      end
+      private :last_ditch_validity_push
 
       # For some questions that should really be MDES-coded dates (or times),
       # we may receive values that aren't dates or times.  This occurs when


### PR DESCRIPTION
As we transition data out of NCS Navigator for one of our 1.6.7 sites,
we have found several situations in which instrument data was truly not
entered.  InstrumentToWarehouse was designed to fill in these missing
values with -4 (i.e. "Missing in Error"), but it does not accomplish
this in all cases.  Some examples:
- responses missing because one part of a multi-part instrument was
  never started
- responses missing due to some unknown cause (see e.g. [1](https://code.bioinformatics.northwestern.edu/redmine/issues/show/9680) if you have
  access to NUBIC's internal issue tracker)

This horrifying, cheesy, yet effective solution makes a last pass over
the created MDES record, and just fills in -4s where it can.  It farts
in the general direction of data quality, but we have been told that
quality now takes a backseat to _just getting the data out_.  Also, it
works.

This commit has no tests because writing test cases for this sort of
thing takes longer than just demonstrating it works by running ETL jobs
on test instances.
