### PR TITLE
3285 eventless contacts

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -17,11 +17,12 @@ class ContactsController < ApplicationController
                              :psu_code => NcsNavigatorCore.psu_code,
                              :contact_date_date => Date.today,
                              :contact_start_time => Time.now.strftime("%H:%M"))
-
-    @event = event_for_person
-    @requires_consent = (@person.participant &&
-                            (@person.participant.consented? == false) &&
-                            !@event.screener_event?)
+    if params[:event_id]
+      @event = event_for_person
+      @requires_consent = (@person.participant &&
+                              (@person.participant.consented? == false) &&
+                              !@event.screener_event?)
+    end
 
     respond_to do |format|
       format.html # new.html.haml
@@ -35,13 +36,17 @@ class ContactsController < ApplicationController
     @person  = Person.find(params[:person_id])
     @contact = Contact.start(@person, params[:contact])
 
-    @event = event_for_person
+    @event = event_for_person unless params[:event_id]  # possibly eventless contacts under #3285
 
     respond_to do |format|
       if @contact.save
         link = find_or_create_contact_link
+        if @event
+          format.html { redirect_to(select_instrument_contact_link_path(link.id), :notice => 'Contact was successfully created.') }
+        else
+          format.html { redirect_to(@person, :notice => 'Contact was successfully created.') }
+        end
 
-        format.html { redirect_to(select_instrument_contact_link_path(link.id), :notice => 'Contact was successfully created.') }
         format.json { render :json => @contact }
       else
         format.html { render :action => "new" }
@@ -220,9 +225,6 @@ class ContactsController < ApplicationController
           participant.events.reload
         end
         participant.pending_events.first
-      else
-        # TODO: be able to create a Contact without an Event - Task #3285
-        raise "No Event identifier provided or Participant found for Contact"
       end
     end
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -18,7 +18,7 @@ class ContactsController < ApplicationController
                              :contact_date_date => Date.today,
                              :contact_start_time => Time.now.strftime("%H:%M"))
 
-    @event = event_for_person
+    @event = event_for_person unless params[:event_id].blank?
     @requires_consent = (@person.participant &&
                             (@person.participant.consented? == false) &&
                             !@event.screener_event?)
@@ -35,13 +35,17 @@ class ContactsController < ApplicationController
     @person  = Person.find(params[:person_id])
     @contact = Contact.start(@person, params[:contact])
 
-    @event = event_for_person
+    @event = event_for_person unless params[:event_id]  # possibly eventless contacts under #3285
 
     respond_to do |format|
       if @contact.save
         link = find_or_create_contact_link
+        if @event
+          format.html { redirect_to(select_instrument_contact_link_path(link.id), :notice => 'Contact was successfully created.') }
+        else
+          format.html { redirect_to(@person, :notice => 'Contact was successfully created.') }
+        end
 
-        format.html { redirect_to(select_instrument_contact_link_path(link.id), :notice => 'Contact was successfully created.') }
         format.json { render :json => @contact }
       else
         format.html { render :action => "new" }
@@ -220,9 +224,6 @@ class ContactsController < ApplicationController
           participant.events.reload
         end
         participant.pending_events.first
-      else
-        # TODO: be able to create a Contact without an Event - Task #3285
-        raise "No Event identifier provided or Participant found for Contact"
       end
     end
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -17,11 +17,12 @@ class ContactsController < ApplicationController
                              :psu_code => NcsNavigatorCore.psu_code,
                              :contact_date_date => Date.today,
                              :contact_start_time => Time.now.strftime("%H:%M"))
-
-    @event = event_for_person unless params[:event_id].blank?
-    @requires_consent = (@person.participant &&
-                            (@person.participant.consented? == false) &&
-                            !@event.screener_event?)
+    if params[:event_id]
+      @event = event_for_person
+      @requires_consent = (@person.participant &&
+                              (@person.participant.consented? == false) &&
+                              !@event.screener_event?)
+    end
 
     respond_to do |format|
       format.html # new.html.haml

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -54,7 +54,7 @@ class ParticipantsController < ApplicationController
   def show
     @person = @participant.person
     @participant = @person.participant
-    @events_and_contacts = events_and_contact_links
+    @events_and_contact_links = events_and_contact_links
 
     @participant_activity_plan = psc.build_activity_plan(@participant)
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -24,10 +24,10 @@ class PeopleController < ApplicationController
   def events_and_contact_links
     rows = @person.events +
            @person.contact_links
-    if @person.participant       
-      row += @participant.events +
-             @participant.person.contact_links.collect(&:event) +
-             @participant.person.contact_links.select {|cl| cl.event.nil?}
+    if @person && @participant
+      rows += @participant.events +
+              @person.contact_links.collect(&:event) +
+              @person.contact_links.select {|cl| cl.event.nil?}
     end
     rows.compact.uniq.flatten
   end
@@ -36,8 +36,8 @@ class PeopleController < ApplicationController
   # GET /people/1
   def show
     @person = Person.includes(:contact_links, :events).find(params[:id])
-    @events_and_contact_links = events_and_contact_links
     @participant = @person.participant
+    @events_and_contact_links = events_and_contact_links
 
     redirect_to participant_path(@participant) if @participant
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -21,9 +21,14 @@ class PeopleController < ApplicationController
     end
   end
 
+  def events_and_contact_links
+  end
+  private :events_and_contact_links
+
   # GET /people/1
   def show
-    @person = Person.find(params[:id])
+    @person = Person.includes(:contact_links, :events).find(params[:id])
+    @events_and_contacts = @person.events + @person.contact_links
     @participant = @person.participant
     redirect_to participant_path(@participant) if @participant
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -21,10 +21,24 @@ class PeopleController < ApplicationController
     end
   end
 
+  def events_and_contact_links
+    rows = @person.events +
+           @person.contact_links
+    if @person.participant       
+      row += @participant.events +
+             @participant.person.contact_links.collect(&:event) +
+             @participant.person.contact_links.select {|cl| cl.event.nil?}
+    end
+    rows.compact.uniq.flatten
+  end
+  private :events_and_contact_links
+
   # GET /people/1
   def show
-    @person = Person.find(params[:id])
+    @person = Person.includes(:contact_links, :events).find(params[:id])
+    @events_and_contact_links = events_and_contact_links
     @participant = @person.participant
+
     redirect_to participant_path(@participant) if @participant
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -22,14 +22,23 @@ class PeopleController < ApplicationController
   end
 
   def events_and_contact_links
+    rows = @person.events +
+           @person.contact_links
+    if @person.participant       
+      row += @participant.events +
+             @participant.person.contact_links.collect(&:event) +
+             @participant.person.contact_links.select {|cl| cl.event.nil?}
+    end
+    rows.compact.uniq.flatten
   end
   private :events_and_contact_links
 
   # GET /people/1
   def show
     @person = Person.includes(:contact_links, :events).find(params[:id])
-    @events_and_contacts = @person.events + @person.contact_links
+    @events_and_contact_links = events_and_contact_links
     @participant = @person.participant
+
     redirect_to participant_path(@participant) if @participant
   end
 

--- a/app/views/contacts/_form_fields_with_event.html.haml
+++ b/app/views/contacts/_form_fields_with_event.html.haml
@@ -1,0 +1,72 @@
+.column-container
+  = f.hidden_field :psu_code
+  = hidden_field_tag :event_type_id, @event.event_type.id
+  = hidden_field_tag :event_id, @event_id
+  = hidden_field_tag :contact_link_id, @contact_link.id if @contact_link
+  = hidden_field_tag :next_event, params[:next_event]
+
+  %p
+    = label_tag "When did this contact happen?"
+    %br
+    = f.label :contact_date_date, "Date"
+    = f.text_field :contact_date_date, :class => "required datepicker"
+
+  %p
+    - if @staff_list.blank?
+      Could not load staff list. Using logged in staff member as person who made contact.
+    - else
+      %span{ :class => "date_label" }
+        = label_tag :staff_id, "Who Made Contact?"
+      %br
+      - selected = @contact_link.try(:staff_id) || @current_staff_id
+      = select_tag :staff_id, options_for_select(@staff_list, :selected => selected), :class => "required"
+
+  %p
+    = f.label :contact_start_time, "Start Time"
+    = f.text_field :contact_start_time, :class => "timepicker"
+
+  - unless f.object.new_record?
+    %p
+      = f.label :contact_end_time, "End Time"
+      = f.text_field :contact_end_time, :class => "timepicker"
+
+  = render "shared/ncs_code_select", { :f => f, :code => :who_contacted_code, :label_text => "How does the contacted person relate to the NCS?", :other => :who_contacted_other, :help_text => "contacts/contact_who_contacted_tooltip" }
+
+  = render "shared/ncs_code_select", { :f => f, :code => :contact_type_code, :label_text => "How did you contact them?", :other => :contact_type_other }
+
+  - unless f.object.new_record?
+
+    = render "shared/ncs_code_select", { :f => f, :code => :contact_location_code, :label_text => "Location", :other => :contact_location_other }
+    = render "shared/ncs_code_select", { :f => f, :code => :contact_private_code, :label_text => "Were there Privacy Issues?", :help_text => "contacts/contact_private_tooltip" }
+
+    %p
+      = f.label :contact_private_detail, "Privacy Issues Detail"
+      %span{ :class => "help_icon" }
+      = render "contacts/contact_private_detail_tooltip"
+    %p
+      = f.text_field :contact_private_detail
+
+    %p
+      = f.label :contact_distance, "Distance (format xx.x)"
+      %br
+      = f.text_field :contact_distance
+
+  - unless f.object.new_record?
+    = render "shared/disposition_code", { :f => f, :code => :contact_disposition }
+
+    = render "shared/ncs_code_select", { :f => f, :code => :contact_language_code, :label_text => "Language", :other => :contact_language_other }
+    = render "shared/ncs_code_select", { :f => f, :code => :contact_interpret_code, :label_text => "Interpret", :other => :contact_interpret_other, :help_text => "contacts/contact_interpret_tooltip" }
+
+  %p
+    = f.label :contact_comment, "Optional Comments"
+    %br
+    = f.text_area :contact_comment
+
+:javascript
+  $(document).ready(function() {
+    wire_up_select_other("#contact_contact_type_code","#contact_contact_type_other");
+    wire_up_select_other("#contact_contact_language_code","#contact_contact_language_other");
+    wire_up_select_other("#contact_contact_interpret_code","#contact_contact_interpret_other");
+    wire_up_select_other("#contact_contact_location_code","#contact_contact_location_other");
+    wire_up_select_other("#contact_who_contacted_code","#contact_who_contacted_other");
+  });

--- a/app/views/contacts/_form_fields_without_event.html.haml
+++ b/app/views/contacts/_form_fields_without_event.html.haml
@@ -1,8 +1,6 @@
 .column-container
   = f.hidden_field :psu_code
-  - if @event
-    = hidden_field_tag :event_type_id, @event.event_type.id
-    = hidden_field_tag :event_id, @event_id if @event_id
+  = hidden_field_tag :event_id, -1
   = hidden_field_tag :contact_link_id, @contact_link.id if @contact_link
   = hidden_field_tag :next_event, params[:next_event]
 
@@ -26,37 +24,29 @@
     = f.label :contact_start_time, "Start Time"
     = f.text_field :contact_start_time, :class => "timepicker"
 
-  - unless f.object.new_record?
-    %p
-      = f.label :contact_end_time, "End Time"
-      = f.text_field :contact_end_time, :class => "timepicker"
-
   = render "shared/ncs_code_select", { :f => f, :code => :who_contacted_code, :label_text => "How does the contacted person relate to the NCS?", :other => :who_contacted_other, :help_text => "contacts/contact_who_contacted_tooltip" }
 
   = render "shared/ncs_code_select", { :f => f, :code => :contact_type_code, :label_text => "How did you contact them?", :other => :contact_type_other }
 
-  - unless f.object.new_record?
+  = render "shared/ncs_code_select", { :f => f, :code => :contact_location_code, :label_text => "Location", :other => :contact_location_other }
+  = render "shared/ncs_code_select", { :f => f, :code => :contact_private_code, :label_text => "Were there Privacy Issues?", :help_text => "contacts/contact_private_tooltip" }
 
-    = render "shared/ncs_code_select", { :f => f, :code => :contact_location_code, :label_text => "Location", :other => :contact_location_other }
-    = render "shared/ncs_code_select", { :f => f, :code => :contact_private_code, :label_text => "Were there Privacy Issues?", :help_text => "contacts/contact_private_tooltip" }
+  %p
+    = f.label :contact_private_detail, "Privacy Issues Detail"
+    %span{ :class => "help_icon" }
+    = render "contacts/contact_private_detail_tooltip"
+  %p
+    = f.text_field :contact_private_detail
 
-    %p
-      = f.label :contact_private_detail, "Privacy Issues Detail"
-      %span{ :class => "help_icon" }
-      = render "contacts/contact_private_detail_tooltip"
-    %p
-      = f.text_field :contact_private_detail
+  %p
+    = f.label :contact_distance, "Distance (format xx.x)"
+    %br
+    = f.text_field :contact_distance
 
-    %p
-      = f.label :contact_distance, "Distance (format xx.x)"
-      %br
-      = f.text_field :contact_distance
+  = render "shared/disposition_code", { :f => f, :code => :contact_disposition }
 
-  - unless f.object.new_record?
-    = render "shared/disposition_code", { :f => f, :code => :contact_disposition }
-
-    = render "shared/ncs_code_select", { :f => f, :code => :contact_language_code, :label_text => "Language", :other => :contact_language_other }
-    = render "shared/ncs_code_select", { :f => f, :code => :contact_interpret_code, :label_text => "Interpret", :other => :contact_interpret_other, :help_text => "contacts/contact_interpret_tooltip" }
+  = render "shared/ncs_code_select", { :f => f, :code => :contact_language_code, :label_text => "Language", :other => :contact_language_other }
+  = render "shared/ncs_code_select", { :f => f, :code => :contact_interpret_code, :label_text => "Interpret", :other => :contact_interpret_other, :help_text => "contacts/contact_interpret_tooltip" }
 
   %p
     = f.label :contact_comment, "Optional Comments"

--- a/app/views/contacts/_form_with_event.html.haml
+++ b/app/views/contacts/_form_with_event.html.haml
@@ -4,7 +4,7 @@
 
     = render "shared/custom_error_messages", :object => f.object
 
-    = render "contacts/form_fields", :f => f
+    = render "contacts/form_fields_with_event", :f => f
 
     %p
       = f.submit "Start Contact", :disable_with => 'Submitting...'

--- a/app/views/contacts/_form_with_event.html.haml
+++ b/app/views/contacts/_form_with_event.html.haml
@@ -1,0 +1,10 @@
+.page_section
+  = form_for([person, contact], :html => {:autocomplete => "off"}) do |f|
+    = hidden_field_tag :event_id, event.id
+
+    = render "shared/custom_error_messages", :object => f.object
+
+    = render "contacts/form_fields", :f => f
+
+    %p
+      = f.submit "Start Contact", :disable_with => 'Submitting...'

--- a/app/views/contacts/_form_without_event.html.haml
+++ b/app/views/contacts/_form_without_event.html.haml
@@ -2,7 +2,7 @@
   = form_for([person, contact], :html => {:autocomplete => "off"}) do |f|
     = render "shared/custom_error_messages", :object => f.object
 
-    = render "contacts/form_fields", :f => f
+    = render "contacts/form_fields_without_event", :f => f
 
     %p
-      = f.submit "Start Contact", :disable_with => 'Submitting...'
+      = f.submit "Save Contact", :disable_with => 'Submitting...'

--- a/app/views/contacts/_form_without_event.html.haml
+++ b/app/views/contacts/_form_without_event.html.haml
@@ -1,0 +1,8 @@
+.page_section
+  = form_for([person, contact], :html => {:autocomplete => "off"}) do |f|
+    = render "shared/custom_error_messages", :object => f.object
+
+    = render "contacts/form_fields", :f => f
+
+    %p
+      = f.submit "Start Contact", :disable_with => 'Submitting...'

--- a/app/views/contacts/edit.html.haml
+++ b/app/views/contacts/edit.html.haml
@@ -13,7 +13,10 @@
 
     = render "shared/custom_error_messages", :object => f.object
 
-    = render "contacts/form_fields", :f => f
+    - if @event.nil?
+      = render "contacts/form_fields_without_event", :f => f
+    - else
+      = render "contacts/form_fields_with_event", :f => f
 
     %p
       = f.submit "Submit", :disable_with => 'Submitting...'

--- a/app/views/contacts/new.html.haml
+++ b/app/views/contacts/new.html.haml
@@ -9,13 +9,7 @@
     %span.warning
       Consent required
 
-.page_section
-  = form_for([@person, @contact], :html => {:autocomplete => "off"}) do |f|
-    = hidden_field_tag :event_id, @event.id
-
-    = render "shared/custom_error_messages", :object => f.object
-
-    = render "contacts/form_fields", :f => f
-
-    %p
-      = f.submit "Start Contact", :disable_with => 'Submitting...'
+- if @event
+  = render "contacts/form_with_event", :person => @person, :contact => @contact, :event => @event
+- else
+  =render "contacts/form_without_event", :person => @person, :contact => @contact

--- a/app/views/people/_events_and_contacts.html.haml
+++ b/app/views/people/_events_and_contacts.html.haml
@@ -2,10 +2,10 @@
   .participant_contacts
     %div= link_to "New Contact without Event", new_person_contact_path(@person),
       :class => "add_link icon_link", :title => "New Contact for #{blank_safe(@person.to_s)} without Event"
-    - if @events_and_contacts.blank?
+    - if @events_and_contact_links.blank?
       %div= "No events or contacts exist for #{blank_safe(@person.to_s)}."
     - else
-      - sort_by_started_at(@events_and_contacts).each do |row|
+      - sort_by_started_at(@events_and_contact_links).each do |row|
         -if row.is_a?(ContactLink)
           - contact = row.contact
           .event

--- a/app/views/people/_events_and_contacts.html.haml
+++ b/app/views/people/_events_and_contacts.html.haml
@@ -1,6 +1,6 @@
 .page_section
   .participant_contacts
-    %div= link_to "New Contact without Event", new_person_contact_path(@person),
+    %div= link_to "New Contact without Event", new_person_contact_path(@person, :event_id => -1),
       :class => "add_link icon_link", :title => "New Contact for #{blank_safe(@person.to_s)} without Event"
     - if @events_and_contact_links.blank?
       %div= "No events or contacts exist for #{blank_safe(@person.to_s)}."

--- a/app/views/people/_events_and_contacts.html.haml
+++ b/app/views/people/_events_and_contacts.html.haml
@@ -1,9 +1,11 @@
 .page_section
   .participant_contacts
-    - if @events_and_contacts.blank?
-      = "No events or contacts exist for #{blank_safe(@person.to_s)}."
+    %div= link_to "New Contact without Event", new_person_contact_path(@person),
+      :class => "add_link icon_link", :title => "New Contact for #{blank_safe(@person.to_s)} without Event"
+    - if @events_and_contact_links.blank?
+      %div= "No events or contacts exist for #{blank_safe(@person.to_s)}."
     - else
-      - sort_by_started_at(@events_and_contacts).each do |row|
+      - sort_by_started_at(@events_and_contact_links).each do |row|
         -if row.is_a?(ContactLink)
           - contact = row.contact
           .event

--- a/app/views/people/_events_and_contacts.html.haml
+++ b/app/views/people/_events_and_contacts.html.haml
@@ -1,7 +1,9 @@
 .page_section
   .participant_contacts
+    %div= link_to "New Contact without Event", new_person_contact_path(@person),
+      :class => "add_link icon_link", :title => "New Contact for #{blank_safe(@person.to_s)} without Event"
     - if @events_and_contacts.blank?
-      = "No events or contacts exist for #{blank_safe(@person.to_s)}."
+      %div= "No events or contacts exist for #{blank_safe(@person.to_s)}."
     - else
       - sort_by_started_at(@events_and_contacts).each do |row|
         -if row.is_a?(ContactLink)

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -60,10 +60,29 @@ describe ContactsController do
             assigns[:contact].should equal(mock_contact)
           end
 
-          it "assigns a new event as @event" do
-            get :new, :person_id => @person.id, :event_id => @event.id
-            assigns[:event].should == @event
-            assigns[:event].event_type.should == @preg_screen_event
+          context "@event assignemnt is based on params[:event_id]" do
+            it "an omitted event_id yields the next_event_for_person as a default" do
+              get :new, :person_id => @person.id
+              assigns[:event].should == @participant.pending_events.first
+              assigns[:event].event_type.should === @preg_screen_event
+            end
+
+            it "a nil event_id yields the next_event_for_person as a default" do
+              get :new, :person_id => @person.id, :event_id => nil
+              assigns[:event].should == @participant.pending_events.first
+              assigns[:event].event_type.should == @preg_screen_event
+            end
+            
+            it "a valid event_id yields that Event record" do
+              get :new, :person_id => @person.id, :event_id => @event.id
+              assigns[:event].should == @event
+              assigns[:event].event_type.should == @preg_screen_event
+            end
+
+            it "an event_id of -1 yields nil (an eventless contact - see #3285)" do
+              get :new, :person_id => @person.id, :event_id => -1
+              assigns[:event].should be_nil
+            end
           end
         end
 
@@ -114,6 +133,7 @@ describe ContactsController do
             let(:contact_type_code) { Contact::MAILING_CONTACT_CODE }
             it "is Pregnancy Screener Event" do
               get :edit, :id => contact.id, :contact_link_id => @contact_link.id
+              binding.pry
               assigns[:disposition_group].should == "Pregnancy Screener Event"
             end
           end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -61,7 +61,7 @@ describe ContactsController do
           end
 
           it "assigns a new event as @event" do
-            get :new, :person_id => @person.id
+            get :new, :person_id => @person.id, :event_id => @event.id
             assigns[:event].should == @event
             assigns[:event].event_type.should == @preg_screen_event
           end
@@ -73,9 +73,9 @@ describe ContactsController do
             Contact.stub(:new).and_return(mock_contact)
           end
 
-          it "raises an exception" do
+          it "succeeds as an eventless contact" do
             person = Factory(:person)
-            expect { get :new, :person_id => person.id }.to raise_error
+            expect { get :new, :person_id => person.id }.to_not raise_error
           end
         end
       end
@@ -329,7 +329,7 @@ describe ContactsController do
         end
 
         it "assigns a new event as @event" do
-          get :new, :person_id => @person.id
+          get :new, :person_id => @person.id, :event_id => @event33.id
           assigns[:event].should == @event33
           assigns[:event].event_type.local_code.should == 33
         end
@@ -340,7 +340,7 @@ describe ContactsController do
 
             Event.stub(:schedule_and_create_placeholder).and_return(nil)
 
-            get :new, :person_id => @person.id, :event_type_id => NcsCode.low_intensity_data_collection.id
+            get :new, :person_id => @person.id, :event_id => @event33.id, :event_type_id => NcsCode.low_intensity_data_collection.id
             assigns[:event].event_type.local_code.should == NcsCode.low_intensity_data_collection.local_code
           end
         end

--- a/spec/controllers/participants_controller_spec.rb
+++ b/spec/controllers/participants_controller_spec.rb
@@ -154,12 +154,12 @@ describe ParticipantsController do
       end
       it "selects 1 contact_link and 2 events related to the mother" do
         get :show, :id => @m_participant.id
-        assigns[:events_and_contacts].count.should == 3
+        assigns[:events_and_contact_links].count.should == 3
       end
 
       it "select mother's event with a contact_link related to the child" do
         get :show, :id => @c_participant.id
-        assigns[:events_and_contacts].first.should == @cl_ev
+        assigns[:events_and_contact_links].first.should == @cl_ev
       end
 
     end


### PR DESCRIPTION
I'll try to summarize this:

The goal is to allow the creation of contacts that aren't tied to and event via the UI (eventless contacts stored from imported data were already supported). This is in contrast to the current functionality where all events created in the UI must be associated with an event, and therefore indirectly, to a participant.
#### Controller changes
- `app/controllers/contacts_controller.rb#create`
  - only handles `@requires_consent` if an event is involved
  - when creating a contact, it redirects to the **decision page** if **there is** an event
  - when creating a contact, it redirects to the **person** view if **there is not** an event
  - `#event_for_person` - change the two-outcome conditional (either the `Event` from the specified `params[:event_id]` into a three-outcome case statement in order to handle the eventless contact scenario
- `app/controllers/participants_controller.rb`
  - rename `@events_and_contacts` to `@events_and_contact_links`
- `app/controllers/people_controller.rb`
  - made an `#events_and_contact_links` method, similar to the one from the `participants_controller` so that the view can display contacts on a `Person` (new functionality) - previously you could only create a contact on an `Event`, and therefore it was always tied, indirectly, to a participant
  - eager loads `Person => ContactLinks` and passes it to the view
#### View changes
- Partials
  - Split `app/views/contacts/_form_fields.html.haml` into a `_form_fields_with_event` and `_form_fields_without_event` partial, which presents a slightly different view in each of those two cases
  - the `_form_fields_without_event` partial also sets up an explicit `-1` value for `event_id` to indicate to the controller that this is a contact without an event
- other view changes...
  - conditional logic to render the proper partials in the associated situations (a contact with an event vs. a contact without an event)
- `app/views/people/_events_and_contacts.html.haml` - added a "Create contact without event" link
#### Test changes
- `spec/controllers/contacts_controller_spec.rb` - coverage of how the setting of `@event` has changed
- `spec/controllers/participants_controller_spec.rb` - simple change to reflect the renaming of a variable
