### PR TITLE
Exclude psu_id and recruit_type from the -4orcing process (#4571)

### DIFF
--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -411,6 +411,10 @@ module NcsNavigator::Core::Warehouse
         record.class.properties.each do |prop|
           name = prop.name
 
+          # These are assigned by ncs_mdes_warehouse's ApplyGlobalValuesFilter;
+          # see lib/ncs_navigator/warehouse/filters/apply_global_values_filter.rb:45-61.
+          next if name.to_s == 'psu_id' || name.to_s == 'recruit_type'
+
           if record.send(name).blank? && record.class.properties[name].required?
             set_first_valid(record, name, [-4])
           end


### PR DESCRIPTION
`psu_id` and `recruit_type` are set further up the pipeline (specifically, as an [ApplyGlobalValuesFilter](https://github.com/NUBIC/ncs_mdes_warehouse/blob/master/lib/ncs_navigator/warehouse/filters/apply_global_values_filter.rb#L45-L61) in ncs_mdes_warehouse).  Setting it here interferes with that process.
