### PR TITLE
4628 handle response sets without participant

### DIFF
--- a/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
+++ b/lib/ncs_navigator/core/warehouse/instrument_to_warehouse.rb
@@ -186,6 +186,7 @@ module NcsNavigator::Core::Warehouse
 
       def initialize(participant, table_ident, table_content, response_group)
         @participant = participant
+        @p_id = @participant.try(:p_id)
         @table_identifier = table_ident
         @table_content = table_content
         @response_group = response_group
@@ -203,7 +204,7 @@ module NcsNavigator::Core::Warehouse
         # Bins are per-repeat
         (self.response_group == response.response_group) &&
         # and are per-participant
-        (self.participant.p_id == response.response_set.participant.p_id) &&
+        (@p_id == response.response_set.participant.try(:p_id)) &&
         # and are per-MDES table
         (self.table_identifier == table_ident_for_response(response)) &&
         # and must have only one response per question

--- a/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
+++ b/spec/lib/ncs_navigator/core/warehouse/instrument_to_warehouse_spec.rb
@@ -168,6 +168,13 @@ module NcsNavigator::Core::Warehouse
               a :string
               a_neg_1 "REFUSED"
               a_neg_2 "DON'T KNOW"
+
+              q_ADDRESS_2 "ADDRESS 2",
+              :pick=>:one,
+              :data_export_identifier=>"PBS_ELIG_SCREENER.ADDRESS_2"
+              a :string
+              a_neg_1 "REFUSED"
+              a_neg_2 "DON'T KNOW"
             DSL
           }
           let(:primary) { records.find { |rec| rec.class.mdes_table_name == 'pbs_elig_screener' } }
@@ -196,9 +203,20 @@ module NcsNavigator::Core::Warehouse
           end
 
           describe 'when there is no participant' do
+            let(:question2) { questions_map['ADDRESS_2'] }
+            let!(:response2) {
+              create_response_for(question2) { |r|
+                r.answer = question2.answers.find_by_text('REFUSED')
+              }
+            }
             before do
               response_set.participant = nil
               response_set.save!
+            end
+
+            it 'bins both responses' do
+              primary.address_1.should == '-1'
+              primary.address_2.should == '-1'
             end
 
             it 'uses -4 for PPG_FIRST' do


### PR DESCRIPTION
Currently responses from screeners where participant was deemed ineligible are not making it to the warehouse.  This should fix the problem.
