### PR TITLE
Remove association integrity check

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -31,8 +31,6 @@ class Response < ActiveRecord::Base
 
   default_scope includes(:answer, :question)
 
-  validate :ensure_association_integrity
-
   ##
   # Raise an error if the answer associated with this Response
   # is not in the set of answers for the associated Question.


### PR DESCRIPTION
Once, we were trying to figure out why we were getting bad answer IDs for questions.  We now know why (it's related to date entry in some old surveys) and we have a way to fix corrupted data.

We do not, however, have a way to fix data that never made it into Cases' database in the first place.  As such, it's better to take this check out.
